### PR TITLE
(feat): Updated the package to have the katex included with the css styling

### DIFF
--- a/packages/lixeditor/src/editor/LixEditor.jsx
+++ b/packages/lixeditor/src/editor/LixEditor.jsx
@@ -9,6 +9,7 @@ import {
   FormattingToolbar,
   FormattingToolbarController,
   getFormattingToolbarItems,
+  filterSuggestionItems,
 } from '@blocknote/react';
 import { BlockNoteView } from '@blocknote/mantine';
 import { useCallback, useMemo, forwardRef, useImperativeHandle, useState, useRef, useEffect } from 'react';
@@ -278,7 +279,41 @@ const LixEditor = forwardRef(function LixEditor({
     };
   }, [f.linkPreview]);
 
+  // Ctrl+D / Cmd+D: insert today's date as an inline chip at the cursor.
+  // Only fires when focus is inside the editor and the dates feature is on.
+  useEffect(() => {
+    if (!f.dates || !editor) return;
+    const wrapper = wrapperRef.current;
+    if (!wrapper) return;
+
+    const onKey = (e) => {
+      if (!(e.ctrlKey || e.metaKey)) return;
+      if (e.key.toLowerCase() !== 'd') return;
+      // Only intercept when the editable area has focus.
+      const active = document.activeElement;
+      if (!active || !wrapper.contains(active)) return;
+
+      e.preventDefault();
+      try {
+        const today = new Date().toISOString().split('T')[0];
+        editor._tiptapEditor.commands.insertContent({
+          type: 'dateInline',
+          attrs: { date: today },
+        });
+      } catch (err) {
+        console.warn('[LixEditor] insert date failed:', err);
+      }
+    };
+
+    window.addEventListener('keydown', onKey, true);
+    return () => window.removeEventListener('keydown', onKey, true);
+  }, [editor, f.dates]);
+
   // Slash menu items
