### PR TITLE
feat: Medium-style feed + reader UX (tabs, follow, recommendations)

### DIFF
--- a/app/api/blogs/[slugid]/recommendations/route.js
+++ b/app/api/blogs/[slugid]/recommendations/route.js
@@ -1,0 +1,89 @@
+export const runtime = 'edge';
+import { NextResponse } from 'next/server';
+
+const FIELDS = `b.id, b.slug, b.title, b.subtitle, b.cover_image_r2_key,
+  b.author_id, b.published_as, b.published_at, b.read_time_minutes, b.like_count, b.comment_count`;
+const EXCLUDE_TEST = "b.author_id NOT IN (SELECT id FROM users WHERE LOWER(username) = 'selenium-cutlet')";
+
+// GET — "next blogs to read": related by tag, then more from the author, then
+// trending. Excludes the current blog and the test author.
+export async function GET(request, { params }) {
+  const { slugid } = await params;
+  const limit = 4;
+  try {
+    const { getDB } = await import('../../../../../lib/cloudflare');
+    const db = getDB();
+
+    const blog = await db.prepare('SELECT id, author_id FROM blogs WHERE id = ?').bind(slugid).first();
+    const authorId = blog?.author_id || null;
+
+    const picked = [];
+    const seen = new Set([slugid]);
+    const add = (rows) => {
+      for (const r of rows) {
+        if (picked.length >= limit) break;
+        if (!seen.has(r.id)) { seen.add(r.id); picked.push(r); }
+      }
+    };
+
+    // 1) Shares a tag with this blog.
+    const tagRows = await db.prepare(`
+      SELECT ${FIELDS} FROM blogs b
+      WHERE b.status = 'published' AND b.id != ? AND ${EXCLUDE_TEST}
+        AND b.id IN (
+          SELECT blog_id FROM blog_tags WHERE tag IN (SELECT tag FROM blog_tags WHERE blog_id = ?)
+        )
+      ORDER BY b.like_count DESC, b.published_at DESC LIMIT ?
+    `).bind(slugid, slugid, limit).all();
+    add(tagRows?.results || []);
+
+    // 2) More from the same author.
+    if (picked.length < limit && authorId) {
+      const moreRows = await db.prepare(`
+        SELECT ${FIELDS} FROM blogs b
+        WHERE b.status = 'published' AND b.author_id = ? AND b.id != ?
+        ORDER BY b.published_at DESC LIMIT ?
+      `).bind(authorId, slugid, limit).all();
+      add(moreRows?.results || []);
+    }
+
+    // 3) Trending fallback.
+    if (picked.length < limit) {
+      const trend = await db.prepare(`
+        SELECT ${FIELDS} FROM blogs b
+        WHERE b.status = 'published' AND b.id != ? AND ${EXCLUDE_TEST}
+        ORDER BY b.like_count DESC, b.view_count DESC, b.published_at DESC LIMIT ?
+      `).bind(slugid, limit).all();
+      add(trend?.results || []);
+    }
+
+    if (picked.length === 0) return NextResponse.json({ posts: [] });
+
+    // Enrich with author + org.
+    const authorIds = [...new Set(picked.map(p => p.author_id))];
+    const aPh = authorIds.map(() => '?').join(',');
+    const authors = await db.prepare(`SELECT id, username, display_name, avatar_url FROM users WHERE id IN (${aPh})`).bind(...authorIds).all();
+    const aMap = Object.fromEntries((authors?.results || []).map(a => [a.id, a]));
+
+    const orgIds = [...new Set(picked.filter(p => p.published_as?.startsWith('org:')).map(p => p.published_as.slice(4)))];
+    let oMap = {};
+    if (orgIds.length) {
+      const oPh = orgIds.map(() => '?').join(',');
+      const orgs = await db.prepare(`SELECT id, slug, name, logo_r2_key FROM orgs WHERE id IN (${oPh})`).bind(...orgIds).all();
+      oMap = Object.fromEntries((orgs?.results || []).map(o => [o.id, o]));
+    }
+
+    const posts = picked.map(p => {
+      const orgId = p.published_as?.startsWith('org:') ? p.published_as.slice(4) : null;
+      const o = orgId ? oMap[orgId] : null;
+      return {
+        ...p,
+        author: aMap[p.author_id] || { username: 'unknown', display_name: 'Unknown' },
+        org: o ? { slug: o.slug, name: o.name, logo_url: o.logo_r2_key } : null,
+      };
+    });
+    return NextResponse.json({ posts });
+  } catch (e) {
+    return NextResponse.json({ posts: [] });
+  }
+}

--- a/app/api/feed/route.js
+++ b/app/api/feed/route.js
@@ -7,6 +7,9 @@ const BLOG_FIELDS = `b.id, b.slug, b.title, b.subtitle, b.cover_image_r2_key, b.
   b.author_id, b.published_as, b.published_at, b.read_time_minutes,
   b.like_count, b.clap_total, b.comment_count, b.view_count`;
 
