### PR TITLE
fix(subpages): id-or-slug resolution + apply missing 0022 columns (closes #24 #25)

### DIFF
--- a/app/api/subpages/route.js
+++ b/app/api/subpages/route.js
@@ -18,10 +18,16 @@ export async function POST(request) {
     const { getDB } = await import('../../../lib/cloudflare');
     const db = getDB();
 
-    // Verify blog ownership
-    const blog = await db.prepare('SELECT author_id FROM blogs WHERE id = ?').bind(blogId).first();
+    // Resolve the parent by canonical id OR human slug — in production the edit
+    // URL carries the slug, so callers may pass either (#24). Sub-pages are
+    // always stored under the canonical blog id.
+    let blog = await db.prepare('SELECT id, author_id FROM blogs WHERE id = ?').bind(blogId).first();
+    if (!blog) {
+      blog = await db.prepare('SELECT id, author_id FROM blogs WHERE LOWER(slug) = LOWER(?) ORDER BY updated_at DESC LIMIT 1').bind(blogId).first();
+    }
     if (!blog) return NextResponse.json({ error: 'Blog not found' }, { status: 404 });
     if (blog.author_id !== session.userId) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    const canonicalBlogId = blog.id;
 
     // Cap sub-pages per kind: max 2 doc sub-pages and max 2 canvas sub-pages per blog.
     // (Nesting is structurally impossible — a sub-page's id is never a blogs row,
@@ -29,7 +35,7 @@ export async function POST(request) {
     const kindCap = subpageKind === 'canvas' ? MAX_CANVAS_PER_BLOG : MAX_SUBPAGES_PER_BLOG;
     const kindCount = await db.prepare(
       'SELECT COUNT(*) as n FROM subpages WHERE blog_id = ? AND kind = ?'
-    ).bind(blogId, subpageKind).first();
+    ).bind(canonicalBlogId, subpageKind).first();
     if ((kindCount?.n ?? 0) >= kindCap) {
       const label = subpageKind === 'canvas' ? 'Canvas' : 'Sub-page';
       return NextResponse.json({ error: `${label} limit reached (max ${kindCap} per blog)` }, { status: 409 });
@@ -42,9 +48,9 @@ export async function POST(request) {
 
     await db.prepare(
       'INSERT INTO subpages (id, blog_id, title, content, created_at, updated_at, kind, metadata) VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
-    ).bind(id, blogId, title || 'Untitled', initialContent, now, now, subpageKind, metaStr).run();
+    ).bind(id, canonicalBlogId, title || 'Untitled', initialContent, now, now, subpageKind, metaStr).run();
 
-    return NextResponse.json({ id, blogId, title: title || 'Untitled', kind: subpageKind });
+    return NextResponse.json({ id, blogId: canonicalBlogId, title: title || 'Untitled', kind: subpageKind });
   } catch (err) {
     return NextResponse.json({ error: err.message }, { status: 500 });
   }
@@ -94,9 +100,16 @@ export async function GET(request) {
 
     if (!blogId) return NextResponse.json({ error: 'Missing blogId or id' }, { status: 400 });
 
+    // Accept id or slug (edit URLs use the slug in prod) — sub-pages are keyed
+    // by the canonical blog id.
+    let canonicalBlogId = blogId;
+    const parentRow = await db.prepare('SELECT id FROM blogs WHERE id = ? OR LOWER(slug) = LOWER(?) ORDER BY (id = ?) DESC LIMIT 1')
+      .bind(blogId, blogId, blogId).first();
+    if (parentRow?.id) canonicalBlogId = parentRow.id;
+
     const { results } = await db.prepare(
       'SELECT id, blog_id, title, kind, created_at, updated_at FROM subpages WHERE blog_id = ? ORDER BY created_at ASC'
-    ).bind(blogId).all();
+    ).bind(canonicalBlogId).all();
 
     return NextResponse.json({ subpages: results || [] });
   } catch (err) {

--- a/src/components/Editor/BlogEditor.jsx
+++ b/src/components/Editor/BlogEditor.jsx
@@ -252,7 +252,7 @@ function getCustomSlashMenuItems(editor, callbacks = {}) {
     },
     {
       title: 'Sub Page',
-      subtext: 'Nested page within this blog',
+      subtext: 'Nested page within this blog (max 2 per blog)',
       group: 'Custom Blocks',
       aliases: ['subpage', 'sub page', 'tabs', 'nested', 'page in page', 'child page'],
       icon: <Icon d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" d2="M14 2v6h6M16 13H8M16 17H8" />,


### PR DESCRIPTION
Part of #9 — backend/sub-pages batch.

## Diagnosis
Queried the remote D1: the `subpages` table was **missing the `kind` and `metadata` columns** (migration 0022 showed as applied in tracking but the columns weren't there — recorded-but-not-effective). That produced the canvas SQLite error (#25). Separately, the editor passes the blog **slug** (edit URLs use the slug in prod) but the API looked up `blogs WHERE id = ?` → 404 → sub-pages silently failed to create (#24).

## Closes #25 — Canvas D1/SQLite error
Applied 0022's additive statements directly to remote D1 (`ALTER TABLE subpages ADD COLUMN kind … / metadata …` + the index) since `migrations list` reported nothing pending. Verified `PRAGMA table_info(subpages)` now includes `kind` + `metadata`. **Prod is fixed now.**

## Closes #24 — Sub-pages not creating in production
- The subpages API (POST + GET list) now resolves the parent blog by **canonical id OR slug**, and always stores/queries sub-pages under the canonical id.
- The "Sub Page" slash item now notes the **max 2 per blog** limit.

> Note: a fresh DB applies 0022 correctly via migrations; this only remediates the existing remote DB whose tracking was out of sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