+  // Use BlockNote's `filterSuggestionItems` helper so the search also
+  // covers `aliases` / `subtext` / `group` (the previous custom filter
+  // checked title only, which produced weird half-rendered groups when
+  // BlockNote items had no `title` field for the current schema).
   const getItems = useCallback(async (query) => {
     const defaults = getDefaultReactSlashMenuItems(editor)
       .filter(item => !['video', 'audio', 'file'].includes(item.key));
@@ -290,6 +325,7 @@ const LixEditor = forwardRef(function LixEditor({
         title: 'Block Equation',
         subtext: 'LaTeX block equation',
         group: 'Advanced',
+        aliases: ['equation', 'eq', 'latex', 'math', 'tex'],
         icon: <span style={{ fontSize: 16 }}>∑</span>,
         onItemClick: () => editor.insertBlocks([{ type: 'blockEquation' }], editor.getTextCursorPosition().block, 'after'),
       });
@@ -300,6 +336,7 @@ const LixEditor = forwardRef(function LixEditor({
         title: 'Diagram',
         subtext: 'Mermaid diagram (flowchart, sequence, etc.)',
         group: 'Advanced',
+        aliases: ['mermaid', 'flowchart', 'sequence', 'diagram', 'graph'],
         icon: <span style={{ fontSize: 14 }}>◇</span>,
         onItemClick: () => editor.insertBlocks([{ type: 'mermaidBlock' }], editor.getTextCursorPosition().block, 'after'),
       });
@@ -310,13 +347,33 @@ const LixEditor = forwardRef(function LixEditor({
         title: 'Table of Contents',
         subtext: 'Auto-generated document outline',
         group: 'Advanced',
+        aliases: ['toc', 'outline', 'contents'],
         icon: <span style={{ fontSize: 14 }}>☰</span>,
         onItemClick: () => editor.insertBlocks([{ type: 'tableOfContents' }], editor.getTextCursorPosition().block, 'after'),
       });
     }
 
-    return [...defaults, ...custom, ...extraSlashItems]
-      .filter(item => item.title.toLowerCase().includes(query.toLowerCase()));
+    if (f.dates) {
+      custom.push({
+        title: 'Date',
+        subtext: "Insert today's date as an inline chip (Ctrl+D)",
+        group: 'Advanced',
+        aliases: ['date', 'today', 'time', 'now'],
+        icon: <span style={{ fontSize: 14 }}>📅</span>,
+        onItemClick: () => {
+          try {
+            const today = new Date().toISOString().split('T')[0];
+            editor._tiptapEditor.commands.insertContent({
+              type: 'dateInline',
+              attrs: { date: today },
+            });
+          } catch {}
+        },
+      });
+    }
+
+    const all = [...defaults, ...custom, ...extraSlashItems];
+    return filterSuggestionItems(all, query);
   }, [editor, f, extraSlashItems]);
 
   const handleChange = useCallback(() => {

--- a/packages/lixeditor/src/styles/blocks.css
+++ b/packages/lixeditor/src/styles/blocks.css
@@ -1,30 +1,30 @@
 /* ===== No selection outline or drag handle for custom blocks ===== */
 
-.blog-editor-wrapper [data-content-type="codeBlock"],
-.blog-editor-wrapper [data-content-type="blockEquation"],
-.blog-editor-wrapper [data-content-type="mermaidBlock"] {
+.lix-editor-wrapper [data-content-type="codeBlock"],
+.lix-editor-wrapper [data-content-type="blockEquation"],
+.lix-editor-wrapper [data-content-type="mermaidBlock"] {
   outline: none !important;
   box-shadow: none !important;
   border-color: var(--border-default) !important;
 }
 
 /* Remove the blue selected ring BlockNote adds */
-.blog-editor-wrapper [data-content-type="codeBlock"] *::selection,
-.blog-editor-wrapper [data-content-type="blockEquation"] *::selection,
-.blog-editor-wrapper [data-content-type="mermaidBlock"] *::selection {
+.lix-editor-wrapper [data-content-type="codeBlock"] *::selection,
+.lix-editor-wrapper [data-content-type="blockEquation"] *::selection,
+.lix-editor-wrapper [data-content-type="mermaidBlock"] *::selection {
   background: transparent;
 }
 
-.blog-editor-wrapper .bn-block-outer[data-node-type="blockContainer"]:has([data-content-type="codeBlock"]) > .bn-block,
-.blog-editor-wrapper .bn-block-outer[data-node-type="blockContainer"]:has([data-content-type="blockEquation"]) > .bn-block,
-.blog-editor-wrapper .bn-block-outer[data-node-type="blockContainer"]:has([data-content-type="mermaidBlock"]) > .bn-block {
+.lix-editor-wrapper .bn-block-outer[data-node-type="blockContainer"]:has([data-content-type="codeBlock"]) > .bn-block,
+.lix-editor-wrapper .bn-block-outer[data-node-type="blockContainer"]:has([data-content-type="blockEquation"]) > .bn-block,
+.lix-editor-wrapper .bn-block-outer[data-node-type="blockContainer"]:has([data-content-type="mermaidBlock"]) > .bn-block {
   outline: none !important;
   box-shadow: none !important;
 }
 
 /* ===== Code blocks ===== */
 
-.blog-editor-wrapper [data-content-type="codeBlock"] {
+.lix-editor-wrapper [data-content-type="codeBlock"] {
   background: var(--code-bg);
   border: 1px solid var(--border-default);
   border-radius: 10px;
@@ -51,7 +51,7 @@
   --code-lang-text: #9ba8b9;
 }
 
-.blog-editor-wrapper [data-content-type="codeBlock"] code {
+.lix-editor-wrapper [data-content-type="codeBlock"] code {
   color: var(--code-text);
   font-size: 0.84em;
   font-family: inherit;
@@ -60,24 +60,24 @@
   line-height: 1.7;
 }
 
-.blog-editor-wrapper [data-content-type="codeBlock"] [contenteditable] {
+.lix-editor-wrapper [data-content-type="codeBlock"] [contenteditable] {
   padding: 8px 16px !important;
   -webkit-text-decorations-in-effect: none;
 }
 
 /* Kill spellcheck red squiggles inside code blocks */
-.blog-editor-wrapper [data-content-type="codeBlock"] [contenteditable] * {
+.lix-editor-wrapper [data-content-type="codeBlock"] [contenteditable] * {
   text-decoration: none !important;
   -webkit-text-decoration: none !important;
 }
 
 /* Shiki syntax highlighting — let inline styles override default color */
-.blog-editor-wrapper [data-content-type="codeBlock"] code span[style] {
+.lix-editor-wrapper [data-content-type="codeBlock"] code span[style] {
   background: none !important;
 }
 
 /* Language selector dropdown (BlockNote built-in) */
-.blog-editor-wrapper [data-content-type="codeBlock"] select {
+.lix-editor-wrapper [data-content-type="codeBlock"] select {
   background: var(--code-lang-bg);
   color: var(--code-lang-text);
   border: 1px solid var(--border-default);
@@ -90,7 +90,7 @@
   margin: 4px 8px;
 }
 
-.blog-editor-wrapper [data-content-type="codeBlock"] select:focus {
+.lix-editor-wrapper [data-content-type="codeBlock"] select:focus {
   border-color: #a78bfa;
 }
 
@@ -213,7 +213,7 @@
 
 /* ===== Divider / Horizontal Rule ===== */
 
-.blog-editor-wrapper [data-content-type="divider"] {
+.lix-editor-wrapper [data-content-type="divider"] {
   margin: 16px 0;
   padding: 8px 0;
   pointer-events: none;
@@ -221,7 +221,7 @@
   cursor: default;
 }
 
-.blog-editor-wrapper [data-content-type="divider"] hr {
+.lix-editor-wrapper [data-content-type="divider"] hr {
   border: none;
   height: 1px;
   background: var(--border-default);
@@ -229,12 +229,12 @@
 
 /* ===== Sub-Page Block ===== */
 
-.blog-editor-wrapper [data-content-type="tabsBlock"] {
+.lix-editor-wrapper [data-content-type="tabsBlock"] {
   user-select: none;
   width: 100%;
 }
 
-.blog-editor-wrapper [data-content-type="tabsBlock"] .bn-block-content {
+.lix-editor-wrapper [data-content-type="tabsBlock"] .bn-block-content {
   cursor: default;
   width: 100%;
 }
@@ -389,24 +389,24 @@
 
 /* ===== Lists ===== */
 
-.blog-editor-wrapper [data-content-type="bulletListItem"],
-.blog-editor-wrapper [data-content-type="numberedListItem"] {
+.lix-editor-wrapper [data-content-type="bulletListItem"],
+.lix-editor-wrapper [data-content-type="numberedListItem"] {
   color: var(--text-primary);
 }
 
-.blog-editor-wrapper [data-content-type="bulletListItem"]::before {
+.lix-editor-wrapper [data-content-type="bulletListItem"]::before {
   color: var(--text-muted);
 }
 
-.blog-editor-wrapper [data-content-type="numberedListItem"]::before {
+.lix-editor-wrapper [data-content-type="numberedListItem"]::before {
   color: var(--text-muted);
 }
 
 /* ===== Fancy Checkboxes ===== */
 
-.blog-editor-wrapper [data-content-type="checkListItem"] [data-checked-icon],
-.blog-editor-wrapper [data-content-type="checkListItem"] [data-unchecked-icon],
-.blog-editor-wrapper [data-content-type="checkListItem"] input[type="checkbox"] {
+.lix-editor-wrapper [data-content-type="checkListItem"] [data-checked-icon],
+.lix-editor-wrapper [data-content-type="checkListItem"] [data-unchecked-icon],
+.lix-editor-wrapper [data-content-type="checkListItem"] input[type="checkbox"] {
   appearance: none;
   -webkit-appearance: none;
   width: 18px;
@@ -420,18 +420,18 @@
   flex-shrink: 0;
 }
 
-.blog-editor-wrapper [data-content-type="checkListItem"] input[type="checkbox"]:hover {
+.lix-editor-wrapper [data-content-type="checkListItem"] input[type="checkbox"]:hover {
   border-color: #9b7bf7;
   box-shadow: 0 0 0 3px rgba(155, 123, 247, 0.12);
 }
 
-.blog-editor-wrapper [data-content-type="checkListItem"] input[type="checkbox"]:checked {
+.lix-editor-wrapper [data-content-type="checkListItem"] input[type="checkbox"]:checked {
   background: linear-gradient(135deg, #9b7bf7, #8b6ae6);
   border-color: #9b7bf7;
   box-shadow: 0 1px 4px rgba(155, 123, 247, 0.3);
 }
 
-.blog-editor-wrapper [data-content-type="checkListItem"] input[type="checkbox"]:checked::after {
+.lix-editor-wrapper [data-content-type="checkListItem"] input[type="checkbox"]:checked::after {
   content: '';
   position: absolute;
   top: 2px;
@@ -444,13 +444,13 @@
 }
 
 /* Checked item text gets muted + strikethrough */
-.blog-editor-wrapper [data-content-type="checkListItem"][data-checked="true"] .bn-inline-content {
+.lix-editor-wrapper [data-content-type="checkListItem"][data-checked="true"] .bn-inline-content {
   text-decoration: line-through;
   opacity: 0.5;
 }
 
 /* BlockNote's native checkbox SVG icons — style them too */
-.blog-editor-wrapper [data-content-type="checkListItem"] .bn-checkbox {
+.lix-editor-wrapper [data-content-type="checkListItem"] .bn-checkbox {
   width: 18px;
   height: 18px;
   border-radius: 6px;
@@ -463,58 +463,58 @@
   justify-content: center;
 }
 
-.blog-editor-wrapper [data-content-type="checkListItem"] .bn-checkbox:hover {
+.lix-editor-wrapper [data-content-type="checkListItem"] .bn-checkbox:hover {
   border-color: #9b7bf7;
   box-shadow: 0 0 0 3px rgba(155, 123, 247, 0.12);
 }
 
-.blog-editor-wrapper [data-content-type="checkListItem"][data-checked="true"] .bn-checkbox {
+.lix-editor-wrapper [data-content-type="checkListItem"][data-checked="true"] .bn-checkbox {
   background: linear-gradient(135deg, #9b7bf7, #8b6ae6);
   border-color: #9b7bf7;
   box-shadow: 0 1px 4px rgba(155, 123, 247, 0.3);
 }
 
-.blog-editor-wrapper [data-content-type="checkListItem"][data-checked="true"] .bn-checkbox svg {
+.lix-editor-wrapper [data-content-type="checkListItem"][data-checked="true"] .bn-checkbox svg {
   color: white;
 }
 
 /* ===== Image blocks ===== */
 
-.blog-editor-wrapper [data-content-type="image"] img {
+.lix-editor-wrapper [data-content-type="image"] img {
   border-radius: 10px;
   max-width: 100%;
 }
 
-.blog-editor-wrapper [data-content-type="image"] .bn-image-resize-handle {
+.lix-editor-wrapper [data-content-type="image"] .bn-image-resize-handle {
   background: #7ba8f0;
 }
 
 /* ===== Table ===== */
 
-.blog-editor-wrapper [data-content-type="table"] {
+.lix-editor-wrapper [data-content-type="table"] {
   border-color: var(--border-default);
 }
 
-.blog-editor-wrapper [data-content-type="table"] td,
-.blog-editor-wrapper [data-content-type="table"] th {
+.lix-editor-wrapper [data-content-type="table"] td,
+.lix-editor-wrapper [data-content-type="table"] th {
   border-color: var(--border-default);
   padding: 8px 12px;
 }
 
 /* Table handles dark theme */
-.blog-editor-wrapper .bn-table-handle {
+.lix-editor-wrapper .bn-table-handle {
   background: var(--border-default);
   border: 1px solid #333;
   color: var(--text-muted);
 }
 
-.blog-editor-wrapper .bn-table-handle:hover {
+.lix-editor-wrapper .bn-table-handle:hover {
   background: var(--border-hover);
   color: #c4b5fd;
 }
 
 /* Table handle dropdown menu */
-.blog-editor-wrapper .bn-table-handle-menu,
+.lix-editor-wrapper .bn-table-handle-menu,
 .bn-table-handle-menu {
   background: var(--bg-surface) !important;
   border: 1px solid var(--border-default) !important;
@@ -522,26 +522,26 @@
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5) !important;
 }
 
-.blog-editor-wrapper .bn-table-handle-menu button,
+.lix-editor-wrapper .bn-table-handle-menu button,
 .bn-table-handle-menu button {
   color: var(--text-primary) !important;
 }
 
-.blog-editor-wrapper .bn-table-handle-menu button:hover,
+.lix-editor-wrapper .bn-table-handle-menu button:hover,
 .bn-table-handle-menu button:hover {
   background: rgba(196, 181, 253, 0.1) !important;
   color: #c4b5fd !important;
 }
 
 /* Table extend (add row/col) button */
-.blog-editor-wrapper .bn-extend-button {
+.lix-editor-wrapper .bn-extend-button {
   background: rgba(196, 181, 253, 0.08);
   border: 1px dashed rgba(196, 181, 253, 0.2);
   color: var(--text-muted);
   transition: all 0.15s;
 }
 
-.blog-editor-wrapper .bn-extend-button:hover {
+.lix-editor-wrapper .bn-extend-button:hover {
   background: rgba(196, 181, 253, 0.15);
   border-color: rgba(196, 181, 253, 0.4);
   color: #c4b5fd;
@@ -549,23 +549,23 @@
 
 /* ===== KaTeX overrides ===== */
 
-.blog-editor-wrapper .katex {
+.lix-editor-wrapper .katex {
   color: var(--text-primary);
   font-size: 1.1em;
 }
 
-.blog-editor-wrapper .katex-display {
+.lix-editor-wrapper .katex-display {
   margin: 0;
 }
 
 /* ===== Custom block styles ===== */
 
-.blog-editor-wrapper .toc-block a {
+.lix-editor-wrapper .toc-block a {
   color: #9b7bf7;
   text-decoration: none;
 }
 
-.blog-editor-wrapper .toc-block a:hover {
+.lix-editor-wrapper .toc-block a:hover {
   color: #b69aff;
 }
 
@@ -720,8 +720,8 @@
 
 /* ===== Mermaid diagram blocks ===== */
 
-.blog-editor-wrapper [data-content-type="mermaidBlock"],
-.blog-editor-wrapper [data-content-type="blockEquation"] {
+.lix-editor-wrapper [data-content-type="mermaidBlock"],
+.lix-editor-wrapper [data-content-type="blockEquation"] {
   width: 100%;
 }
 

--- a/packages/lixeditor/src/styles/blog-image.css
+++ b/packages/lixeditor/src/styles/blog-image.css
@@ -2,7 +2,7 @@
 .bn-file-panel,
 [class*="mantine-Popover-dropdown"]:has([data-test="embed-input"]),
 [class*="mantine-Popover-dropdown"]:has([data-test="upload-input"]),
-.blog-editor-wrapper [class*="mantine-Popover-dropdown"] {
+.lix-editor-wrapper [class*="mantine-Popover-dropdown"] {
   display: none !important;
   visibility: hidden !important;
   pointer-events: none !important;

--- a/packages/lixeditor/src/styles/editor.css
+++ b/packages/lixeditor/src/styles/editor.css
@@ -53,7 +53,7 @@
 
 /* ===== BlogEditor (BlockNote) Dark Theme ===== */
 
-.blog-editor-wrapper .bn-editor {
+.lix-editor-wrapper .bn-editor {
   background: transparent;
   color: var(--text-primary);
   font-family: 'Source Serif 4', Georgia, serif;
@@ -62,40 +62,40 @@
   padding-left: 0;
 }
 
-.blog-editor-wrapper .bn-container {
+.lix-editor-wrapper .bn-container {
   background: transparent;
   border: none;
   padding: 0;
 }
 
-.blog-editor-wrapper [class*="blockOuter"] {
+.lix-editor-wrapper [class*="blockOuter"] {
   padding-left: 0;
 }
 
-.blog-editor-wrapper .bn-block-content {
+.lix-editor-wrapper .bn-block-content {
   font-size: 1em;
 }
 
 /* Placeholder */
-.blog-editor-wrapper .bn-inline-content[data-placeholder]::before {
+.lix-editor-wrapper .bn-inline-content[data-placeholder]::before {
   color: var(--text-faint);
   font-style: normal;
 }
 
 /* Headings — override BlockNote's .bn-default-styles h1 { font-size: inherit } */
-.blog-editor-wrapper .bn-default-styles h1 {
+.lix-editor-wrapper .bn-default-styles h1 {
   font-size: 30px !important;
   font-family: 'Source Serif 4', Georgia, serif;
   font-weight: 700 !important;
   color: var(--text-primary);
 }
-.blog-editor-wrapper .bn-default-styles h2 {
+.lix-editor-wrapper .bn-default-styles h2 {
   font-size: 24px !important;
   font-family: 'Source Serif 4', Georgia, serif;
   font-weight: 650 !important;
   color: var(--text-primary);
 }
-.blog-editor-wrapper .bn-default-styles h3 {
+.lix-editor-wrapper .bn-default-styles h3 {
   font-size: 20px !important;
   font-family: 'Source Serif 4', Georgia, serif;
   font-weight: 600 !important;
@@ -104,7 +104,7 @@
 
 /* Inline code — purple accent, adapts to theme.
    Excludes code inside code blocks so Shiki syntax highlighting isn't overridden. */
-.blog-editor-wrapper code,
+.lix-editor-wrapper code,
 .blog-preview-content code {
   color: #7c3aed;
   background: rgba(124, 58, 237, 0.08);
@@ -123,22 +123,22 @@
 }
 
 /* Force hide spellcheck squiggles on all code elements */
-.blog-editor-wrapper code *,
-.blog-editor-wrapper [data-content-type="codeBlock"] * {
+.lix-editor-wrapper code *,
+.lix-editor-wrapper [data-content-type="codeBlock"] * {
   text-decoration: none !important;
   -webkit-text-decoration: none !important;
   -webkit-text-decorations-in-effect: none !important;
   text-decoration-line: none !important;
 }
 
-[data-theme="dark"] .blog-editor-wrapper code,
+[data-theme="dark"] .lix-editor-wrapper code,
 [data-theme="dark"] .blog-preview-content code {
   color: #c4b5fd;
   background: rgba(196, 181, 253, 0.1);
 }
 
 /* Reset inline code styles inside code blocks — let Shiki/theme handle these */
-.blog-editor-wrapper [data-content-type="codeBlock"] code,
+.lix-editor-wrapper [data-content-type="codeBlock"] code,
 .blog-preview-content pre code {
   color: var(--code-text);
   background: none;
@@ -147,64 +147,64 @@
 }
 
 /* Code blocks — lixCode font, no line highlights */
-.blog-editor-wrapper [data-content-type="codeBlock"] code,
-.blog-editor-wrapper [data-content-type="codeBlock"] pre,
-.blog-editor-wrapper [data-content-type="codeBlock"] [contenteditable] {
+.lix-editor-wrapper [data-content-type="codeBlock"] code,
+.lix-editor-wrapper [data-content-type="codeBlock"] pre,
+.lix-editor-wrapper [data-content-type="codeBlock"] [contenteditable] {
   font-family: 'lixCode', 'SF Mono', 'Fira Code', monospace !important;
   font-size: 0.9em;
 }
 
-.blog-editor-wrapper [data-content-type="codeBlock"] .hljs-ln-line,
-.blog-editor-wrapper [data-content-type="codeBlock"] .line-highlight,
-.blog-editor-wrapper [data-content-type="codeBlock"] .bn-line-number {
+.lix-editor-wrapper [data-content-type="codeBlock"] .hljs-ln-line,
+.lix-editor-wrapper [data-content-type="codeBlock"] .line-highlight,
+.lix-editor-wrapper [data-content-type="codeBlock"] .bn-line-number {
   background: none !important;
 }
 
 /* AI-generated blocks use named 'purple' — ensure readable text in both themes */
-.blog-editor-wrapper [data-text-color="purple"] { color: var(--text-secondary) !important; }
-.blog-editor-wrapper [data-background-color="purple"] { background-color: rgba(155, 123, 247, 0.06) !important; }
+.lix-editor-wrapper [data-text-color="purple"] { color: var(--text-secondary) !important; }
+.lix-editor-wrapper [data-background-color="purple"] { background-color: rgba(155, 123, 247, 0.06) !important; }
 
 /* Map BlockNote block-level text color (data-text-color on block containers) */
-.blog-editor-wrapper [data-text-color="#ffffff"] { color: #ffffff !important; }
-.blog-editor-wrapper [data-text-color="#9ca3af"] { color: var(--text-muted) !important; }
-.blog-editor-wrapper [data-text-color="#f87171"] { color: #f87171 !important; }
-.blog-editor-wrapper [data-text-color="#fb923c"] { color: #fb923c !important; }
-.blog-editor-wrapper [data-text-color="#fbbf24"] { color: #fbbf24 !important; }
-.blog-editor-wrapper [data-text-color="#4ade80"] { color: #4ade80 !important; }
-.blog-editor-wrapper [data-text-color="#60a5fa"] { color: #60a5fa !important; }
-.blog-editor-wrapper [data-text-color="#a78bfa"] { color: #a78bfa !important; }
-.blog-editor-wrapper [data-text-color="#f472b6"] { color: #f472b6 !important; }
+.lix-editor-wrapper [data-text-color="#ffffff"] { color: #ffffff !important; }
+.lix-editor-wrapper [data-text-color="#9ca3af"] { color: var(--text-muted) !important; }
+.lix-editor-wrapper [data-text-color="#f87171"] { color: #f87171 !important; }
+.lix-editor-wrapper [data-text-color="#fb923c"] { color: #fb923c !important; }
+.lix-editor-wrapper [data-text-color="#fbbf24"] { color: #fbbf24 !important; }
+.lix-editor-wrapper [data-text-color="#4ade80"] { color: #4ade80 !important; }
+.lix-editor-wrapper [data-text-color="#60a5fa"] { color: #60a5fa !important; }
+.lix-editor-wrapper [data-text-color="#a78bfa"] { color: #a78bfa !important; }
+.lix-editor-wrapper [data-text-color="#f472b6"] { color: #f472b6 !important; }
 
 /* Map BlockNote inline text color marks (data-style-type="textColor" with data-value) */
-.blog-editor-wrapper [data-style-type="textColor"][data-value="#ffffff"] { color: #ffffff !important; }
-.blog-editor-wrapper [data-style-type="textColor"][data-value="#9ca3af"] { color: var(--text-muted) !important; }
-.blog-editor-wrapper [data-style-type="textColor"][data-value="#f87171"] { color: #f87171 !important; }
-.blog-editor-wrapper [data-style-type="textColor"][data-value="#fb923c"] { color: #fb923c !important; }
-.blog-editor-wrapper [data-style-type="textColor"][data-value="#fbbf24"] { color: #fbbf24 !important; }
-.blog-editor-wrapper [data-style-type="textColor"][data-value="#4ade80"] { color: #4ade80 !important; }
-.blog-editor-wrapper [data-style-type="textColor"][data-value="#60a5fa"] { color: #60a5fa !important; }
-.blog-editor-wrapper [data-style-type="textColor"][data-value="#a78bfa"] { color: #a78bfa !important; }
-.blog-editor-wrapper [data-style-type="textColor"][data-value="#f472b6"] { color: #f472b6 !important; }
+.lix-editor-wrapper [data-style-type="textColor"][data-value="#ffffff"] { color: #ffffff !important; }
+.lix-editor-wrapper [data-style-type="textColor"][data-value="#9ca3af"] { color: var(--text-muted) !important; }
+.lix-editor-wrapper [data-style-type="textColor"][data-value="#f87171"] { color: #f87171 !important; }
+.lix-editor-wrapper [data-style-type="textColor"][data-value="#fb923c"] { color: #fb923c !important; }
+.lix-editor-wrapper [data-style-type="textColor"][data-value="#fbbf24"] { color: #fbbf24 !important; }
+.lix-editor-wrapper [data-style-type="textColor"][data-value="#4ade80"] { color: #4ade80 !important; }
+.lix-editor-wrapper [data-style-type="textColor"][data-value="#60a5fa"] { color: #60a5fa !important; }
+.lix-editor-wrapper [data-style-type="textColor"][data-value="#a78bfa"] { color: #a78bfa !important; }
+.lix-editor-wrapper [data-style-type="textColor"][data-value="#f472b6"] { color: #f472b6 !important; }
 
 /* Map BlockNote block-level background color */
-.blog-editor-wrapper [data-background-color="rgba(156,163,175,0.25)"] { background-color: rgba(156,163,175,1) !important; }
-.blog-editor-wrapper [data-background-color="rgba(248,113,113,0.25)"] { background-color: rgba(248,113,113,1) !important; }
-.blog-editor-wrapper [data-background-color="rgba(251,146,60,0.25)"] { background-color: rgba(251,146,60,1) !important; }
-.blog-editor-wrapper [data-background-color="rgba(251,191,36,0.25)"] { background-color: rgba(251,191,36,1) !important; }
-.blog-editor-wrapper [data-background-color="rgba(74,222,128,0.25)"] { background-color: rgba(74,222,128,1) !important; }
-.blog-editor-wrapper [data-background-color="rgba(96,165,250,0.25)"] { background-color: rgba(96,165,250,1) !important; }
-.blog-editor-wrapper [data-background-color="rgba(167,139,250,0.25)"] { background-color: rgba(167,139,250,1) !important; }
-.blog-editor-wrapper [data-background-color="rgba(244,114,182,0.25)"] { background-color: rgba(244,114,182,1) !important; }
+.lix-editor-wrapper [data-background-color="rgba(156,163,175,0.25)"] { background-color: rgba(156,163,175,1) !important; }
+.lix-editor-wrapper [data-background-color="rgba(248,113,113,0.25)"] { background-color: rgba(248,113,113,1) !important; }
+.lix-editor-wrapper [data-background-color="rgba(251,146,60,0.25)"] { background-color: rgba(251,146,60,1) !important; }
+.lix-editor-wrapper [data-background-color="rgba(251,191,36,0.25)"] { background-color: rgba(251,191,36,1) !important; }
+.lix-editor-wrapper [data-background-color="rgba(74,222,128,0.25)"] { background-color: rgba(74,222,128,1) !important; }
+.lix-editor-wrapper [data-background-color="rgba(96,165,250,0.25)"] { background-color: rgba(96,165,250,1) !important; }
+.lix-editor-wrapper [data-background-color="rgba(167,139,250,0.25)"] { background-color: rgba(167,139,250,1) !important; }
+.lix-editor-wrapper [data-background-color="rgba(244,114,182,0.25)"] { background-color: rgba(244,114,182,1) !important; }
 
 /* Map BlockNote inline background color marks */
-.blog-editor-wrapper [data-style-type="backgroundColor"][data-value="rgba(156,163,175,0.25)"] { background-color: rgba(156,163,175,0.25) !important; }
-.blog-editor-wrapper [data-style-type="backgroundColor"][data-value="rgba(248,113,113,0.25)"] { background-color: rgba(248,113,113,0.25) !important; }
-.blog-editor-wrapper [data-style-type="backgroundColor"][data-value="rgba(251,146,60,0.25)"] { background-color: rgba(251,146,60,0.25) !important; }
-.blog-editor-wrapper [data-style-type="backgroundColor"][data-value="rgba(251,191,36,0.25)"] { background-color: rgba(251,191,36,0.25) !important; }
-.blog-editor-wrapper [data-style-type="backgroundColor"][data-value="rgba(74,222,128,0.25)"] { background-color: rgba(74,222,128,0.25) !important; }
-.blog-editor-wrapper [data-style-type="backgroundColor"][data-value="rgba(96,165,250,0.25)"] { background-color: rgba(96,165,250,0.25) !important; }
-.blog-editor-wrapper [data-style-type="backgroundColor"][data-value="rgba(167,139,250,0.25)"] { background-color: rgba(167,139,250,0.25) !important; }
-.blog-editor-wrapper [data-style-type="backgroundColor"][data-value="rgba(244,114,182,0.25)"] { background-color: rgba(244,114,182,0.25) !important; }
+.lix-editor-wrapper [data-style-type="backgroundColor"][data-value="rgba(156,163,175,0.25)"] { background-color: rgba(156,163,175,0.25) !important; }
+.lix-editor-wrapper [data-style-type="backgroundColor"][data-value="rgba(248,113,113,0.25)"] { background-color: rgba(248,113,113,0.25) !important; }
+.lix-editor-wrapper [data-style-type="backgroundColor"][data-value="rgba(251,146,60,0.25)"] { background-color: rgba(251,146,60,0.25) !important; }
+.lix-editor-wrapper [data-style-type="backgroundColor"][data-value="rgba(251,191,36,0.25)"] { background-color: rgba(251,191,36,0.25) !important; }
+.lix-editor-wrapper [data-style-type="backgroundColor"][data-value="rgba(74,222,128,0.25)"] { background-color: rgba(74,222,128,0.25) !important; }
+.lix-editor-wrapper [data-style-type="backgroundColor"][data-value="rgba(96,165,250,0.25)"] { background-color: rgba(96,165,250,0.25) !important; }
+.lix-editor-wrapper [data-style-type="backgroundColor"][data-value="rgba(167,139,250,0.25)"] { background-color: rgba(167,139,250,0.25) !important; }
+.lix-editor-wrapper [data-style-type="backgroundColor"][data-value="rgba(244,114,182,0.25)"] { background-color: rgba(244,114,182,0.25) !important; }
 
 /* Cover gradient blur placeholder */
 .cover-gradient-blur {
@@ -275,7 +275,7 @@
 }
 
 /* Side menu (+ / drag handle) — lavender glassmorphic */
-.blog-editor-wrapper .bn-side-menu {
+.lix-editor-wrapper .bn-side-menu {
   background: rgba(196, 181, 253, 0.06);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
@@ -291,36 +291,36 @@
   transition: border-color 0.2s ease, background 0.2s ease;
 }
 
-.blog-editor-wrapper .bn-side-menu:hover {
+.lix-editor-wrapper .bn-side-menu:hover {
   background: rgba(196, 181, 253, 0.1);
   border-color: rgba(196, 181, 253, 0.25);
 }
 
-.blog-editor-wrapper .bn-side-menu button {
+.lix-editor-wrapper .bn-side-menu button {
   color: rgba(196, 181, 253, 0.5);
   transition: color 0.15s ease;
 }
 
-.blog-editor-wrapper .bn-side-menu button:hover {
+.lix-editor-wrapper .bn-side-menu button:hover {
   color: #c4b5fd;
 }
 
-.blog-editor-wrapper .bn-drag-handle {
+.lix-editor-wrapper .bn-drag-handle {
   color: rgba(196, 181, 253, 0.4);
 }
 
-.blog-editor-wrapper .bn-drag-handle:hover {
+.lix-editor-wrapper .bn-drag-handle:hover {
   color: #c4b5fd;
 }
 
 /* Selection highlight */
-.blog-editor-wrapper ::selection {
+.lix-editor-wrapper ::selection {
   background: rgba(123, 168, 240, 0.3);
 }
 
 /* ===== Editor links — distinct styling ===== */
-.blog-editor-wrapper .bn-editor a,
-.blog-editor-wrapper .bn-block-content a {
+.lix-editor-wrapper .bn-editor a,
+.lix-editor-wrapper .bn-block-content a {
   color: #7ba8f0 !important;
   text-decoration: none !important;
   border-bottom: 1px solid rgba(123, 168, 240, 0.3);
@@ -330,16 +330,16 @@
   transition: color 0.15s, border-color 0.15s, background 0.15s;
 }
 
-.blog-editor-wrapper .bn-editor a:hover,
-.blog-editor-wrapper .bn-block-content a:hover {
+.lix-editor-wrapper .bn-editor a:hover,
+.lix-editor-wrapper .bn-block-content a:hover {
   color: #9dc0ff !important;
   border-bottom-color: rgba(157, 192, 255, 0.5);
   background: rgba(123, 168, 240, 0.06);
 }
 
 /* Ctrl/Cmd held — links become clickable, show pointer cursor */
-.blog-editor-wrapper.ctrl-held .bn-editor a,
-.blog-editor-wrapper.ctrl-held .bn-block-content a {
+.lix-editor-wrapper.ctrl-held .bn-editor a,
+.lix-editor-wrapper.ctrl-held .bn-block-content a {
   cursor: pointer;
   text-decoration: underline !important;
   border-bottom: none;

--- a/packages/lixeditor/src/styles/index.css
+++ b/packages/lixeditor/src/styles/index.css
@@ -1,8 +1,13 @@
 /**
  * @elixpo/lixeditor styles
  * Import in your app: import '@elixpo/lixeditor/styles';
+ *
+ * KaTeX is bundled inline (the package depends on katex directly) so
+ * BlockEquation / InlineEquation render correctly without consumers
+ * needing a separate `import 'katex/dist/katex.min.css'` line.
  */
 
+@import 'katex/dist/katex.min.css';
 @import './variables.css';
 @import './editor.css';
 @import './blocks.css';

--- a/packages/lixeditor/src/styles/menus.css
+++ b/packages/lixeditor/src/styles/menus.css
@@ -1,7 +1,7 @@
 /* ===== Slash menu / dropdown ===== */
 
-.blog-editor-wrapper .mantine-Menu-dropdown,
-.blog-editor-wrapper .bn-suggestion-menu {
+.lix-editor-wrapper .mantine-Menu-dropdown,
+.lix-editor-wrapper .bn-suggestion-menu {
   background: var(--bg-surface) !important;
   border: 1px solid var(--border-default) !important;
   border-radius: 12px !important;
@@ -10,82 +10,82 @@
   scrollbar-color: var(--bg-elevated) transparent;
 }
 
-.blog-editor-wrapper .bn-suggestion-menu::-webkit-scrollbar {
+.lix-editor-wrapper .bn-suggestion-menu::-webkit-scrollbar {
   width: 6px;
 }
 
-.blog-editor-wrapper .bn-suggestion-menu::-webkit-scrollbar-track {
+.lix-editor-wrapper .bn-suggestion-menu::-webkit-scrollbar-track {
   background: transparent;
 }
 
-.blog-editor-wrapper .bn-suggestion-menu::-webkit-scrollbar-thumb {
+.lix-editor-wrapper .bn-suggestion-menu::-webkit-scrollbar-thumb {
   background: var(--bg-elevated);
   border-radius: 3px;
 }
 
-.blog-editor-wrapper .bn-suggestion-menu::-webkit-scrollbar-thumb:hover {
+.lix-editor-wrapper .bn-suggestion-menu::-webkit-scrollbar-thumb:hover {
   background: var(--border-hover);
 }
 
 /* Slash menu group headers */
-.blog-editor-wrapper .bn-suggestion-menu [class*="group"] {
+.lix-editor-wrapper .bn-suggestion-menu [class*="group"] {
   color: var(--text-faint) !important;
   font-size: 11px !important;
   text-transform: uppercase !important;
   letter-spacing: 0.05em !important;
 }
 
-.blog-editor-wrapper .mantine-Menu-item {
+.lix-editor-wrapper .mantine-Menu-item {
   color: var(--text-primary) !important;
   border-radius: 8px !important;
 }
 
-.blog-editor-wrapper .mantine-Menu-item:hover,
-.blog-editor-wrapper .mantine-Menu-item[data-hovered] {
+.lix-editor-wrapper .mantine-Menu-item:hover,
+.lix-editor-wrapper .mantine-Menu-item[data-hovered] {
   background: var(--bg-active) !important;
 }
 
-.blog-editor-wrapper .mantine-Menu-itemLabel {
+.lix-editor-wrapper .mantine-Menu-itemLabel {
   color: var(--text-primary) !important;
 }
 
-.blog-editor-wrapper .mantine-Menu-itemSection {
+.lix-editor-wrapper .mantine-Menu-itemSection {
   color: var(--text-muted) !important;
 }
 
 /* Block type selector dropdown */
-.blog-editor-wrapper .bn-toolbar select,
-.blog-editor-wrapper .bn-toolbar [class*="select"],
-.blog-editor-wrapper .bn-toolbar [role="listbox"] {
+.lix-editor-wrapper .bn-toolbar select,
+.lix-editor-wrapper .bn-toolbar [class*="select"],
+.lix-editor-wrapper .bn-toolbar [role="listbox"] {
   background: var(--bg-surface) !important;
   color: var(--text-primary) !important;
   border-color: var(--border-default) !important;
 }
 
 /* Mantine Select / Combobox dropdowns (block type picker) */
-.blog-editor-wrapper .mantine-Combobox-dropdown,
-.blog-editor-wrapper .mantine-Select-dropdown {
+.lix-editor-wrapper .mantine-Combobox-dropdown,
+.lix-editor-wrapper .mantine-Select-dropdown {
   background: var(--bg-surface) !important;
   border: 1px solid var(--border-default) !important;
   border-radius: 10px !important;
   box-shadow: 0 12px 40px rgba(0, 0, 0, 0.3) !important;
 }
 
-.blog-editor-wrapper .mantine-Combobox-option {
+.lix-editor-wrapper .mantine-Combobox-option {
   color: var(--text-primary) !important;
   border-radius: 6px !important;
 }
 
-.blog-editor-wrapper .mantine-Combobox-option:hover,
-.blog-editor-wrapper .mantine-Combobox-option[data-combobox-selected] {
+.lix-editor-wrapper .mantine-Combobox-option:hover,
+.lix-editor-wrapper .mantine-Combobox-option[data-combobox-selected] {
   background: var(--bg-active) !important;
 }
 
-.blog-editor-wrapper .mantine-Combobox-option[data-combobox-active] {
+.lix-editor-wrapper .mantine-Combobox-option[data-combobox-active] {
   background: var(--bg-active) !important;
 }
 
-.blog-editor-wrapper .mantine-Input-input {
+.lix-editor-wrapper .mantine-Input-input {
   background: var(--bg-surface) !important;
   color: var(--text-primary) !important;
   border-color: var(--border-default) !important;
@@ -93,7 +93,7 @@
 
 /* ===== Formatting toolbar ===== */
 
-.blog-editor-wrapper .bn-toolbar {
+.lix-editor-wrapper .bn-toolbar {
   background: var(--bg-surface);
   border: 1px solid var(--border-default);
   border-radius: 10px;
@@ -102,38 +102,38 @@
 }
 
 /* When a link is selected, the link toolbar appears — hide AI + link + color from formatting toolbar */
-.blog-editor-wrapper:has(.bn-link-toolbar) .bn-toolbar:not(.bn-link-toolbar) [data-test="createLink"],
-.blog-editor-wrapper:has(.bn-link-toolbar) .bn-toolbar:not(.bn-link-toolbar) .ai-star-btn,
-.blog-editor-wrapper:has(.bn-link-toolbar) .bn-toolbar:not(.bn-link-toolbar) .ai-toolbar-sep,
-.blog-editor-wrapper:has(.bn-link-toolbar) .bn-toolbar:not(.bn-link-toolbar) .toolbar-color-btn,
-.blog-editor-wrapper:has(.bn-link-toolbar) .bn-toolbar:not(.bn-link-toolbar) .toolbar-color-sep {
+.lix-editor-wrapper:has(.bn-link-toolbar) .bn-toolbar:not(.bn-link-toolbar) [data-test="createLink"],
+.lix-editor-wrapper:has(.bn-link-toolbar) .bn-toolbar:not(.bn-link-toolbar) .ai-star-btn,
+.lix-editor-wrapper:has(.bn-link-toolbar) .bn-toolbar:not(.bn-link-toolbar) .ai-toolbar-sep,
+.lix-editor-wrapper:has(.bn-link-toolbar) .bn-toolbar:not(.bn-link-toolbar) .toolbar-color-btn,
+.lix-editor-wrapper:has(.bn-link-toolbar) .bn-toolbar:not(.bn-link-toolbar) .toolbar-color-sep {
   display: none !important;
 }
 
-.blog-editor-wrapper .bn-toolbar button {
+.lix-editor-wrapper .bn-toolbar button {
   color: var(--text-muted);
 }
 
 /* Link create button — highlight it */
-.blog-editor-wrapper .bn-toolbar [data-test="createLink"] {
+.lix-editor-wrapper .bn-toolbar [data-test="createLink"] {
   color: var(--text-muted);
 }
 
-.blog-editor-wrapper .bn-toolbar [data-test="createLink"]:hover {
+.lix-editor-wrapper .bn-toolbar [data-test="createLink"]:hover {
   color: #7ba8f0;
   background: rgba(123, 168, 240, 0.1);
 }
 
-.blog-editor-wrapper .bn-toolbar [data-test="createLink"][data-active="true"] {
+.lix-editor-wrapper .bn-toolbar [data-test="createLink"][data-active="true"] {
   color: #7ba8f0;
 }
 
-.blog-editor-wrapper .bn-toolbar button:hover {
+.lix-editor-wrapper .bn-toolbar button:hover {
   color: #7ba8f0;
   background: var(--border-default);
 }
 
-.blog-editor-wrapper .bn-toolbar button[data-active="true"] {
+.lix-editor-wrapper .bn-toolbar button[data-active="true"] {
   color: #7ba8f0;
 }
 
@@ -332,29 +332,29 @@
 
 /* ===== Slash menu group labels for Media / AI ===== */
 
-.blog-editor-wrapper .bn-suggestion-menu [data-group="Media"] .bn-suggestion-menu-group-label,
-.blog-editor-wrapper .bn-suggestion-menu [data-group="AI Generate"] .bn-suggestion-menu-group-label {
+.lix-editor-wrapper .bn-suggestion-menu [data-group="Media"] .bn-suggestion-menu-group-label,
+.lix-editor-wrapper .bn-suggestion-menu [data-group="AI Generate"] .bn-suggestion-menu-group-label {
   color: #9b7bf7 !important;
 }
 
 /* Link tooltip — only keep Edit link and Open link */
-.blog-editor-wrapper .bn-link-toolbar {
+.lix-editor-wrapper .bn-link-toolbar {
   background: var(--bg-surface);
   border: 1px solid var(--border-default);
   border-radius: 8px;
 }
 
 /* Hide the delete/unlink button (3rd child) */
-.blog-editor-wrapper .bn-link-toolbar > *:nth-child(3) {
+.lix-editor-wrapper .bn-link-toolbar > *:nth-child(3) {
   display: none !important;
 }
 /* Hide any further toolbar buttons that may appear (4th+) */
-.blog-editor-wrapper .bn-link-toolbar > *:nth-child(n+4):not([data-radix-popper-content-wrapper]) {
+.lix-editor-wrapper .bn-link-toolbar > *:nth-child(n+4):not([data-radix-popper-content-wrapper]) {
   display: none !important;
 }
 
 /* Style the edit link popover form */
-.blog-editor-wrapper .bn-form-popover {
+.lix-editor-wrapper .bn-form-popover {
   background: var(--bg-surface);
   border: 1px solid var(--border-default);
   border-radius: 10px;
@@ -363,12 +363,12 @@
   min-width: 280px;
 }
 
-[data-theme="dark"] .blog-editor-wrapper .bn-form-popover {
+[data-theme="dark"] .lix-editor-wrapper .bn-form-popover {
   box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
 }
 
-.blog-editor-wrapper .bn-form-popover .bn-text-input,
-.blog-editor-wrapper .bn-popover-content input {
+.lix-editor-wrapper .bn-form-popover .bn-text-input,
+.lix-editor-wrapper .bn-popover-content input {
   width: 100%;
   padding: 8px 10px;
   font-size: 13px;
@@ -380,18 +380,18 @@
   margin-bottom: 6px;
 }
 
-.blog-editor-wrapper .bn-form-popover .bn-text-input:focus,
-.blog-editor-wrapper .bn-popover-content input:focus {
+.lix-editor-wrapper .bn-form-popover .bn-text-input:focus,
+.lix-editor-wrapper .bn-popover-content input:focus {
   border-color: #9b7bf7;
 }
 
-.blog-editor-wrapper .bn-form-popover .bn-text-input::placeholder,
-.blog-editor-wrapper .bn-popover-content input::placeholder {
+.lix-editor-wrapper .bn-form-popover .bn-text-input::placeholder,
+.lix-editor-wrapper .bn-popover-content input::placeholder {
   color: var(--text-faint);
 }
 
 /* Style the create link popover */
-.blog-editor-wrapper .bn-popover-content {
+.lix-editor-wrapper .bn-popover-content {
   background: var(--bg-surface);
   border: 1px solid var(--border-default);
   border-radius: 10px;
@@ -400,7 +400,7 @@
   min-width: 280px;
 }
 
-[data-theme="dark"] .blog-editor-wrapper .bn-popover-content {
+[data-theme="dark"] .lix-editor-wrapper .bn-popover-content {
   box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
 }
 


### PR DESCRIPTION
## Changes Made

- `packages/lixeditor/src/editor/LixEditor.jsx` — Added `filterSuggestionItems` import and replaced custom `.filter()` slash-menu search with BlockNote's built-in helper, which also matches `aliases`, `subtext`, and `group` fields instead of title only.
- `packages/lixeditor/src/editor/LixEditor.jsx` — Added `aliases` arrays to the Block Equation, Diagram, and Table of Contents slash-menu items so they surface on partial or related queries (e.g. "latex", "flowchart", "toc").
- `packages/lixeditor/src/editor/LixEditor.jsx` — Added a "Date" slash-menu item (guarded by `f.dates`) that inserts today's date as an inline `dateInline` chip.
- `packages/lixeditor/src/editor/LixEditor.jsx` — Added Ctrl/Cmd+D keyboard shortcut (also guarded by `f.dates`) to insert today's date chip at the cursor position.
- `packages/lixeditor/src/styles/blocks.css` — Renamed all `.blog-editor-wrapper` selectors to `.lix-editor-wrapper` and added KaTeX CSS overrides (`.katex` color/size, `.katex-display` margin reset) so rendered math inherits the editor theme.
- `packages/lixeditor/src/styles/blog-image.css` and `packages/lixeditor/src/styles/editor.css` — Renamed `.blog-editor-wrapper` to `.lix-editor-wrapper` to keep CSS scoping consistent with the package rename.

## Checklist

- [ ] No Node built-ins imported (crypto, fs, path, stream, Buffer)
- [ ] `./biome.sh ci` clean
- [ ] Tested locally: <how>