### PR TITLE
feat(comments): @mention tagging in comments & replies (closes #10)

### DIFF
--- a/app/api/blogs/[slugid]/comments/route.js
+++ b/app/api/blogs/[slugid]/comments/route.js
@@ -119,16 +119,40 @@ export async function POST(request, { params }) {
         });
       }
 
+      const alreadyNotified = new Set([session.userId]);
+      if (blog.author_id !== session.userId) alreadyNotified.add(blog.author_id);
+
       // Notify parent comment author if reply (and not self)
       if (parentId) {
         const parent = await db.prepare('SELECT user_id FROM comments WHERE id = ?').bind(parentId).first();
         if (parent && parent.user_id !== session.userId && parent.user_id !== blog.author_id) {
+          alreadyNotified.add(parent.user_id);
           await notify(db, {
             userId: parent.user_id, type: 'mention',
             actorId: session.userId, actorName: user?.display_name || user?.username,
             actorAvatar: user?.avatar_url, targetId: slugid,
             targetTitle: blog.title, targetUrl: blogUrl,
           });
+        }
+      }
+
+      // @mentions in the comment body (#10): resolve real usernames, record
+      // them, and notify each mentioned user (skipping self / already-notified).
+      const unames = [...new Set([...content.matchAll(/(?:^|[^a-zA-Z0-9_])@([a-zA-Z0-9_-]+)/g)].map((m) => m[1].toLowerCase()))].slice(0, 20);
+      if (unames.length) {
+        const ph = unames.map(() => '?').join(',');
+        const found = await db.prepare(`SELECT id, username FROM users WHERE LOWER(username) IN (${ph})`).bind(...unames).all();
+        for (const u of (found?.results || [])) {
+          try { await db.prepare('INSERT OR IGNORE INTO comment_mentions (comment_id, user_id) VALUES (?, ?)').bind(id, u.id).run(); } catch {}
+          if (!alreadyNotified.has(u.id)) {
+            alreadyNotified.add(u.id);
+            await notify(db, {
+              userId: u.id, type: 'mention',
+              actorId: session.userId, actorName: user?.display_name || user?.username,
+              actorAvatar: user?.avatar_url, targetId: slugid,
+              targetTitle: blog.title, targetUrl: blogUrl,
+            });
+          }
         }
       }
     } catch {}

--- a/app/api/blogs/[slugid]/comments/route.js
+++ b/app/api/blogs/[slugid]/comments/route.js
@@ -48,6 +48,28 @@ export async function GET(request, { params }) {
         c.replies = (replyMap[c.id] || []).slice(0, 100);
         c.reply_count = (replyMap[c.id] || []).length;
       }
+
+      // Attach @mention usernames per comment/reply so the client can linkify
+      // only the tokens that resolved to real users (#10).
+      const allIds = [];
+      for (const c of comments) { allIds.push(c.id); for (const r of c.replies) allIds.push(r.id); }
+      if (allIds.length) {
+        // Guard: degrade gracefully if comment_mentions isn't migrated yet.
+        try {
+          const mp = allIds.map(() => '?').join(',');
+          const mres = await db.prepare(`
+            SELECT cm.comment_id, u.username
+            FROM comment_mentions cm JOIN users u ON u.id = cm.user_id
+            WHERE cm.comment_id IN (${mp})
+          `).bind(...allIds).all();
+          const byComment = {};
+          for (const row of (mres?.results || [])) (byComment[row.comment_id] ||= []).push(row.username);
+          for (const c of comments) {
+            c.mentions = byComment[c.id] || [];
+            for (const r of c.replies) r.mentions = byComment[r.id] || [];
+          }
+        } catch { /* table not migrated yet — skip mention linkification */ }
+      }
     }
 
     const total = await db.prepare('SELECT COUNT(*) as c FROM comments WHERE blog_id = ? AND parent_id IS NULL').bind(slugid).first();