+// Keep the test author ("selenium-cutlet") out of every feed surface.
+const EXCLUDE_TEST = " AND b.author_id NOT IN (SELECT id FROM users WHERE LOWER(username) = 'selenium-cutlet')";
+
 /**
  * GET /api/feed — personalized feed
  *
@@ -32,6 +35,8 @@ export async function GET(request) {
       const { kvCache } = await import('../../../lib/cache');
       const cacheKey = filterTag
         ? `v1:feed:anon:tag:${filterTag}:p${page}`
+        : filterType === 'featured'
+        ? `v1:feed:anon:featured:p${page}`
         : `v1:feed:anon:trending:p${page}`;
 
       const cached = await kvCache(cacheKey, 180, async () => {
@@ -40,6 +45,8 @@ export async function GET(request) {
         const now = Math.floor(Date.now() / 1000);
         let posts = filterTag
           ? await queryByTag(db, filterTag, now, limit, offset)
+          : filterType === 'featured'
+          ? backfill(await queryFeatured(db, now, limit, offset), await queryTrending(db, now, limit, offset), limit)
           : await queryTrending(db, now, limit, offset);
         // Recency fallback so the public feed isn't empty when posts are older than the trending window.
         if (!filterTag && posts.length < limit) {
@@ -64,6 +71,9 @@ export async function GET(request) {
 
     if (filterType === 'following') {
       posts = await queryFollowing(db, userId, now, limit, offset);
+    } else if (filterType === 'featured') {
+      posts = await queryFeatured(db, now, limit, offset);
+      if (posts.length < limit) posts = backfill(posts, await queryTrending(db, now, limit, offset), limit);
     } else if (filterTag) {
       posts = await queryByTag(db, filterTag, now, limit, offset);
     } else {
@@ -89,7 +99,7 @@ async function queryFollowing(db, userId, now, limit, offset) {
   const result = await db.prepare(`
     SELECT ${BLOG_FIELDS}
     FROM blogs b
-    WHERE b.status = 'published' AND b.published_at > ?
+    WHERE b.status = 'published'${EXCLUDE_TEST} AND b.published_at > ?
       AND (
         b.author_id IN (SELECT following_id FROM follows WHERE follower_id = ? AND following_type = 'user')
         OR b.published_as IN (
@@ -114,7 +124,7 @@ async function queryInterests(db, userId, now, limit) {
   const result = await db.prepare(`
     SELECT ${BLOG_FIELDS}
     FROM blogs b
-    WHERE b.status = 'published' AND b.published_at > ?
+    WHERE b.status = 'published'${EXCLUDE_TEST} AND b.published_at > ?
       AND b.id IN (
         SELECT blog_id FROM blog_tags WHERE tag IN (
           SELECT tag FROM user_interests WHERE user_id = ?
@@ -135,11 +145,34 @@ async function queryTrending(db, now, limit, offset) {
   const result = await db.prepare(`
     SELECT ${BLOG_FIELDS}
     FROM blogs b
-    WHERE b.status = 'published' AND b.published_at > ?
+    WHERE b.status = 'published'${EXCLUDE_TEST} AND b.published_at > ?
     ORDER BY b.like_count DESC, b.view_count DESC, b.published_at DESC
     LIMIT ? OFFSET ?
   `).bind(cutoff, limit, offset).all();
   return result?.results || [];
+}
+
+// ─── Featured: editorial / staff-org picks (newest first) ────────────
+async function queryFeatured(db, now, limit, offset) {
+  const result = await db.prepare(`
+    SELECT ${BLOG_FIELDS}
+    FROM blogs b
+    WHERE b.status = 'published'${EXCLUDE_TEST}
+      AND b.published_as = ?
+    ORDER BY b.published_at DESC
+    LIMIT ? OFFSET ?
+  `).bind(`org:${STAFF_ORG_ID}`, limit, offset).all();
+  return result?.results || [];
+}
+
+// Top up `base` with items from `extra` (deduped) until it reaches `limit`.
+function backfill(base, extra, limit) {
+  const have = new Set(base.map(p => p.id));
+  for (const p of extra) {
+    if (base.length >= limit) break;
+    if (!have.has(p.id)) { have.add(p.id); base.push(p); }
+  }
+  return base;
 }
 
 // ─── Tag-filtered ────────────────────────────────────────────────────
@@ -148,7 +181,7 @@ async function queryByTag(db, tag, now, limit, offset) {
   const result = await db.prepare(`
     SELECT ${BLOG_FIELDS}
     FROM blogs b
-    WHERE b.status = 'published' AND b.published_at > ?
+    WHERE b.status = 'published'${EXCLUDE_TEST} AND b.published_at > ?
       AND b.id IN (SELECT blog_id FROM blog_tags WHERE LOWER(tag) = LOWER(?))
     ORDER BY b.published_at DESC
     LIMIT ? OFFSET ?
@@ -161,7 +194,7 @@ async function queryRecent(db, limit, offset = 0) {
   const result = await db.prepare(`
     SELECT ${BLOG_FIELDS}
     FROM blogs b
-    WHERE b.status = 'published'
+    WHERE b.status = 'published'${EXCLUDE_TEST}
     ORDER BY b.published_at DESC
     LIMIT ? OFFSET ?
   `).bind(limit, offset).all();

--- a/app/api/orgs/[slug]/follow/route.js
+++ b/app/api/orgs/[slug]/follow/route.js
@@ -1,0 +1,64 @@
+export const runtime = 'edge';
+import { NextResponse } from 'next/server';
+import { getSession } from '../../../../../lib/auth';
+
+async function getOrg(db, slug) {
+  return db.prepare('SELECT id, slug, name FROM orgs WHERE LOWER(slug) = LOWER(?)').bind(slug).first();
+}
+
+// GET — does the current user follow this org? { following }
+export async function GET(request, { params }) {
+  const { slug } = await params;
+  const session = await getSession().catch(() => null);
+  if (!session?.userId) return NextResponse.json({ following: false });
+  try {
+    const { getDB } = await import('../../../../../lib/cloudflare');
+    const db = getDB();
+    const org = await getOrg(db, slug);
+    if (!org) return NextResponse.json({ following: false });
+    const row = await db.prepare(
+      "SELECT 1 FROM follows WHERE follower_id = ? AND following_id = ? AND following_type = 'org'"
+    ).bind(session.userId, org.id).first();
+    return NextResponse.json({ following: !!row });
+  } catch {
+    return NextResponse.json({ following: false });
+  }
+}
+
+// POST — follow this org
+export async function POST(request, { params }) {
+  const { slug } = await params;
+  const session = await getSession();
+  if (!session?.userId) return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  try {
+    const { getDB } = await import('../../../../../lib/cloudflare');
+    const db = getDB();
+    const org = await getOrg(db, slug);
+    if (!org) return NextResponse.json({ error: 'Org not found' }, { status: 404 });
+    await db.prepare(
+      "INSERT OR IGNORE INTO follows (follower_id, following_id, following_type) VALUES (?, ?, 'org')"
+    ).bind(session.userId, org.id).run();
+    return NextResponse.json({ following: true });
+  } catch {
+    return NextResponse.json({ error: 'Failed to follow' }, { status: 500 });
+  }
+}
+
+// DELETE — unfollow this org
+export async function DELETE(request, { params }) {
+  const { slug } = await params;
+  const session = await getSession();
+  if (!session?.userId) return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  try {
+    const { getDB } = await import('../../../../../lib/cloudflare');
+    const db = getDB();
+    const org = await getOrg(db, slug);
+    if (!org) return NextResponse.json({ error: 'Org not found' }, { status: 404 });
+    await db.prepare(
+      "DELETE FROM follows WHERE follower_id = ? AND following_id = ? AND following_type = 'org'"
+    ).bind(session.userId, org.id).run();
+    return NextResponse.json({ following: false });
+  } catch {
+    return NextResponse.json({ error: 'Failed to unfollow' }, { status: 500 });
+  }
+}

--- a/src/components/BlogFollowButtons.jsx
+++ b/src/components/BlogFollowButtons.jsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useAuth } from '../context/AuthContext';
+import Link from 'next/link';
+
+// Generic follow toggle for a user or an org. `kind` = 'user' | 'org'.
+export function FollowToggle({ kind, handle, compact = false }) {
+  const { user } = useAuth();
+  const [following, setFollowing] = useState(false);
+  const [self, setSelf] = useState(false);
+  const base = kind === 'org'
+    ? `/api/orgs/${encodeURIComponent(handle)}/follow`
+    : `/api/users/${encodeURIComponent(handle)}/follow`;
+
+  useEffect(() => {
+    if (!user || !handle) return;
+    let active = true;
+    fetch(base).then(r => r.ok ? r.json() : null).then(d => {
+      if (!active || !d) return;
+      setFollowing(!!d.following);
+      setSelf(!!d.self);
+    }).catch(() => {});
+    return () => { active = false; };
+  }, [handle, user]);
+
+  if (self) return null;
+
+  const toggle = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!user) {
+      const next = typeof window !== 'undefined' ? window.location.pathname : '/';
+      window.location.href = `/sign-in?next=${encodeURIComponent(next)}`;
+      return;
+    }
+    const was = following;
+    setFollowing(!was);
+    fetch(base, { method: was ? 'DELETE' : 'POST' })
+      .then(r => r.ok ? r.json() : Promise.reject())
+      .then(d => setFollowing(!!d.following))
+      .catch(() => setFollowing(was));
+  };
+
+  return (
+    <button
+      onClick={toggle}
+      className={`${compact ? 'text-[12px] px-3 py-1' : 'text-[13px] px-4 py-1.5'} font-medium rounded-full transition-colors flex-shrink-0`}
+      style={following
+        ? { color: 'var(--text-muted)', border: '1px solid var(--border-default)' }
+        : { color: '#fff', backgroundColor: '#9b7bf7' }}
+    >
+      {following ? 'Following' : 'Follow'}
+    </button>
+  );
+}
+
+// End-of-blog follow card — author (+ org when applicable). `author` =
+// { username, display_name, avatar_url }; `org` = { slug, name, logo_url }.
+export default function BlogFollowCard({ author, org }) {
+  const rows = [];
+  if (org?.slug) rows.push({ kind: 'org', handle: org.slug, name: org.name, avatar: org.logo_url, href: `/${org.slug}`, square: true });
+  if (author?.username) rows.push({ kind: 'user', handle: author.username, name: author.display_name || author.username, sub: `@${author.username}`, avatar: author.avatar_url, href: `/${author.username}` });
+  if (rows.length === 0) return null;
+
+  return (
+    <div className="my-10 rounded-2xl p-5" style={{ backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border-default)' }}>
+      <p className="text-[12px] font-semibold uppercase tracking-wide mb-4" style={{ color: 'var(--text-faint)' }}>
+        Keep up with {rows.length > 1 ? 'them' : 'their work'}
+      </p>
+      <div className="space-y-4">
+        {rows.map((r) => (
+          <div key={`${r.kind}:${r.handle}`} className="flex items-center gap-3">
+            <Link href={r.href} className="flex-shrink-0">
+              {r.avatar ? (
+                <img src={r.avatar} alt="" className={`h-11 w-11 object-cover ${r.square ? 'rounded-lg' : 'rounded-full'}`} />
+              ) : (
+                <div className={`h-11 w-11 flex items-center justify-center text-[15px] font-bold ${r.square ? 'rounded-lg' : 'rounded-full'}`} style={{ backgroundColor: 'var(--bg-elevated)', color: 'var(--text-faint)' }}>{(r.name || '?')[0].toUpperCase()}</div>
+              )}
+            </Link>
+            <Link href={r.href} className="min-w-0 flex-1">
+              <p className="text-[15px] font-semibold truncate" style={{ color: 'var(--text-primary)' }}>{r.name}{r.kind === 'org' && <span className="text-[11px] font-normal ml-1.5" style={{ color: 'var(--text-faint)' }}>Organization</span>}</p>
+              {r.sub && <p className="text-[12px] truncate" style={{ color: 'var(--text-faint)' }}>{r.sub}</p>}
+            </Link>
+            <FollowToggle kind={r.kind} handle={r.handle} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/BlogRecommendations.jsx
+++ b/src/components/BlogRecommendations.jsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import { generateBlogBanner } from '../utils/pixelAvatar';
+
+// "More to read" under the comments — related blogs (by tag, author, trending).
+export default function BlogRecommendations({ blogId }) {
+  const [posts, setPosts] = useState([]);
+
+  useEffect(() => {
+    if (!blogId) return;
+    let active = true;
+    fetch(`/api/blogs/${blogId}/recommendations`)
+      .then(r => r.ok ? r.json() : null)
+      .then(d => { if (active && d) setPosts(d.posts || []); })
+      .catch(() => {});
+    return () => { active = false; };
+  }, [blogId]);
+
+  if (posts.length === 0) return null;
+
+  return (
+    <div className="mt-12 pt-8" style={{ borderTop: '1px solid var(--divider)' }}>
+      <h3 className="text-[16px] font-bold mb-5" style={{ color: 'var(--text-primary)' }}>More to read</h3>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
+        {posts.map((p) => {
+          const author = p.author || {};
+          const href = `/${(p.org?.slug) || author.username || 'unknown'}/${p.slug}`;
+          const cover = p.cover_image_r2_key || generateBlogBanner(p.id || p.slug);
+          return (
+            <Link key={p.id} href={href} className="group flex gap-3">
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-1.5 mb-1 text-[12px]" style={{ color: 'var(--text-secondary)' }}>
+                  {author.avatar_url ? (
+                    <img src={author.avatar_url} alt="" className="h-4 w-4 rounded-full object-cover" />
+                  ) : (
+                    <div className="h-4 w-4 rounded-full flex items-center justify-center text-[8px] font-bold" style={{ backgroundColor: 'var(--bg-elevated)', color: 'var(--text-faint)' }}>{(author.display_name || author.username || '?')[0].toUpperCase()}</div>
+                  )}
+                  <span className="truncate">{p.org ? `In ${p.org.name}` : (author.display_name || author.username)}</span>
+                </div>
+                <p className="text-[15px] font-bold leading-[1.3] line-clamp-2 group-hover:opacity-80 transition-opacity" style={{ color: 'var(--text-primary)', fontFamily: "'Source Serif 4', Georgia, serif" }}>{p.title || 'Untitled'}</p>
+                {p.read_time_minutes > 0 && <p className="text-[12px] mt-1.5" style={{ color: 'var(--text-faint)' }}>{p.read_time_minutes} min read</p>}
+              </div>
+              <img src={cover} alt="" className="w-[72px] h-[72px] rounded-md object-cover flex-shrink-0 self-center" style={{ backgroundColor: 'var(--bg-elevated)' }} />
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Editor/BlogPreview.jsx
+++ b/src/components/Editor/BlogPreview.jsx
@@ -329,7 +329,7 @@ function renderBlocksToHTML(blocks) {
   return html;
 }
 
-export default function BlogPreview({ title, subtitle, coverPreview, coverZoom, coverPos, pageEmoji, tags, html, blocks, user, org, coAuthorCount, coAuthors = [], wordCount }) {
+export default function BlogPreview({ title, subtitle, coverPreview, coverZoom, coverPos, pageEmoji, tags, html, blocks, user, org, coAuthorCount, coAuthors = [], wordCount, followSlot = null }) {
   const { isDark } = useTheme();
   const contentRef = useRef(null);
   const [showBackToTop, setShowBackToTop] = useState(false);
@@ -750,6 +750,7 @@ export default function BlogPreview({ title, subtitle, coverPreview, coverZoom, 
               <span className="text-[var(--text-faint)]">·</span>
               <span>{wordCount || 0} {(wordCount || 0) === 1 ? 'word' : 'words'}</span>
             </div>
+            {followSlot && <div className="ml-auto flex items-center gap-2">{followSlot}</div>}
           </div>
         );
       })()}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -183,118 +183,77 @@ function SearchBar() {
 
 function FeedCard({ post }) {
   const author = post.author || {};
-  const bannerSrc = post.cover_image_r2_key || generateBlogBanner(post.id || post.slug);
+  const cover = post.cover_image_r2_key || generateBlogBanner(post.id || post.slug);
+  const href = `/${(post.org?.slug) || author.username || 'unknown'}/${post.slug}`;
+  const bylineName = post.org ? post.org.name : (author.display_name || author.username);
+  const allAuthors = [{ display_name: author.display_name, username: author.username, avatar_url: author.avatar_url }, ...(post.co_authors || [])];
   return (
-    <article
-      className="group rounded-xl mb-3 transition-all duration-200 hover:shadow-md overflow-hidden relative"
-      style={{
-        backgroundColor: 'var(--bg-surface)',
-        border: '1px solid var(--border-default)',
-        boxShadow: '0 1px 3px rgba(0,0,0,0.04)',
-      }}
-    >
-      {/* Banner fading in from the right */}
-      <div className="absolute inset-0 overflow-hidden pointer-events-none">
-        <img
-          src={bannerSrc}
-          alt=""
-          className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
-          style={{ opacity: 0.18 }}
-        />
-        <div className="absolute inset-0" style={{ background: 'linear-gradient(90deg, var(--bg-surface) 30%, transparent 100%)' }} />
-      </div>
-
-      <div className="relative p-5">
-        <Link href={`/${author.username || 'unknown'}/${post.slug}`} className="block cursor-pointer">
-          {(() => {
-            const allAuthors = [
-              { display_name: author.display_name, username: author.username, avatar_url: author.avatar_url },
-              ...(post.co_authors || []),
-            ];
-            const shownAvatars = allAuthors.slice(0, 5);
-            const shownNames = allAuthors.slice(0, 3);
-            const moreNames = allAuthors.length - shownNames.length;
-            return (
-              <div className="flex items-center gap-2 mb-3">
-                <div className="flex -space-x-2">
-                  {shownAvatars.map((a, i) => (
-                    a.avatar_url ? (
-                      <img key={i} src={a.avatar_url} alt="" title={a.display_name || a.username} className="h-6 w-6 rounded-full object-cover ring-2 ring-[var(--bg-surface)]" />
-                    ) : (
-                      <div key={i} title={a.display_name || a.username} className="h-6 w-6 rounded-full flex items-center justify-center text-[10px] font-bold ring-2 ring-[var(--bg-surface)]" style={{ backgroundColor: 'var(--bg-elevated)', color: 'var(--text-faint)' }}>
-                        {(a.display_name || a.username || '?')[0].toUpperCase()}
-                      </div>
-                    )
-                  ))}
-                </div>
-                <span className="text-[13px] flex items-center gap-1.5" style={{ color: 'var(--text-muted)' }}>
-                  {post.is_staff && (
-                    <span className="text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded" style={{ backgroundColor: '#9b7bf718', color: '#9b7bf7', border: '1px solid #9b7bf730' }}>Staff</span>
-                  )}
-                  {post.org && (
-                    <><span style={{ color: 'var(--text-secondary)' }}>in {post.org.name}</span><span className="mx-0.5" style={{ color: 'var(--text-faint)' }}>&middot;</span></>
-                  )}
-                  <span style={{ color: 'var(--text-secondary)' }}>{shownNames.map((a) => a.display_name || a.username).join(', ')}</span>
-                  {moreNames > 0 && (
-                    <span style={{ color: 'var(--text-faint)' }}>+ {moreNames} more</span>
-                  )}
-                </span>
-                <span className="ml-auto text-[11px]" style={{ color: 'var(--text-faint)' }}>{timeAgo(post.published_at)}</span>
-              </div>
-            );
-          })()}
-          <div className="flex-1 min-w-0">
-            <h2 className="text-[18px] font-bold leading-[1.3] mb-1 group-hover:opacity-75 transition-opacity font-serif tracking-[-0.01em]" style={{ color: 'var(--text-primary)' }}>
-              {post.title || 'Untitled'}
-            </h2>
-            {post.subtitle && (
-              <p className="text-[14px] leading-[1.55] line-clamp-2 mb-3" style={{ color: 'var(--text-muted)' }}>
-                {post.subtitle}
-              </p>
+    <article className="group py-6" style={{ borderBottom: '1px solid var(--divider)' }}>
+      <Link href={href} className="flex gap-5 cursor-pointer">
+        {/* Left: byline + title + subtitle + stats */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-2 text-[13px]" style={{ color: 'var(--text-secondary)' }}>
+            {post.org?.logo_url ? (
+              <img src={post.org.logo_url} alt="" className="h-5 w-5 rounded object-cover" />
+            ) : author.avatar_url ? (
+              <img src={author.avatar_url} alt="" className="h-5 w-5 rounded-full object-cover" />
+            ) : (
+              <div className="h-5 w-5 rounded-full flex items-center justify-center text-[9px] font-bold" style={{ backgroundColor: 'var(--bg-elevated)', color: 'var(--text-faint)' }}>{(bylineName || '?')[0].toUpperCase()}</div>
             )}
-            <div className="flex items-center gap-3 text-[12px] flex-wrap" style={{ color: 'var(--text-faint)' }}>
-              {(post.tags || []).slice(0, 2).map(tag => (
-                <span key={tag} className="text-[11px] px-2 py-0.5 rounded-full font-medium" style={{ backgroundColor: 'var(--accent-subtle)', color: 'var(--accent)' }}>{tag}</span>
-              ))}
-              {post.read_time_minutes > 0 && <span>{post.read_time_minutes} min read</span>}
-              {post.like_count > 0 && (
-                <span className="flex items-center gap-1">
-                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" /></svg>
-                  {post.like_count}
-                </span>
-              )}
-              {post.comment_count > 0 && (
-                <span className="flex items-center gap-1">
-                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" /></svg>
-                  {post.comment_count}
-                </span>
-              )}
-            </div>
+            <span className="truncate">
+              {post.org && <>In <span className="font-medium" style={{ color: 'var(--text-primary)' }}>{post.org.name}</span> by </>}
+              <span className="font-medium" style={{ color: 'var(--text-primary)' }}>{author.display_name || author.username}</span>
+              {allAuthors.length > 1 && <span style={{ color: 'var(--text-faint)' }}> +{allAuthors.length - 1}</span>}
+            </span>
+            {post.is_staff && (
+              <span className="text-[9px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded flex-shrink-0" style={{ backgroundColor: '#9b7bf718', color: '#9b7bf7', border: '1px solid #9b7bf730' }}>Staff</span>
+            )}
           </div>
-        </Link>
-        {post.can_edit && (
-          <div className="mt-3 pt-3 flex items-center gap-2" style={{ borderTop: '1px solid var(--divider)' }}>
-            <Link
-              href={`/edit/${post.slug || post.id}`}
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[12px] font-medium transition-colors"
-              style={{ color: 'var(--text-faint)', backgroundColor: 'var(--bg-elevated)', border: '1px solid var(--border-default)' }}
-              onClick={e => e.stopPropagation()}
-            >
-              <ion-icon name="create-outline" style={{ fontSize: '13px' }} />
-              Edit
-            </Link>
-            <Link
-              href={`/edit/${post.slug || post.id}?panel=settings`}
-              className="flex items-center justify-center w-8 h-8 rounded-lg transition-colors"
-              style={{ color: 'var(--text-faint)', backgroundColor: 'var(--bg-elevated)', border: '1px solid var(--border-default)' }}
-              onClick={e => e.stopPropagation()}
-              title="Blog settings"
-            >
-              <ion-icon name="settings-outline" style={{ fontSize: '14px' }} />
-            </Link>
+
+          <h2 className="text-[20px] font-extrabold leading-[1.25] mb-1 group-hover:opacity-80 transition-opacity tracking-[-0.01em]" style={{ color: 'var(--text-primary)', fontFamily: "'Source Serif 4', Georgia, serif" }}>
+            {post.title || 'Untitled'}
+          </h2>
+          {post.subtitle && (
+            <p className="text-[15px] leading-[1.5] line-clamp-2 mb-3" style={{ color: 'var(--text-muted)' }}>{post.subtitle}</p>
+          )}
+
+          <div className="flex items-center gap-3 text-[12px] flex-wrap" style={{ color: 'var(--text-faint)' }}>
+            <span>{timeAgo(post.published_at)}</span>
+            {(post.tags || []).slice(0, 1).map(tag => (
+              <span key={tag} className="text-[11px] px-2 py-0.5 rounded-full font-medium" style={{ backgroundColor: 'var(--bg-elevated)', color: 'var(--text-body)' }}>{tag}</span>
+            ))}
+            {post.read_time_minutes > 0 && <span>{post.read_time_minutes} min read</span>}
+            {(post.clap_total > 0 || post.like_count > 0) && (
+              <span className="flex items-center gap-1">
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M7 11v8m0 0H5a1 1 0 01-1-1v-6a1 1 0 011-1h2m3-4l-1 5h6l-1 5" /></svg>
+                {post.clap_total || post.like_count}
+              </span>
+            )}
+            {post.comment_count > 0 && (
+              <span className="flex items-center gap-1">
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" /></svg>
+                {post.comment_count}
+              </span>
+            )}
           </div>
-        )}
-      </div>
+        </div>
+
+        {/* Right: square cover thumbnail */}
+        <div className="flex-shrink-0 self-center hidden sm:block">
+          <img src={cover} alt="" className="w-[112px] h-[112px] rounded-md object-cover" style={{ backgroundColor: 'var(--bg-elevated)' }} />
+        </div>
+      </Link>
+
+      {post.can_edit && (
+        <div className="mt-3 flex items-center gap-2">
+          <Link href={`/edit/${post.slug || post.id}`} className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[12px] font-medium transition-colors" style={{ color: 'var(--text-faint)', backgroundColor: 'var(--bg-elevated)', border: '1px solid var(--border-default)' }}>
+            <ion-icon name="create-outline" style={{ fontSize: '13px' }} /> Edit
+          </Link>
+          <Link href={`/edit/${post.slug || post.id}?panel=settings`} className="flex items-center justify-center w-8 h-8 rounded-lg transition-colors" style={{ color: 'var(--text-faint)', backgroundColor: 'var(--bg-elevated)', border: '1px solid var(--border-default)' }} title="Blog settings">
+            <ion-icon name="settings-outline" style={{ fontSize: '14px' }} />
+          </Link>
+        </div>
+      )}
     </article>
   );
 }
@@ -346,6 +305,45 @@ function TopPickCard({ post, index }) {
   );
 }
 
