### PR TITLE
fix(editor): WYSIWYG quick wins — mermaid focus, emoji/slash menu height, remove TOC insert, codeblock label (part of #9)

### DIFF
--- a/src/components/Editor/BlogEditor.jsx
+++ b/src/components/Editor/BlogEditor.jsx
@@ -218,14 +218,9 @@ function getCustomSlashMenuItems(editor, callbacks = {}) {
       icon: <Icon d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" d2="M3 3h18v18H3z M8.5 10a1.5 1.5 0 100-3 1.5 1.5 0 000 3z M21 15l-5-5L5 21" />,
       onItemClick: () => editor.insertBlocks([{ type: 'image', props: { url: '' } }], editor.getTextCursorPosition().block, 'after'),
     },
-    {
-      title: 'Table of Contents',
-      subtext: 'Auto-generated page outline',
-      group: 'Custom Blocks',
-      aliases: ['toc', 'outline', 'contents', 'navigation'],
-      icon: <Icon d="M3 12h18M3 6h18M3 18h12" />,
-      onItemClick: () => editor.insertBlocks([{ type: 'tableOfContents' }], editor.getTextCursorPosition().block, 'after'),
-    },
+    // Table of Contents is no longer insertable — the floating TOC is rendered
+    // automatically at the top-right of every blog. The `tableOfContents` block
+    // spec stays mounted for backward compat with already-saved blogs (#19).
     {
       title: 'Block Equation',
       subtext: 'Render LaTeX as a block',

--- a/src/components/Editor/blocks/MermaidBlock.jsx
+++ b/src/components/Editor/blocks/MermaidBlock.jsx
@@ -321,7 +321,16 @@ export const MermaidBlock = createReactBlockSpec(
       const debounceRef = useRef(null);
 
       useEffect(() => {
-        if (editing && inputRef.current) inputRef.current.focus();
+        if (!editing) return;
+        // Focus the textarea once it's painted. A bare focus() can lose the
+        // race with BlockNote re-focusing the editor right after insert, so we
+        // focus on the next frame and again shortly after as a fallback (#17).
+        const raf = requestAnimationFrame(() => {
+          const el = inputRef.current;
+          if (el) { el.focus(); el.setSelectionRange(el.value.length, el.value.length); }
+        });
+        const t = setTimeout(() => inputRef.current?.focus(), 80);
+        return () => { cancelAnimationFrame(raf); clearTimeout(t); };
       }, [editing]);
 
       // Debounced live preview update while typing

--- a/src/styles/editor/blocks.css
+++ b/src/styles/editor/blocks.css
@@ -40,8 +40,10 @@
 :root {
   --code-bg: #f8f8fb;
   --code-text: #3d3d50;
-  --code-lang-bg: #eeeef2;
-  --code-lang-text: #6b7280;
+  /* Darker label text on a slightly stronger chip so the language selector is
+     clearly visible in light mode (was #6b7280 on #eeeef2 — too low contrast). */
+  --code-lang-bg: #dfe3ea;
+  --code-lang-text: #44485a;
 }
 
 [data-theme="dark"] {

--- a/src/styles/editor/menus.css
+++ b/src/styles/editor/menus.css
@@ -10,6 +10,16 @@
   scrollbar-color: var(--bg-elevated) transparent;
 }
 
+/* Cap the height of the slash + emoji (":") menus so they scroll internally
+   instead of overflowing off-screen behind the navbar (#18). The emoji picker
+   is BlockNote's built-in grid menu. */
+.blog-editor-wrapper .bn-suggestion-menu,
+.bn-suggestion-menu,
+.bn-grid-suggestion-menu {
+  max-height: min(320px, 50vh) !important;
+  overflow-y: auto !important;
+}
+
 .blog-editor-wrapper .bn-suggestion-menu::-webkit-scrollbar {
   width: 6px;
 }


### PR DESCRIPTION
Part of #9 — first "quick wins" chunk of the WYSIWYG editor bug batch.

## Fixes
- **Closes #19** — "Table of Contents" removed from the slash/insert menu (the floating TOC already renders automatically top-right). The `tableOfContents` block spec stays mounted so already-saved blogs still render.
- **Closes #17** — After `/mermaid`, the cursor now lands inside the placeholder. Focus is set on the next animation frame (with a short timeout fallback) so it doesn't lose the race with BlockNote re-focusing the editor after insert.
- **Closes #18** — The slash and emoji (`:`) menus now have a capped height (`max-height: min(320px, 50vh)`) with internal scroll, so the emoji picker no longer overflows off-screen behind the navbar.
- **Addresses #16** — Code-block language label is now legible in light mode (was grey-on-grey, ~invisible). ⚠️ Language **auto-detection** is still pending and remains open on #16.

## Deferred (not in this PR)
- **#15** (slash menu closing after a space) — this is BlockNote's internal `SuggestionMenuController` behavior; AI-space handling was ruled out (AI is disabled). It needs a live reproduction to fix safely without risking the core command menu, so I'm leaving it for the verify pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