--- a/migrations/0026_comment_mentions.sql
+++ b/migrations/0026_comment_mentions.sql
@@ -1,0 +1,12 @@
+-- @mentions inside comments / replies (#10).
+-- One row per (comment, mentioned user). Used to notify tagged users and to
+-- reliably linkify @username tokens in rendered comments.
+CREATE TABLE IF NOT EXISTS comment_mentions (
+  comment_id TEXT NOT NULL REFERENCES comments(id) ON DELETE CASCADE,
+  user_id TEXT NOT NULL REFERENCES users(id),
+  created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+  PRIMARY KEY (comment_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_comment_mentions_user ON comment_mentions(user_id);
+CREATE INDEX IF NOT EXISTS idx_comment_mentions_comment ON comment_mentions(comment_id);

--- a/src/components/BlogComments.jsx
+++ b/src/components/BlogComments.jsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '../context/AuthContext';
 import Link from 'next/link';
+import MentionTextarea, { renderMentions } from './MentionTextarea';
 
 function timeAgo(ts) {
   if (!ts) return '';
@@ -100,11 +101,11 @@ export default function BlogComments({ blogId, blogAuthorId }) {
             </div>
           )}
           <div className="flex-1">
-            <textarea
+            <MentionTextarea
               value={newComment}
               onChange={e => setNewComment(e.target.value)}
               onKeyDown={e => { if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) { e.preventDefault(); postComment(newComment); } }}
-              placeholder="Add a comment..."
+              placeholder="Add a comment... (@ to mention)"
               rows={2}
               className="w-full px-1 py-3 outline-none text-[14px] resize-none bg-transparent"
               style={{ borderBottom: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
@@ -176,7 +177,7 @@ export default function BlogComments({ blogId, blogAuthorId }) {
                       </div>
                     </div>
                   ) : (
-                    <p className="text-[14px] leading-relaxed whitespace-pre-wrap" style={{ color: 'var(--text-body)' }}>{c.content}</p>
+                    <p className="text-[14px] leading-relaxed whitespace-pre-wrap" style={{ color: 'var(--text-body)' }}>{renderMentions(c.content, c.mentions, Link)}</p>
                   )}
 
                   {/* Actions: reply, edit, delete */}
@@ -201,13 +202,13 @@ export default function BlogComments({ blogId, blogAuthorId }) {
                   {/* Reply input */}
                   {replyTo?.id === c.id && (
                     <div className="flex gap-2 mt-3">
-                      <textarea
+                      <MentionTextarea
                         value={replyText}
                         onChange={e => setReplyText(e.target.value)}
-                        placeholder={`Reply to ${replyTo.username}...`}
+                        placeholder={`Reply to ${replyTo.username}... (@ to mention)`}
                         rows={2}
-                        className="flex-1 rounded-lg px-3 py-2 outline-none text-[13px] resize-none"
-                        style={{ backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
+                        className="w-full rounded-lg px-3 py-2 outline-none text-[13px] resize-none"
+                        style={{ flex: 1, backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
                         autoFocus
                       />
                       <button
@@ -239,7 +240,7 @@ export default function BlogComments({ blogId, blogAuthorId }) {
                               <Link href={`/${r.username}`} className="text-[12px] font-semibold" style={{ color: 'var(--text-primary)' }}>{r.display_name || r.username}</Link>
                               <span className="text-[10px]" style={{ color: 'var(--text-faint)' }}>{timeAgo(r.created_at)}</span>
                             </div>
-                            <p className="text-[13px] leading-relaxed whitespace-pre-wrap" style={{ color: 'var(--text-body)' }}>{r.content}</p>
+                            <p className="text-[13px] leading-relaxed whitespace-pre-wrap" style={{ color: 'var(--text-body)' }}>{renderMentions(r.content, r.mentions, Link)}</p>
                           </div>
                         </div>
                       ))}

--- a/src/components/MentionTextarea.jsx
+++ b/src/components/MentionTextarea.jsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useState, useRef, useEffect, useCallback } from 'react';
+
+// A <textarea> with @username autocomplete (#10). Reuses /api/search?scope=users.
+// Drop-in: same value/onChange/placeholder/rows/className/style/onKeyDown props.
+// On select, replaces the active "@query" token with "@username ".
+export default function MentionTextarea({
+  value, onChange, placeholder, rows = 2, className, style, onKeyDown, autoFocus,
+}) {
+  const taRef = useRef(null);
+  const [menu, setMenu] = useState(null); // { query, start, results, active }
+  const debounceRef = useRef(null);
+
+  // Find an @token immediately before the caret (no whitespace inside).
+  const detect = useCallback((el) => {
+    const caret = el.selectionStart;
+    const upto = el.value.slice(0, caret);
+    const m = upto.match(/(?:^|\s)@([a-zA-Z0-9_-]*)$/);
+    if (!m) return null;
+    return { query: m[1], start: caret - m[1].length - 1 }; // index of '@'
+  }, []);
+
+  useEffect(() => {
+    if (!menu || menu.query == null) return;
+    clearTimeout(debounceRef.current);
+    if (menu.query.length < 1) { setMenu((p) => p && { ...p, results: [] }); return; }
+    debounceRef.current = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/search?q=${encodeURIComponent(menu.query)}&scope=users`);
+        const data = res.ok ? await res.json() : { users: [] };
+        setMenu((p) => p && { ...p, results: (data.users || []).slice(0, 6), active: 0 });
+      } catch { setMenu((p) => p && { ...p, results: [] }); }
+    }, 250);
+    return () => clearTimeout(debounceRef.current);
+  }, [menu?.query]);
+
+  const handleChange = (e) => {
+    onChange(e);
+    const d = detect(e.target);
+    setMenu(d ? { ...d, results: [], active: 0 } : null);
+  };
+
+  const pick = (u) => {
+    const el = taRef.current;
+    if (!el || !menu) return;
+    const before = value.slice(0, menu.start);
+    const after = value.slice(el.selectionStart);
+    const next = `${before}@${u.username} ${after}`;
+    // Synthesize a change event so the parent state updates.
+    onChange({ target: { value: next } });
+    setMenu(null);
+    requestAnimationFrame(() => {
+      const pos = (before + `@${u.username} `).length;
+      try { el.focus(); el.setSelectionRange(pos, pos); } catch {}
+    });
+  };
+
+  const handleKeyDown = (e) => {
+    if (menu && menu.results?.length) {
+      if (e.key === 'ArrowDown') { e.preventDefault(); setMenu((p) => ({ ...p, active: (p.active + 1) % p.results.length })); return; }
+      if (e.key === 'ArrowUp') { e.preventDefault(); setMenu((p) => ({ ...p, active: (p.active - 1 + p.results.length) % p.results.length })); return; }
+      if (e.key === 'Enter' || e.key === 'Tab') { e.preventDefault(); pick(menu.results[menu.active]); return; }
+      if (e.key === 'Escape') { e.preventDefault(); setMenu(null); return; }
+    }
+    onKeyDown?.(e);
+  };
+
+  return (
+    <div className="relative" style={{ flex: style?.flex }}>
+      <textarea
+        ref={taRef}
+        value={value}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        onBlur={() => setTimeout(() => setMenu(null), 150)}
+        placeholder={placeholder}
+        rows={rows}
+        className={className}
+        style={style}
+        autoFocus={autoFocus}
+      />
+      {menu && menu.results?.length > 0 && (
+        <div
+          className="absolute left-0 z-50 mt-1 w-64 rounded-lg overflow-hidden"
+          style={{ top: '100%', background: 'var(--bg-surface)', border: '1px solid var(--border-default)', boxShadow: '0 12px 40px rgba(0,0,0,0.4)' }}
+        >
+          {menu.results.map((u, i) => (
+            <button
+              key={u.id}
+              type="button"
+              onMouseDown={(e) => { e.preventDefault(); pick(u); }}
+              className="flex items-center gap-2 w-full px-3 py-2 text-left"
+              style={{ background: i === menu.active ? 'var(--bg-active)' : 'transparent' }}
+            >
+              {u.avatar_url
+                ? <img src={u.avatar_url} alt="" className="w-6 h-6 rounded-full object-cover" />
+                : <span className="w-6 h-6 rounded-full flex items-center justify-center text-[11px] font-bold" style={{ background: 'var(--bg-elevated)', color: 'var(--text-muted)' }}>{(u.display_name || u.username || '?')[0].toUpperCase()}</span>}
+              <span className="min-w-0">
+                <span className="block text-[13px] font-medium truncate" style={{ color: 'var(--text-primary)' }}>{u.display_name || u.username}</span>
+                <span className="block text-[11px] truncate" style={{ color: 'var(--text-faint)' }}>@{u.username}</span>
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Linkify @username tokens that resolved to real users (passed as a Set/array
+// of usernames). Returns an array of strings + <a> nodes for React rendering.
+export function renderMentions(text, mentioned, LinkComp) {
+  if (!text) return text;
+  const set = new Set((mentioned || []).map((u) => u.toLowerCase()));
+  if (set.size === 0) return text;
+  const parts = [];
+  const re = /(^|[^a-zA-Z0-9_])@([a-zA-Z0-9_-]+)/g;
+  let last = 0; let m; let key = 0;
+  while ((m = re.exec(text)) !== null) {
+    const uname = m[2];
+    if (!set.has(uname.toLowerCase())) continue;
+    const at = m.index + m[1].length;
+    if (at > last) parts.push(text.slice(last, at));
+    const A = LinkComp || 'a';
+    parts.push(
+      <A key={`m${key++}`} href={`/${uname}`} style={{ color: 'var(--accent)', fontWeight: 500 }}>@{uname}</A>,
+    );
+    last = at + uname.length + 1;
+  }
+  if (last < text.length) parts.push(text.slice(last));
+  return parts.length ? parts : text;
+}


### PR DESCRIPTION
Closes #10 — @mention tagging in comments & replies.

## What
- **`comment_mentions`** table (migration 0026) — already applied to remote D1 (verified).
- **`MentionTextarea`** — reusable `<textarea>` with `@`-autocomplete over `/api/search?scope=users` (debounced, keyboard nav, inserts `@username`). Used for the new-comment and reply inputs.
- **POST** (`comments/route.js`) — resolves `@username` tokens to real users, records `comment_mentions`, and sends a `mention` notification to each (skipping self / the already-notified blog author & parent commenter).
- **GET** — attaches each comment/reply's resolved mention usernames (guarded so listing still works if the table isn't migrated).
- **Render** — linkifies `@username` → `/username` for resolved mentions only; unknown `@tokens` stay plain text.

## Notes / scope
- Decision (per triage): plain-text content + join table, no rich-content migration.
- Users only (not orgs/blogs) in comment mentions.
- **Edit** of an existing comment doesn't re-parse mentions yet (mentions captured on create/reply) — minor follow-up if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
