### PR TITLE
feat(editor): inline buttons, page context menu, breadcrumbs UX (closes #21 #22 #23)

### DIFF
--- a/src/components/Editor/BlogEditor.jsx
+++ b/src/components/Editor/BlogEditor.jsx
@@ -31,6 +31,7 @@ import { DateInline } from './blocks/DateInline';
 import { MentionInline } from './blocks/MentionInline';
 import { BlogMentionInline } from './blocks/BlogMentionInline';
 import { OrgMentionInline } from './blocks/OrgMentionInline';
+import { InlineButton } from './blocks/InlineButton';
 
 // AI features (space-to-AI menu, AI block, AI selection toolbar, AI image gen)
 // are temporarily disabled and surfaced as "Coming soon". Flip to re-enable.
@@ -108,6 +109,7 @@ const schema = BlockNoteSchema.create({
     mention: MentionInline,
     blogMention: BlogMentionInline,
     orgMention: OrgMentionInline,
+    inlineButton: InlineButton,
   },
 });
 
@@ -615,6 +617,7 @@ function doSanitize(blocks) {
 
 const BlogEditor = forwardRef(function BlogEditor({ onChange, initialContent, onReady, onTitleChange, blogId, collaboration, onCollabSeeded }, ref) {
   const { isDark } = useTheme();
+  const [pageMenu, setPageMenu] = useState(null); // {x,y} for the right-click page menu (#21)
   const [showMentionMenu, setShowMentionMenu] = useState(false);
   const [mentionQuery, setMentionQuery] = useState('');
   const [mentionPos, setMentionPos] = useState({ top: 0, left: 0 });
@@ -949,6 +952,23 @@ const BlogEditor = forwardRef(function BlogEditor({ onChange, initialContent, on
         return (
           <FormattingToolbar>
             {items}
+            {/* Convert the selection into an inline button (#22). */}
+            {link.kind === 'none' && (
+              <button
+                key="makeButton"
+                type="button"
+                className="bn-button"
+                title="Make button"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => {
+                  const text = (ed.getSelectedText?.() || '').trim();
+                  ed.insertInlineContent([{ type: 'inlineButton', props: { label: text || 'Button', href: '' } }]);
+                }}
+                style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', width: 28, height: 28 }}
+              >
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="3" y="8" width="18" height="8" rx="2" /><path d="M8 12h8" /></svg>
+              </button>
+            )}
             {link.kind === 'none' && <CreateLinkButton key="createLink" />}
             {link.kind === 'full' && (
               <button
@@ -2479,7 +2499,17 @@ const BlogEditor = forwardRef(function BlogEditor({ onChange, initialContent, on
   }, [editor, getAiBlockIds, highlightAiBlocks, getFullBlogContext, blogId, handleAIKeep, aiMenuPos, hideSparkle, onTitleChange, replaceImagePlaceholder]);
 
   return (
-    <div className={`blog-editor-wrapper${aiGenerating ? ' ai-editor-locked' : ''}`} ref={wrapperRef} style={{ position: 'relative' }}>
+    <div
+      className={`blog-editor-wrapper${aiGenerating ? ' ai-editor-locked' : ''}`}
+      ref={wrapperRef}
+      style={{ position: 'relative' }}
+      onContextMenu={(e) => {
+        // Keep native menus on links/inputs/toolbars; otherwise show ours (#21).
+        if (e.target.closest('a, input, textarea, button, .bn-link-toolbar, [data-content-type="codeBlock"]')) return;
+        e.preventDefault();
+        setPageMenu({ x: Math.min(e.clientX, window.innerWidth - 230), y: Math.min(e.clientY, window.innerHeight - 320) });
+      }}
+    >
       <BlockNoteView
         editor={editor}
         onChange={handleChange}
@@ -2495,6 +2525,41 @@ const BlogEditor = forwardRef(function BlogEditor({ onChange, initialContent, on
         <FormattingToolbarController formattingToolbar={LinkAwareFormattingToolbar} />
         <TableHandlesController />
       </BlockNoteView>
+
+      {/* Page context menu (#21) — quick block inserts on right-click */}
+      {pageMenu && (
+        <>
+          <div style={{ position: 'fixed', inset: 0, zIndex: 90 }} onMouseDown={() => setPageMenu(null)} onContextMenu={(e) => { e.preventDefault(); setPageMenu(null); }} />
+          <div className="page-context-menu" style={{ position: 'fixed', top: pageMenu.y, left: pageMenu.x, zIndex: 91 }}>
+            {[
+              { label: 'Heading', type: 'heading', props: { level: 2 }, d: 'M6 4v16M18 4v16M6 12h12' },
+              { label: 'Bullet list', type: 'bulletListItem', d: 'M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01' },
+              { label: 'Image', type: 'image', props: { url: '' }, d: 'M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4M3 3h18v18H3z M21 15l-5-5L5 21' },
+              { label: 'Table', type: 'table', d: 'M3 3h18v18H3zM3 9h18M3 15h18M9 3v18M15 3v18' },
+              { label: 'Code block', type: 'codeBlock', d: 'M16 18l6-6-6-6M8 6l-6 6 6 6' },
+              { label: 'Quote', type: 'quote', d: 'M3 21c3 0 7-1 7-8V5H3v7h4M14 21c3 0 7-1 7-8V5h-7v7h4' },
+              { label: 'Divider', type: 'divider', d: 'M3 12h18' },
+            ].map((it) => (
+              <button
+                key={it.label}
+                type="button"
+                className="page-context-menu-item"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => {
+                  try {
+                    const cur = editor.getTextCursorPosition().block;
+                    editor.insertBlocks([{ type: it.type, ...(it.props ? { props: it.props } : {}) }], cur, 'after');
+                  } catch {}
+                  setPageMenu(null);
+                }}
+              >
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d={it.d} /></svg>
+                {it.label}
+              </button>
+            ))}
+          </div>
+        </>
+      )}
 
       {/* @ Mention menu */}
       {showMentionMenu && mentionQuery && (

--- a/src/components/Editor/BlogPreview.jsx
+++ b/src/components/Editor/BlogPreview.jsx
@@ -120,6 +120,13 @@ function renderBlocksToHTML(blocks) {
       if (c.type === 'orgMention' && c.props?.slug) {
         return `<a href="/${c.props.slug}" class="mention-chip"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink:0"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75"/></svg>@${c.props.slug}</a>`;
       }
+      if (c.type === 'inlineButton') {
+        const label = (c.props?.label || 'Button').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        const href = c.props?.href || '';
+        return href
+          ? `<a href="${href}" class="inline-button-chip" target="_blank" rel="noopener noreferrer">${label}</a>`
+          : `<span class="inline-button-chip">${label}</span>`;
+      }
       // Links wrap child content — recurse into c.content for the link text
       if (c.type === 'link' && c.href) {
         const linkText = c.content ? inlineToHTML(c.content) : (c.text || c.href).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');

--- a/src/components/Editor/blocks/Breadcrumbs.jsx
+++ b/src/components/Editor/blocks/Breadcrumbs.jsx
@@ -3,6 +3,9 @@
 import { createReactBlockSpec } from '@blocknote/react';
 import { useState } from 'react';
 
+// Breadcrumbs block (#23): a structured, easy-to-edit segment builder.
+// Click the trail (or the Edit button) to open the editor; each segment has a
+// label + optional URL with add/remove, plus a live preview of the trail.
 export const Breadcrumbs = createReactBlockSpec(
   {
     type: 'breadcrumbs',
@@ -13,33 +16,80 @@ export const Breadcrumbs = createReactBlockSpec(
   },
   {
     render: ({ block, editor }) => {
-      let items = [];
-      try { items = JSON.parse(block.props.items); } catch {}
+      let initial = [];
+      try { initial = JSON.parse(block.props.items); } catch {}
 
-      const [editing, setEditing] = useState(items.length === 0);
-      const [text, setText] = useState(items.map((i) => `${i.label}|${i.href || ''}`).join('\n'));
+      const [editing, setEditing] = useState(initial.length === 0);
+      const [segments, setSegments] = useState(
+        initial.length ? initial : [{ label: '', href: '' }],
+      );
+
+      const update = (i, field, value) =>
+        setSegments((s) => s.map((seg, idx) => (idx === i ? { ...seg, [field]: value } : seg)));
+      const addSegment = () => setSegments((s) => [...s, { label: '', href: '' }]);
+      const removeSegment = (i) => setSegments((s) => s.filter((_, idx) => idx !== i));
 
       const save = () => {
-        const parsed = text.split('\n').filter(Boolean).map((line) => {
-          const [label, href] = line.split('|');
-          return { label: label?.trim() || 'Page', href: href?.trim() || '' };
-        });
-        editor.updateBlock(block, { props: { items: JSON.stringify(parsed) } });
+        const cleaned = segments
+          .map((s) => ({ label: (s.label || '').trim(), href: (s.href || '').trim() }))
+          .filter((s) => s.label);
+        editor.updateBlock(block, { props: { items: JSON.stringify(cleaned) } });
+        setSegments(cleaned.length ? cleaned : [{ label: '', href: '' }]);
         setEditing(false);
       };
 
       if (editing) {
         return (
           <div className="border border-[var(--border-default)] rounded-xl bg-[var(--bg-surface)] p-4 my-2">
-            <p className="text-[11px] text-[var(--text-muted)] font-medium mb-2">Breadcrumbs (one per line: label|url)</p>
-            <textarea
-              value={text}
-              onChange={(e) => setText(e.target.value)}
-              placeholder={"Home|/\nBlog|/blog\nCurrent Page"}
-              rows={4}
-              className="w-full bg-[var(--bg-app)] border border-[var(--border-default)] rounded-lg p-3 text-[13px] text-[var(--text-primary)] font-mono resize-none outline-none focus:border-[var(--border-hover)] placeholder-[#6b7a8d]"
-            />
-            <div className="flex justify-end gap-2 mt-2">
+            <div className="flex items-center gap-2 mb-3">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#9b7bf7" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M3 12h4l3-3 4 6 3-3h4" /></svg>
+              <span className="text-[12px] font-semibold text-[var(--text-primary)]">Breadcrumbs</span>
+            </div>
+
+            <div className="space-y-2">
+              {segments.map((seg, i) => (
+                <div key={i} className="flex items-center gap-2">
+                  <span className="text-[11px] text-[var(--text-faint)] w-5 text-right">{i + 1}</span>
+                  <input
+                    value={seg.label}
+                    onChange={(e) => update(i, 'label', e.target.value)}
+                    placeholder="Label (e.g. Home)"
+                    className="flex-1 bg-[var(--bg-app)] border border-[var(--border-default)] rounded-lg px-3 py-1.5 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--border-hover)] placeholder-[#6b7a8d]"
+                  />
+                  <input
+                    value={seg.href}
+                    onChange={(e) => update(i, 'href', e.target.value)}
+                    placeholder="URL (optional)"
+                    className="flex-1 bg-[var(--bg-app)] border border-[var(--border-default)] rounded-lg px-3 py-1.5 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--border-hover)] placeholder-[#6b7a8d] font-mono"
+                  />
+                  <button
+                    onClick={() => removeSegment(i)}
+                    disabled={segments.length === 1}
+                    title="Remove segment"
+                    className="text-[var(--text-faint)] hover:text-[#f87171] disabled:opacity-30 transition-colors p-1"
+                  >
+                    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M18 6L6 18M6 6l12 12" /></svg>
+                  </button>
+                </div>
+              ))}
+            </div>
+
+            <button onClick={addSegment} className="flex items-center gap-1.5 mt-2.5 text-[12px] text-[#9b7bf7] hover:text-[#b69aff] transition-colors">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 5v14M5 12h14" /></svg>
+              Add segment
+            </button>
+
+            {/* Live preview */}
+            <div className="flex items-center gap-1.5 text-[13px] mt-3 pt-3 border-t border-[var(--divider)] flex-wrap">
+              {segments.filter((s) => (s.label || '').trim()).map((seg, i) => (
+                <span key={i} className="flex items-center gap-1.5">
+                  {i > 0 && <span className="text-[#4a5568]">/</span>}
+                  <span className={seg.href ? 'text-[#9b7bf7]' : 'text-[var(--text-muted)]'}>{seg.label}</span>
+                </span>
+              ))}
+            </div>
+
+            <div className="flex justify-end gap-2 mt-3">
               <button onClick={() => setEditing(false)} className="px-3 py-1 text-[12px] text-[#888]">Cancel</button>
               <button onClick={save} className="px-3 py-1 text-[12px] bg-[#9b7bf7] text-[var(--text-primary)] rounded-md font-medium hover:bg-[#b69aff] transition-colors">Done</button>
             </div>
@@ -48,19 +98,16 @@ export const Breadcrumbs = createReactBlockSpec(
       }
 
       return (
-        <div className="flex items-center gap-1.5 text-[13px] my-2 flex-wrap" onDoubleClick={() => setEditing(true)}>
-          {items.map((item, i) => (
+        <div className="group flex items-center gap-1.5 text-[13px] my-2 flex-wrap cursor-pointer" onClick={() => setEditing(true)} title="Click to edit breadcrumbs">
+          {initial.map((item, i) => (
             <span key={i} className="flex items-center gap-1.5">
               {i > 0 && <span className="text-[#4a5568]">/</span>}
-              {item.href ? (
-                <span className="text-[#9b7bf7] hover:text-[#b69aff] cursor-pointer transition-colors">{item.label}</span>
-              ) : (
-                <span className="text-[var(--text-muted)]">{item.label}</span>
-              )}
+              <span className={item.href ? 'text-[#9b7bf7] hover:text-[#b69aff] transition-colors' : 'text-[var(--text-muted)]'}>{item.label}</span>
             </span>
           ))}
+          <svg className="opacity-0 group-hover:opacity-100 transition-opacity ml-1 text-[var(--text-faint)]" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7" /><path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z" /></svg>
         </div>
       );
     },
-  }
+  },
 );

--- a/src/components/Editor/blocks/InlineButton.jsx
+++ b/src/components/Editor/blocks/InlineButton.jsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { createReactInlineContentSpec } from '@blocknote/react';
+import { useState, useRef, useEffect } from 'react';
+
+// Inline button (#22): like an inline link, but rendered as a button chip.
+// Created from the selection toolbar (selected text becomes the label); click
+// the chip in the editor to edit its label/link.
+function InlineButtonChip({ inlineContent }) {
+  const [editing, setEditing] = useState(false);
+  const [label, setLabel] = useState(inlineContent.props.label || '');
+  const [href, setHref] = useState(inlineContent.props.href || '');
+  const popupRef = useRef(null);
+
+  useEffect(() => {
+    if (!editing) return;
+    const onDown = (e) => { if (popupRef.current && !popupRef.current.contains(e.target)) setEditing(false); };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [editing]);
+
+  const save = () => {
+    inlineContent.props.label = label.trim() || 'Button';
+    inlineContent.props.href = href.trim();
+    setEditing(false);
+  };
+
+  const open = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setLabel(inlineContent.props.label || '');
+    setHref(inlineContent.props.href || '');
+    setEditing(true);
+  };
+
+  return (
+    <span className="relative inline-flex items-center" contentEditable={false}>
+      <button
+        type="button"
+        className="inline-button-chip"
+        data-inline-type="button"
+        data-href={inlineContent.props.href || ''}
+        onClick={open}
+        title={inlineContent.props.href || 'Click to edit'}
+      >
+        {inlineContent.props.label || 'Button'}
+      </button>
+      {editing && (
+        <div ref={popupRef} className="inline-equation-editor" onMouseDown={(e) => e.stopPropagation()}>
+          <input
+            className="inline-equation-editor-input"
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            placeholder="Button label"
+            autoFocus
+          />
+          <input
+            className="inline-equation-editor-input"
+            style={{ marginTop: 6 }}
+            value={href}
+            onChange={(e) => setHref(e.target.value)}
+            placeholder="https://..."
+            onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); save(); } if (e.key === 'Escape') setEditing(false); }}
+          />
+          <div className="inline-equation-editor-actions">
+            <button className="mermaid-btn-cancel" onClick={() => setEditing(false)}>Cancel</button>
+            <button className="mermaid-btn-save" onClick={save}>Save</button>
+          </div>
+        </div>
+      )}
+    </span>
+  );
+}
+
+export const InlineButton = createReactInlineContentSpec(
+  {
+    type: 'inlineButton',
+    propSchema: {
+      label: { default: 'Button' },
+      href: { default: '' },
+    },
+    content: 'none',
+  },
+  {
+    render: (props) => <InlineButtonChip {...props} />,
+    parse: (el) => {
+      if (el.getAttribute('data-inline-type') === 'button' || el.classList.contains('inline-button-chip')) {
+        return { label: el.textContent?.trim() || 'Button', href: el.getAttribute('data-href') || '' };
+      }
+      return undefined;
+    },
+  },
+);

--- a/src/styles/editor/base.css
+++ b/src/styles/editor/base.css
@@ -190,6 +190,56 @@
 .blog-editor-wrapper [data-style-type="backgroundColor"][data-value="rgba(167,139,250,0.25)"] { background-color: rgba(167,139,250,0.25) !important; }
 .blog-editor-wrapper [data-style-type="backgroundColor"][data-value="rgba(244,114,182,0.25)"] { background-color: rgba(244,114,182,0.25) !important; }
 
+/* Page context menu (#21) */
+.page-context-menu {
+  min-width: 200px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: 10px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
+  padding: 5px;
+}
+.page-context-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 7px 10px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 13px;
+  text-align: left;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+.page-context-menu-item:hover {
+  background: var(--bg-active);
+  color: var(--text-primary);
+}
+
+/* Inline button chip (#22) — editor + preview */
+.inline-button-chip {
+  display: inline-flex;
+  align-items: center;
+  vertical-align: baseline;
+  padding: 2px 12px;
+  margin: 0 1px;
+  border: none;
+  border-radius: 7px;
+  background: #9b7bf7;
+  color: #fff;
+  font-size: 0.9em;
+  font-weight: 600;
+  font-family: inherit;
+  line-height: 1.4;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background 0.15s;
+}
+.inline-button-chip:hover { background: #b69aff; }
+
 /* Cover gradient blur placeholder */
 .cover-gradient-blur {
   background: linear-gradient(


### PR DESCRIPTION
Part of #9 — editor block/menu features.

## Closes #22 — Inline buttons
- New `inlineButton` inline content (chip rendered as a button).
- A **"Make button"** action on the selection toolbar: the selected text becomes the button label; click the chip in the editor to set/edit the label + link.
- Renders in both the editor and the published preview (links open in a new tab).

## Closes #21 — Page context menu
- Right-click anywhere in the editor body for a quick-insert menu: Heading, Bullet list, Image, Table, Code block, Quote, Divider. (Native menu preserved on links/inputs/code.)

## Closes #23 — Breadcrumbs UX
- Replaced the raw `label|url` textarea with a **structured segment editor**: per-segment label + URL inputs, add/remove buttons, and a **live preview** of the trail.
- Click the rendered breadcrumb trail to edit it (previously double-click only).

## Deferred
- **#20** (table-handle right-click menu) → next round. BlockNote's table-op API needs to be verified against the running editor before I wire a custom `TableHandle`; the default handles already provide add/delete on click, so nothing is broken meanwhile.

> Verify on build: the inline-button toolbar action + chip edit popup, and that the page context menu inserts at a sensible position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
