### PR TITLE
[ELIXPO] Add separate NPM and VS Code extension publish workflows

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,30 @@
+name: Publish @elixpo/lixeditor to NPM
+
+on:
+  push:
+    tags:
+      - 'lixeditor@*'
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/lixeditor
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_LIXSKETCH_PUBLISH_TOKEN }}

--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -1,0 +1,29 @@
+name: Publish lixeditor VS Code Extension
+
+on:
+  push:
+    tags:
+      - 'vscode-lixeditor@*'
+
+jobs:
+  publish-vsce:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/vscode-lixeditor
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - run: npx @vscode/vsce publish --no-dependencies
+        env:
+          VSCE_PAT: ${{ secrets.VSCODE_LIXSKETCH_EXT_PUBLISH_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `.github/workflows/publish-npm.yml` — publishes `@elixpo/lixeditor` to NPM on `lixeditor@*` tag push
- Add `.github/workflows/publish-vscode.yml` — publishes lixeditor VS Code extension on `vscode-lixeditor@*` tag push

Both workflows: checkout → setup Node 20 → `npm ci` → build → publish. Secrets required: `NPM_LIXSKETCH_PUBLISH_TOKEN`, `VSCODE_LIXSKETCH_EXT_PUBLISH_TOKEN`.

## Trigger pattern
```
git tag lixeditor@2.5.9      → NPM publish
git tag vscode-lixeditor@2.5.6 → VS Code marketplace publish
git push --follow-tags
```

Fixes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)