+function FollowSuggestion({ u }) {
+  const { user } = useAuth();
+  const [following, setFollowing] = useState(false);
+  const toggle = (e) => {
+    e.preventDefault(); e.stopPropagation();
+    if (!user) { window.location.href = `/sign-in?next=/`; return; }
+    const was = following;
+    setFollowing(!was);
+    fetch(`/api/users/${encodeURIComponent(u.username)}/follow`, { method: was ? 'DELETE' : 'POST' })
+      .then(r => r.ok ? r.json() : Promise.reject())
+      .then(d => setFollowing(!!d.following))
+      .catch(() => setFollowing(was));
+  };
+  return (
+    <div className="flex items-center gap-2.5 mb-3.5">
+      <Link href={`/${u.username}`} className="flex-shrink-0">
+        {u.avatar_url ? (
+          <img src={u.avatar_url} alt="" className="h-9 w-9 rounded-full object-cover" />
+        ) : (
+          <div className="h-9 w-9 rounded-full flex items-center justify-center text-[12px] font-bold" style={{ backgroundColor: 'var(--bg-elevated)', color: 'var(--text-faint)' }}>{(u.display_name || u.username || '?')[0].toUpperCase()}</div>
+        )}
+      </Link>
+      <Link href={`/${u.username}`} className="min-w-0 flex-1">
+        <p className="text-[13px] font-semibold truncate" style={{ color: 'var(--text-primary)' }}>{u.display_name || u.username}</p>
+        <p className="text-[11px] truncate" style={{ color: 'var(--text-faint)' }}>@{u.username}</p>
+      </Link>
+      <button
+        onClick={toggle}
+        className="text-[12px] font-medium px-3 py-1.5 rounded-full transition-colors flex-shrink-0"
+        style={following
+          ? { color: 'var(--text-muted)', border: '1px solid var(--border-default)' }
+          : { color: 'var(--text-primary)', border: '1px solid var(--text-primary)' }}
+      >
+        {following ? 'Following' : 'Follow'}
+      </button>
+    </div>
+  );
+}
+
 function FeedSkeleton() {
   return (
     <div className="space-y-6 py-6">
@@ -379,43 +377,42 @@ export default function App() {
   const [userInterests, setUserInterests] = useState([]);
   const [loading, setLoading] = useState(true);
   const [activeTopic, setActiveTopic] = useState(0);
+  const [tagFilter, setTagFilter] = useState(null); // active Recommended-topic pill
 
-  // Build topic tabs. Tag tabs are derived algorithmically — the user's own
-  // interests first (personalized), then platform-popular tags — deduped and
-  // capped. FIXED_TAGS is only a fallback when there's no data at all.
-  const fixedTabs = [
-    { label: 'For You', icon: 'sparkles', filter: null },
-    { label: 'Following', icon: null, filter: 'following' },
+  // Two tabs only: "For you" (personalized/blended) and "Featured" (editorial).
+  const topics = [
+    { label: 'For you', icon: 'sparkles', filter: null },
+    { label: 'Featured', icon: null, filter: 'featured' },
   ];
-  const dynamicTags = (() => {
+
+  // "Who to follow" — distinct authors from the current feed (not you).
+  const whoToFollow = (() => {
     const seen = new Set();
     const out = [];
-    for (const t of [...userInterests, ...popularTags]) {
-      const key = (t || '').toLowerCase();
-      if (t && !seen.has(key)) { seen.add(key); out.push(t); }
-      if (out.length >= 5) break;
+    for (const p of posts) {
+      const a = p.author;
+      if (a?.username && a.username !== user?.username && a.username !== 'selenium-cutlet' && !seen.has(a.username)) {
+        seen.add(a.username);
+        out.push(a);
+      }
+      if (out.length >= 4) break;
     }
-    return out.length > 0 ? out : FIXED_TAGS;
+    return out;
   })();
-  const tagTabs = dynamicTags.map(tag => ({ label: tag, icon: null, tag }));
-  const topics = [...fixedTabs, ...tagTabs];
 
-  // Fetch feed
+  // Fetch feed — a Recommended-topic pill (tagFilter) overrides the tab.
   useEffect(() => {
-    const topic = topics[activeTopic];
-    if (!topic) return;
-
     setLoading(true);
     let url = '/api/feed?limit=20';
-    if (topic.filter === 'following') url += '&filter=following';
-    else if (topic.tag) url += `&tag=${encodeURIComponent(topic.tag)}`;
+    if (tagFilter) url += `&tag=${encodeURIComponent(tagFilter)}`;
+    else if (topics[activeTopic]?.filter) url += `&filter=${topics[activeTopic].filter}`;
 
     fetch(url)
       .then(r => r.json())
       .then(data => setPosts(data.posts || []))
       .catch(() => setPosts([]))
       .finally(() => setLoading(false));
-  }, [activeTopic, user]);
+  }, [activeTopic, tagFilter, user]);
 
   // Fetch sidebar data once
   useEffect(() => {
@@ -443,11 +440,11 @@ export default function App() {
               {topics.map((topic, i) => (
                 <button
                   key={topic.label}
-                  onClick={() => setActiveTopic(i)}
+                  onClick={() => { setTagFilter(null); setActiveTopic(i); }}
                   className="flex items-center gap-1.5 px-4 py-3 text-[13px] font-medium whitespace-nowrap border-b-2 transition-colors flex-shrink-0"
                   style={{
-                    color: i === activeTopic ? 'var(--text-primary)' : 'var(--text-muted)',
-                    borderBottomColor: i === activeTopic ? 'var(--text-primary)' : 'transparent',
+                    color: !tagFilter && i === activeTopic ? 'var(--text-primary)' : 'var(--text-muted)',
+                    borderBottomColor: !tagFilter && i === activeTopic ? 'var(--text-primary)' : 'transparent',
                   }}
                 >
                   {topic.icon && <ion-icon name={topic.icon} style={{ fontSize: '14px' }} />}
@@ -460,27 +457,17 @@ export default function App() {
 
           {/* Feed */}
           <div className="px-6 pt-4 max-w-[680px] mx-auto">
+            {tagFilter && (
+              <div className="flex items-center gap-2 mb-1 py-2">
+                <span className="text-[13px]" style={{ color: 'var(--text-muted)' }}>Topic:</span>
+                <span className="text-[13px] font-semibold px-2.5 py-0.5 rounded-full" style={{ backgroundColor: 'var(--accent-subtle)', color: 'var(--accent)' }}>{tagFilter}</span>
+                <button onClick={() => setTagFilter(null)} className="text-[12px]" style={{ color: 'var(--text-faint)' }}>✕ clear</button>
+              </div>
+            )}
             {loading ? (
               <FeedSkeleton />
             ) : posts.length > 0 ? (
               posts.map(post => <FeedCard key={post.id} post={post} />)
-            ) : topics[activeTopic]?.filter === 'following' ? (
-              <div className="my-8 rounded-2xl border border-dashed flex flex-col items-center text-center px-6 py-14" style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-surface)' }}>
-                <div className="h-14 w-14 rounded-full flex items-center justify-center mb-4" style={{ backgroundColor: 'var(--bg-elevated)' }}>
-                  <ion-icon name="people-outline" style={{ fontSize: '26px', color: 'var(--text-faint)' }} />
-                </div>
-                <p className="text-[16px] font-semibold" style={{ color: 'var(--text-primary)' }}>Your following feed is empty</p>
-                <p className="text-[13px] mt-1.5 max-w-xs" style={{ color: 'var(--text-muted)' }}>
-                  Follow writers and organizations to see their latest posts here.
-                </p>
-                <button
-                  onClick={() => setActiveTopic(0)}
-                  className="inline-flex items-center gap-2 mt-5 px-5 py-2.5 text-[14px] font-medium text-white bg-[#9b7bf7] hover:bg-[#8b6ae6] rounded-full transition-colors"
-                >
-                  <ion-icon name="sparkles" style={{ fontSize: '16px' }} />
-                  Discover writers
-                </button>
-              </div>
             ) : (
               <div className="my-8 rounded-2xl border border-dashed flex flex-col items-center text-center px-6 py-14" style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-surface)' }}>
                 <div className="h-14 w-14 rounded-full flex items-center justify-center mb-4" style={{ backgroundColor: 'var(--bg-elevated)' }}>
@@ -525,18 +512,25 @@ export default function App() {
               {(popularTags.length > 0 ? popularTags.slice(0, 8) : FIXED_TAGS).map(topic => (
                 <button
                   key={topic}
-                  onClick={() => {
-                    const idx = topics.findIndex(t => t.label === topic);
-                    if (idx >= 0) setActiveTopic(idx);
-                  }}
+                  onClick={() => setTagFilter(topic)}
                   className="px-3.5 py-1.5 rounded-full text-[13px] transition-colors"
-                  style={{ color: 'var(--text-body)', backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border-default)' }}
+                  style={tagFilter === topic
+                    ? { color: 'var(--accent)', backgroundColor: 'var(--accent-subtle)', border: '1px solid var(--accent)' }
+                    : { color: 'var(--text-body)', backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border-default)' }}
                 >
                   {topic}
                 </button>
               ))}
             </div>
           </div>
+
+          {/* Who to follow */}
+          {whoToFollow.length > 0 && (
+            <div className="mb-8">
+              <h3 className="text-[14px] font-bold mb-4 tracking-wide" style={{ color: 'var(--text-primary)' }}>Who to follow</h3>
+              {whoToFollow.map(u => <FollowSuggestion key={u.username} u={u} />)}
+            </div>
+          )}
 
           {/* Writing Prompt */}
           <div className="rounded-xl p-5" style={{ backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border-default)' }}>

--- a/src/views/HandlePage.jsx
+++ b/src/views/HandlePage.jsx
@@ -8,6 +8,8 @@ import { generatePixelAvatar, generateBlogBanner } from '../utils/pixelAvatar';
 import { useAuth } from '../context/AuthContext';
 import BlogInteractionBar from '../components/BlogInteractionBar';
 import BlogComments from '../components/BlogComments';
+import BlogFollowCard, { FollowToggle } from '../components/BlogFollowButtons';
+import BlogRecommendations from '../components/BlogRecommendations';
 import AuthorAttribution from '../components/AuthorAttribution';
 import FollowListModal from '../components/FollowListModal';
 import BlogInviteOverlay from '../components/BlogInviteOverlay';
@@ -184,6 +186,18 @@ function HandlePageInner({ path }) {
             coAuthorCount={blog.co_author_count || 0}
             coAuthors={blog.co_authors || []}
             wordCount={wc}
+            followSlot={!isAuthor ? (
+              <>
+                {data.owner?.type === 'org' && <FollowToggle kind="org" handle={data.owner.slug} compact />}
+                {blog.author_username && <FollowToggle kind="user" handle={blog.author_username} compact />}
+              </>
+            ) : null}
+          />
+
+          {/* End-of-blog follow card — author (+ org) */}
+          <BlogFollowCard
+            author={{ username: blog.author_username, display_name: blog.author_name, avatar_url: blog.author_avatar }}
+            org={data.owner?.type === 'org' ? { slug: data.owner.slug, name: data.owner.name, logo_url: data.owner.logo_url || data.owner.logo_r2_key } : null}
           />
 
           {/* Interaction bar — like, clap, bookmark, share, views */}
@@ -191,6 +205,9 @@ function HandlePageInner({ path }) {
 
           {/* Comments section — always expanded */}
           <BlogComments blogId={blog.id} blogAuthorId={blog.author_id} />
+
+          {/* More to read — related recommendations */}
+          <BlogRecommendations blogId={blog.id} />
         </div>
       </AppShell>
     );


### PR DESCRIPTION
Medium-style feed + reader UX overhaul (root `app/page.jsx` → `src/index.jsx`).

## Home feed
- **Two tabs only**: **For you** (personalized blend) and **Featured** (editorial — staff-org picks, backfilled with trending). New `filter=featured` in `/api/feed`.
- **Medium-style cards**: byline (`In {Org} by {Author}` + staff badge), serif title, 2-line subtitle, claps/comments/read-time, and a **square cover thumbnail** on the right.
- **Right sidebar**: Recommended Topics (pills now filter the feed by tag) + **Who to follow** (distinct feed authors, each with a Follow button).
- **Test blogs hidden**: the `selenium-cutlet` author is excluded from every feed surface.

## Reader
- **Byline Follow**: org + author Follow buttons in the article byline (reader only — editor preview unaffected, via a new `followSlot` on `BlogPreview`).
- **End-of-blog follow card**: author (+ org when applicable) with Follow buttons.
- **"More to read"** under the comments — related by tag → more from author → trending (`/api/blogs/[id]/recommendations`).

## New
- `/api/orgs/[slug]/follow` (GET/POST/DELETE), `/api/blogs/[slugid]/recommendations`.
- `BlogFollowButtons` (FollowToggle for user/org + end card), `BlogRecommendations`.

✅ `npm run build` passes.

> Banner: I went with the Medium square-thumbnail crop (you offered that or keeping the faded background) — easy to switch back if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
