### PR TITLE
[FEAT]: Updated the feed cards and CTA for the header on the blogs

### DIFF
--- a/app/api/blogs/[slugid]/repost/route.js
+++ b/app/api/blogs/[slugid]/repost/route.js
@@ -1,0 +1,68 @@
+export const runtime = 'edge';
+import { NextResponse } from 'next/server';
+import { getSession } from '../../../../../lib/auth';
+
+// Author + accepted co-authors can't repost their own blog.
+async function isOwnBlog(db, blogId, userId) {
+  const blog = await db.prepare('SELECT author_id FROM blogs WHERE id = ?').bind(blogId).first();
+  if (!blog) return { notFound: true };
+  if (blog.author_id === userId) return { own: true };
+  const co = await db.prepare(
+    "SELECT 1 FROM blog_co_authors WHERE blog_id = ? AND user_id = ? AND status = 'accepted'"
+  ).bind(blogId, userId).first();
+  return { own: !!co };
+}
+
+// GET — { count, reposted }
+export async function GET(request, { params }) {
+  const { slugid } = await params;
+  const session = await getSession().catch(() => null);
+  try {
+    const { getDB } = await import('../../../../../lib/cloudflare');
+    const db = getDB();
+    const countRow = await db.prepare('SELECT COUNT(*) AS c FROM reposts WHERE blog_id = ?').bind(slugid).first();
+    let reposted = false;
+    if (session?.userId) {
+      const row = await db.prepare('SELECT 1 FROM reposts WHERE blog_id = ? AND user_id = ?').bind(slugid, session.userId).first();
+      reposted = !!row;
+    }
+    return NextResponse.json({ count: countRow?.c || 0, reposted });
+  } catch {
+    return NextResponse.json({ count: 0, reposted: false });
+  }
+}
+
+// POST — repost
+export async function POST(request, { params }) {
+  const { slugid } = await params;
+  const session = await getSession();
+  if (!session?.userId) return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  try {
+    const { getDB } = await import('../../../../../lib/cloudflare');
+    const db = getDB();
+    const own = await isOwnBlog(db, slugid, session.userId);
+    if (own.notFound) return NextResponse.json({ error: 'Blog not found' }, { status: 404 });
+    if (own.own) return NextResponse.json({ error: "You can't repost your own blog" }, { status: 400 });
+    await db.prepare('INSERT OR IGNORE INTO reposts (user_id, blog_id) VALUES (?, ?)').bind(session.userId, slugid).run();
+    const countRow = await db.prepare('SELECT COUNT(*) AS c FROM reposts WHERE blog_id = ?').bind(slugid).first();
+    return NextResponse.json({ reposted: true, count: countRow?.c || 0 });
+  } catch {
+    return NextResponse.json({ error: 'Failed' }, { status: 500 });
+  }
+}
+
+// DELETE — undo repost
+export async function DELETE(request, { params }) {
+  const { slugid } = await params;
+  const session = await getSession();
+  if (!session?.userId) return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  try {
+    const { getDB } = await import('../../../../../lib/cloudflare');
+    const db = getDB();
+    await db.prepare('DELETE FROM reposts WHERE user_id = ? AND blog_id = ?').bind(session.userId, slugid).run();
+    const countRow = await db.prepare('SELECT COUNT(*) AS c FROM reposts WHERE blog_id = ?').bind(slugid).first();
+    return NextResponse.json({ reposted: false, count: countRow?.c || 0 });
+  } catch {
+    return NextResponse.json({ error: 'Failed' }, { status: 500 });
+  }
+}

--- a/app/api/feed/route.js
+++ b/app/api/feed/route.js
@@ -81,6 +81,7 @@ export async function GET(request) {
     }
 
     posts = await enrichPosts(db, posts, userId);
+    posts = await filterMuted(db, userId, posts);
 
     return NextResponse.json({
       posts,
@@ -315,6 +316,27 @@ async function enrichPosts(db, posts, userId) {
       is_staff: p.published_as === `org:${STAFF_ORG_ID}`,
       can_edit: !!(isAuthor || isOrgMember),
     };
+  });
+}
+
+// ─── Drop posts the user has muted (author / org / tag) ──────────────
+async function filterMuted(db, userId, posts) {
+  if (!posts.length) return posts;
+  let mutes;
+  try {
+    mutes = await db.prepare('SELECT target_type, target_id FROM mutes WHERE user_id = ?').bind(userId).all();
+  } catch { return posts; } // mutes table not migrated yet
+  const rows = mutes?.results || [];
+  if (rows.length === 0) return posts;
+  const mutedAuthors = new Set(rows.filter(r => r.target_type === 'author').map(r => r.target_id));
+  const mutedOrgs = new Set(rows.filter(r => r.target_type === 'org').map(r => r.target_id));
+  const mutedTags = new Set(rows.filter(r => r.target_type === 'tag').map(r => r.target_id.toLowerCase()));
+  return posts.filter(p => {
+    if (mutedAuthors.has(p.author_id)) return false;
+    const orgId = p.published_as?.startsWith('org:') ? p.published_as.slice(4) : null;
+    if (orgId && mutedOrgs.has(orgId)) return false;
+    if ((p.tags || []).some(t => mutedTags.has((t || '').toLowerCase()))) return false;
+    return true;
   });
 }
 

--- a/app/api/mutes/route.js
+++ b/app/api/mutes/route.js
@@ -1,0 +1,54 @@
+export const runtime = 'edge';
+import { NextResponse } from 'next/server';
+import { getSession } from '../../../lib/auth';
+
+const TYPES = new Set(['author', 'org', 'tag']);
+
+// GET — list the current user's mutes.
+export async function GET() {
+  const session = await getSession().catch(() => null);
+  if (!session?.userId) return NextResponse.json({ mutes: [] });
+  try {
+    const { getDB } = await import('../../../lib/cloudflare');
+    const db = getDB();
+    const res = await db.prepare('SELECT target_type, target_id FROM mutes WHERE user_id = ?').bind(session.userId).all();
+    return NextResponse.json({ mutes: res?.results || [] });
+  } catch {
+    return NextResponse.json({ mutes: [] });
+  }
+}
+
+// POST — mute { targetType, targetId }
+export async function POST(request) {
+  const session = await getSession();
+  if (!session?.userId) return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  const { targetType, targetId } = await request.json();
+  if (!TYPES.has(targetType) || !targetId) return NextResponse.json({ error: 'Invalid target' }, { status: 400 });
+  try {
+    const { getDB } = await import('../../../lib/cloudflare');
+    const db = getDB();
+    await db.prepare(
+      'INSERT OR IGNORE INTO mutes (user_id, target_type, target_id) VALUES (?, ?, ?)'
+    ).bind(session.userId, targetType, String(targetId)).run();
+    return NextResponse.json({ ok: true });
+  } catch {
+    return NextResponse.json({ error: 'Failed' }, { status: 500 });
+  }
+}
+
+// DELETE — unmute { targetType, targetId }
+export async function DELETE(request) {
+  const session = await getSession();
+  if (!session?.userId) return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  const { targetType, targetId } = await request.json();
+  if (!TYPES.has(targetType) || !targetId) return NextResponse.json({ error: 'Invalid target' }, { status: 400 });
+  try {
+    const { getDB } = await import('../../../lib/cloudflare');
+    const db = getDB();
+    await db.prepare('DELETE FROM mutes WHERE user_id = ? AND target_type = ? AND target_id = ?')
+      .bind(session.userId, targetType, String(targetId)).run();
+    return NextResponse.json({ ok: true });
+  } catch {
+    return NextResponse.json({ error: 'Failed' }, { status: 500 });
+  }
+}

--- a/app/api/resolve/route.js
+++ b/app/api/resolve/route.js
@@ -67,7 +67,7 @@ export async function GET(request) {
       if (slug) {
         const blog = await db.prepare(`
           SELECT b.id, b.slug, b.title, b.subtitle, b.content, b.cover_image_r2_key,
-            b.cover_pos_x, b.cover_pos_y, b.cover_zoom,
+            b.cover_pos_x, b.cover_pos_y, b.cover_zoom, b.member_only,
             b.status, b.published_as, b.page_emoji, b.read_time_minutes,
             b.published_at, b.created_at, b.updated_at, b.author_id,
             u.username as author_username, u.display_name as author_name, u.avatar_url as author_avatar

--- a/migrations/0029_mutes.sql
+++ b/migrations/0029_mutes.sql
@@ -1,0 +1,11 @@
+-- Per-user mutes for the feed "..." menu: hide an author, an org/publication,
+-- or a topic/tag. target_type = 'author' | 'org' | 'tag'.
+CREATE TABLE IF NOT EXISTS mutes (
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  target_type TEXT NOT NULL,
+  target_id TEXT NOT NULL,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+  PRIMARY KEY (user_id, target_type, target_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_mutes_user ON mutes(user_id);

--- a/migrations/0030_reposts.sql
+++ b/migrations/0030_reposts.sql
@@ -1,0 +1,11 @@
+-- Reposts: a user re-shares a blog to their followers/profile. A user can't
+-- repost a blog they authored or co-author.
+CREATE TABLE IF NOT EXISTS reposts (
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  blog_id TEXT NOT NULL REFERENCES blogs(id) ON DELETE CASCADE,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+  PRIMARY KEY (user_id, blog_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_reposts_blog ON reposts(blog_id);
+CREATE INDEX IF NOT EXISTS idx_reposts_user ON reposts(user_id);

--- a/src/components/BlogInteractionBar.jsx
+++ b/src/components/BlogInteractionBar.jsx
@@ -8,10 +8,30 @@ import { useAuth } from '../context/AuthContext';
  * Handles: view recording, read progress, likes, claps, bookmarks, share.
  * Also reports dwell time as a taste signal.
  */
-export default function BlogInteractionBar({ blogId }) {
+export default function BlogInteractionBar({ blogId, blogAuthorId, canRepost = false }) {
   const { user } = useAuth();
   const [interactions, setInteractions] = useState(null);
   const [clapAnim, setClapAnim] = useState(false);
+  const [reposted, setReposted] = useState(false);
+  const [repostCount, setRepostCount] = useState(0);
+
+  // Repost state
+  useEffect(() => {
+    if (!blogId || !canRepost) return;
+    fetch(`/api/blogs/${blogId}/repost`).then(r => r.ok ? r.json() : null).then(d => {
+      if (!d) return; setReposted(!!d.reposted); setRepostCount(d.count || 0);
+    }).catch(() => {});
+  }, [blogId, canRepost]);
+
+  const toggleRepost = () => {
+    if (!user) { window.location.href = `/sign-in?next=${typeof window !== 'undefined' ? window.location.pathname : '/'}`; return; }
+    const was = reposted;
+    setReposted(!was); setRepostCount(c => c + (was ? -1 : 1));
+    fetch(`/api/blogs/${blogId}/repost`, { method: was ? 'DELETE' : 'POST' })
+      .then(r => r.ok ? r.json() : Promise.reject())
+      .then(d => { setReposted(!!d.reposted); setRepostCount(d.count || 0); })
+      .catch(() => { setReposted(was); setRepostCount(c => c + (was ? 1 : -1)); });
+  };
   const startTime = useRef(Date.now());
   const progressReported = useRef(0);
 
@@ -235,6 +255,19 @@ export default function BlogInteractionBar({ blogId }) {
           <ion-icon name="chatbubble-outline" style={{ fontSize: '17px' }} />
           {interactions.commentCount > 0 && <span>{fmt(interactions.commentCount)}</span>}
         </div>
+
+        {/* Repost — hidden for the author / co-authors */}
+        {canRepost && (
+          <button
+            onClick={toggleRepost}
+            className="flex items-center gap-1.5 px-3 py-2 rounded-full text-[13px] font-medium transition-colors"
+            style={{ color: reposted ? '#16a34a' : 'var(--text-muted)', backgroundColor: reposted ? '#16a34a14' : 'transparent' }}
+            title={reposted ? 'Undo repost' : 'Repost to your followers'}
+          >
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"><path d="M17 1l4 4-4 4"/><path d="M3 11V9a4 4 0 014-4h14"/><path d="M7 23l-4-4 4-4"/><path d="M21 13v2a4 4 0 01-4 4H3"/></svg>
+            {repostCount > 0 && <span>{fmt(repostCount)}</span>}
+          </button>
+        )}
       </div>
 
       {/* Right — utility actions */}

--- a/src/components/Editor/BlogPreview.jsx
+++ b/src/components/Editor/BlogPreview.jsx
@@ -329,7 +329,7 @@ function renderBlocksToHTML(blocks) {
   return html;
 }
 
-export default function BlogPreview({ title, subtitle, coverPreview, coverZoom, coverPos, pageEmoji, tags, html, blocks, user, org, coAuthorCount, coAuthors = [], wordCount, followSlot = null }) {
+export default function BlogPreview({ title, subtitle, coverPreview, coverZoom, coverPos, pageEmoji, tags, html, blocks, user, org, coAuthorCount, coAuthors = [], wordCount, followSlot = null, memberOnly = false, featured = false, publishedAt = null, headerActions = null }) {
   const { isDark } = useTheme();
   const contentRef = useRef(null);
   const [showBackToTop, setShowBackToTop] = useState(false);
@@ -699,9 +699,25 @@ export default function BlogPreview({ title, subtitle, coverPreview, coverZoom, 
       {/* Spacer when emoji overlaps cover */}
       {pageEmoji && coverPreview && <div className="h-8" />}
 
+      {/* Badges — Member-only / Featured */}
+      {(memberOnly || featured) && (
+        <div className="flex items-center gap-2 mt-6 mb-3">
+          {memberOnly && (
+            <span className="flex items-center gap-1.5 text-[13px] px-3 py-1 rounded-full" style={{ border: '1px solid var(--border-default)', color: 'var(--text-body)' }}>
+              <ion-icon name="sparkles" style={{ fontSize: '13px', color: '#e8a840' }} /> Member-only story
+            </span>
+          )}
+          {featured && (
+            <span className="flex items-center gap-1.5 text-[13px] px-3 py-1 rounded-full" style={{ border: '1px solid var(--border-default)', color: 'var(--text-body)' }}>
+              <ion-icon name="ribbon-outline" style={{ fontSize: '14px', color: '#9b7bf7' }} /> Featured
+            </span>
+          )}
+        </div>
+      )}
+
       {/* Title */}
       {title && (
-        <h1 className="text-[2.2em] font-extrabold leading-tight mt-6 mb-2" style={{ fontFamily: "'Source Serif 4', Georgia, serif" }}>{title}</h1>
+        <h1 className={`text-[2.2em] font-extrabold leading-tight ${(memberOnly || featured) ? 'mt-0' : 'mt-6'} mb-2`} style={{ fontFamily: "'Source Serif 4', Georgia, serif" }}>{title}</h1>
       )}
 
       {/* Subtitle */}
@@ -747,13 +763,24 @@ export default function BlogPreview({ title, subtitle, coverPreview, coverZoom, 
               )}
               <span className="text-[var(--text-faint)]">·</span>
               <span>{Math.max(1, Math.ceil((wordCount || 0) / 200))} min read</span>
-              <span className="text-[var(--text-faint)]">·</span>
-              <span>{wordCount || 0} {(wordCount || 0) === 1 ? 'word' : 'words'}</span>
+              {publishedAt && (
+                <>
+                  <span className="text-[var(--text-faint)]">·</span>
+                  <span>{new Date(publishedAt * 1000).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}</span>
+                </>
+              )}
             </div>
             {followSlot && <div className="ml-auto flex items-center gap-2">{followSlot}</div>}
           </div>
         );
       })()}
+
+      {/* Header action bar (clap / comment / repost / save / share) */}
+      {headerActions && (
+        <div className="py-2 mb-1" style={{ borderTop: '1px solid var(--divider)', borderBottom: '1px solid var(--divider)' }}>
+          {headerActions}
+        </div>
+      )}
 
       {/* Tags — under author bar */}
       {tags.length > 0 && (

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -181,25 +181,154 @@ function SearchBar() {
   );
 }
 
-function FeedCard({ post }) {
+// Stacked author avatars (primary + co-authors).
+function AuthorStack({ authors }) {
+  const shown = authors.slice(0, 3);
+  return (
+    <div className="flex -space-x-1.5">
+      {shown.map((a, i) => (
+        a.avatar_url ? (
+          <img key={i} src={a.avatar_url} alt="" title={a.display_name || a.username} className="h-5 w-5 rounded-full object-cover" style={{ boxShadow: '0 0 0 2px var(--bg-app)' }} />
+        ) : (
+          <div key={i} title={a.display_name || a.username} className="h-5 w-5 rounded-full flex items-center justify-center text-[9px] font-bold" style={{ backgroundColor: 'var(--bg-elevated)', color: 'var(--text-faint)', boxShadow: '0 0 0 2px var(--bg-app)' }}>{(a.display_name || a.username || '?')[0].toUpperCase()}</div>
+        )
+      ))}
+    </div>
+  );
+}
+
+// "..." menu — follow author/publication, mute author/publication/topics, report.
+function FeedCardMenu({ post, onHide }) {
+  const { user } = useAuth();
+  const [open, setOpen] = useState(false);
+  const ref = useRef(null);
+  const author = post.author || {};
+  const org = post.org || null;
+
+  useEffect(() => {
+    if (!open) return;
+    const h = (e) => { if (ref.current && !ref.current.contains(e.target)) setOpen(false); };
+    document.addEventListener('mousedown', h);
+    return () => document.removeEventListener('mousedown', h);
+  }, [open]);
+
+  const needAuth = () => { if (!user) { window.location.href = '/sign-in?next=/'; return true; } return false; };
+  const post_ = (url, body) => fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }).catch(() => {});
+
+  const followAuthor = () => { if (needAuth()) return; post_(`/api/users/${author.username}/follow`); setOpen(false); };
+  const followOrg = () => { if (needAuth()) return; post_(`/api/orgs/${org.slug}/follow`); setOpen(false); };
+  const muteAuthor = () => { if (needAuth()) return; post_('/api/mutes', { targetType: 'author', targetId: post.author_id }); setOpen(false); onHide?.(post.id); };
+  const muteOrg = () => { if (needAuth()) return; post_('/api/mutes', { targetType: 'org', targetId: org.id }); setOpen(false); onHide?.(post.id); };
+  const muteTopics = () => { if (needAuth()) return; (post.tags || []).forEach(t => post_('/api/mutes', { targetType: 'tag', targetId: t })); setOpen(false); onHide?.(post.id); };
+  const report = () => {
+    if (needAuth()) return;
+    setOpen(false);
+    if (!confirm('Report this story to the moderators?')) return;
+    post_(`/api/blogs/${post.id}/report`, { reason: 'other', detail: 'Reported from feed' });
+  };
+
+  const item = (label, fn, danger, badge) => (
+    <button onClick={fn} className="w-full text-left px-4 py-2 text-[13px] flex items-center gap-2 transition-colors"
+      style={{ color: danger ? '#f87171' : 'var(--text-body)' }}
+      onMouseEnter={e => e.currentTarget.style.backgroundColor = 'var(--bg-hover)'}
+      onMouseLeave={e => e.currentTarget.style.backgroundColor = 'transparent'}>
+      {label}{badge && <span className="text-[9px] font-bold px-1.5 py-0.5 rounded" style={{ backgroundColor: '#16a34a', color: '#fff' }}>New</span>}
+    </button>
+  );
+
+  return (
+    <div className="relative" ref={ref}>
+      <button onClick={(e) => { e.preventDefault(); setOpen(o => !o); }} className="flex items-center justify-center w-8 h-8 rounded-full transition-colors" style={{ color: 'var(--text-faint)' }} title="More" onMouseEnter={e => e.currentTarget.style.backgroundColor = 'var(--bg-hover)'} onMouseLeave={e => e.currentTarget.style.backgroundColor = 'transparent'}>
+        <ion-icon name="ellipsis-horizontal" style={{ fontSize: '18px' }} />
+      </button>
+      {open && (
+        <div className="absolute right-0 top-9 z-50 w-56 rounded-xl py-1.5 overflow-hidden" style={{ backgroundColor: 'var(--dropdown-bg, var(--bg-surface))', border: '1px solid var(--border-default)', boxShadow: '0 12px 40px rgba(0,0,0,0.35)' }}>
+          {item(`Follow ${author.display_name || author.username}`, followAuthor)}
+          {org && item(`Follow ${org.name}`, followOrg)}
+          <div className="my-1.5" style={{ borderTop: '1px solid var(--divider)' }} />
+          {item('Mute author', muteAuthor)}
+          {org && item('Mute publication', muteOrg)}
+          {(post.tags || []).length > 0 && item('Mute topics', muteTopics, false, true)}
+          <div className="my-1.5" style={{ borderTop: '1px solid var(--divider)' }} />
+          {item('Report story…', report, true)}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Action bar — clap, comment, repost, save, "..." menu.
+function FeedCardActions({ post, onHide }) {
+  const { user } = useAuth();
+  const [claps, setClaps] = useState(post.clap_total || post.like_count || 0);
+  const [saved, setSaved] = useState(false);
+  const [reposted, setReposted] = useState(false);
+  const href = `/${(post.org?.slug) || post.author?.username || 'unknown'}/${post.slug}`;
+  const isOwn = !!post.can_edit; // author / org member — can't repost own
+
+  const guard = (fn) => (e) => {
+    e.preventDefault(); e.stopPropagation();
+    if (!user) { window.location.href = '/sign-in?next=/'; return; }
+    fn();
+  };
+  const clap = guard(() => { setClaps(c => c + 1); fetch(`/api/blogs/${post.id}/clap`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ count: 1 }) }).then(r => r.ok ? r.json() : null).then(d => d && setClaps(d.totalClaps)).catch(() => {}); });
+  const save = guard(() => {
+    const was = saved; setSaved(!was);
+    (was ? fetch(`/api/library/bookmarks/${post.id}`, { method: 'DELETE' })
+         : fetch('/api/library/bookmarks', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ blogId: post.id }) }))
+      .then(r => { if (!r.ok) throw new Error(); }).catch(() => setSaved(was));
+  });
+  const repost = guard(() => {
+    const was = reposted; setReposted(!was);
+    fetch(`/api/blogs/${post.id}/repost`, { method: was ? 'DELETE' : 'POST' })
+      .then(r => r.ok ? r.json() : Promise.reject()).then(d => setReposted(!!d.reposted)).catch(() => setReposted(was));
+  });
+
+  const Stat = ({ d, label, onClick, active, fill }) => (
+    <button onClick={onClick} title={label} className="flex items-center gap-1.5 text-[13px] transition-colors" style={{ color: active ? '#9b7bf7' : 'var(--text-muted)' }}>
+      <svg className="w-[18px] h-[18px]" fill={fill && active ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth={1.6} viewBox="0 0 24 24" strokeLinecap="round" strokeLinejoin="round">{d}</svg>
+    </button>
+  );
+
+  return (
+    <div className="flex items-center gap-5 mt-3">
+      {/* claps */}
+      <button onClick={clap} className="flex items-center gap-1.5 text-[13px] transition-colors" style={{ color: 'var(--text-muted)' }} title="Clap">
+        <svg className="w-[18px] h-[18px]" fill="none" stroke="currentColor" strokeWidth={1.6} viewBox="0 0 24 24" strokeLinecap="round" strokeLinejoin="round"><path d="M7 11v8m0 0H5a1 1 0 01-1-1v-6a1 1 0 011-1h2m3-4l-1 5h6l-1 5" /></svg>
+        {claps > 0 && <span>{claps >= 1000 ? `${(claps / 1000).toFixed(1)}K` : claps}</span>}
+      </button>
+      {/* comments */}
+      <Link href={`${href}#comments`} className="flex items-center gap-1.5 text-[13px]" style={{ color: 'var(--text-muted)' }} title="Comments" onClick={e => e.stopPropagation()}>
+        <svg className="w-[18px] h-[18px]" fill="none" stroke="currentColor" strokeWidth={1.6} viewBox="0 0 24 24" strokeLinecap="round" strokeLinejoin="round"><path d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" /></svg>
+        {post.comment_count > 0 && <span>{post.comment_count}</span>}
+      </Link>
+      {/* repost — not for own blog */}
+      {!isOwn && (
+        <button onClick={repost} className="flex items-center gap-1.5 text-[13px] transition-colors" style={{ color: reposted ? '#16a34a' : 'var(--text-muted)' }} title="Repost">
+          <svg className="w-[18px] h-[18px]" fill="none" stroke="currentColor" strokeWidth={1.6} viewBox="0 0 24 24" strokeLinecap="round" strokeLinejoin="round"><path d="M17 1l4 4-4 4" /><path d="M3 11V9a4 4 0 014-4h14" /><path d="M7 23l-4-4 4-4" /><path d="M21 13v2a4 4 0 01-4 4H3" /></svg>
+        </button>
+      )}
+      <div className="ml-auto flex items-center gap-1">
+        <button onClick={save} className="flex items-center justify-center w-8 h-8 rounded-full transition-colors" style={{ color: saved ? '#9b7bf7' : 'var(--text-faint)' }} title="Save to reading list" onMouseEnter={e => e.currentTarget.style.backgroundColor = 'var(--bg-hover)'} onMouseLeave={e => e.currentTarget.style.backgroundColor = 'transparent'}>
+          <ion-icon name={saved ? 'bookmark' : 'bookmark-outline'} style={{ fontSize: '18px' }} />
+        </button>
+        <FeedCardMenu post={post} onHide={onHide} />
+      </div>
+    </div>
+  );
+}
+
+function FeedCard({ post, onHide }) {
   const author = post.author || {};
   const cover = post.cover_image_r2_key || generateBlogBanner(post.id || post.slug);
   const href = `/${(post.org?.slug) || author.username || 'unknown'}/${post.slug}`;
-  const bylineName = post.org ? post.org.name : (author.display_name || author.username);
   const allAuthors = [{ display_name: author.display_name, username: author.username, avatar_url: author.avatar_url }, ...(post.co_authors || [])];
   return (
     <article className="group py-6" style={{ borderBottom: '1px solid var(--divider)' }}>
       <Link href={href} className="flex gap-5 cursor-pointer">
-        {/* Left: byline + title + subtitle + stats */}
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 mb-2 text-[13px]" style={{ color: 'var(--text-secondary)' }}>
-            {post.org?.logo_url ? (
-              <img src={post.org.logo_url} alt="" className="h-5 w-5 rounded object-cover" />
-            ) : author.avatar_url ? (
-              <img src={author.avatar_url} alt="" className="h-5 w-5 rounded-full object-cover" />
-            ) : (
-              <div className="h-5 w-5 rounded-full flex items-center justify-center text-[9px] font-bold" style={{ backgroundColor: 'var(--bg-elevated)', color: 'var(--text-faint)' }}>{(bylineName || '?')[0].toUpperCase()}</div>
-            )}
+            <AuthorStack authors={allAuthors} />
             <span className="truncate">
               {post.org && <>In <span className="font-medium" style={{ color: 'var(--text-primary)' }}>{post.org.name}</span> by </>}
               <span className="font-medium" style={{ color: 'var(--text-primary)' }}>{author.display_name || author.username}</span>
@@ -214,43 +343,29 @@ function FeedCard({ post }) {
             {post.title || 'Untitled'}
           </h2>
           {post.subtitle && (
-            <p className="text-[15px] leading-[1.5] line-clamp-2 mb-3" style={{ color: 'var(--text-muted)' }}>{post.subtitle}</p>
+            <p className="text-[15px] leading-[1.5] line-clamp-2 mb-2" style={{ color: 'var(--text-muted)' }}>{post.subtitle}</p>
           )}
-
-          <div className="flex items-center gap-3 text-[12px] flex-wrap" style={{ color: 'var(--text-faint)' }}>
+          <div className="flex items-center gap-3 text-[12px]" style={{ color: 'var(--text-faint)' }}>
             <span>{timeAgo(post.published_at)}</span>
             {(post.tags || []).slice(0, 1).map(tag => (
               <span key={tag} className="text-[11px] px-2 py-0.5 rounded-full font-medium" style={{ backgroundColor: 'var(--bg-elevated)', color: 'var(--text-body)' }}>{tag}</span>
             ))}
             {post.read_time_minutes > 0 && <span>{post.read_time_minutes} min read</span>}
-            {(post.clap_total > 0 || post.like_count > 0) && (
-              <span className="flex items-center gap-1">
-                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M7 11v8m0 0H5a1 1 0 01-1-1v-6a1 1 0 011-1h2m3-4l-1 5h6l-1 5" /></svg>
-                {post.clap_total || post.like_count}
-              </span>
-            )}
-            {post.comment_count > 0 && (
-              <span className="flex items-center gap-1">
-                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" /></svg>
-                {post.comment_count}
-              </span>
-            )}
           </div>
         </div>
 
-        {/* Right: square cover thumbnail */}
         <div className="flex-shrink-0 self-center hidden sm:block">
           <img src={cover} alt="" className="w-[112px] h-[112px] rounded-md object-cover" style={{ backgroundColor: 'var(--bg-elevated)' }} />
         </div>
       </Link>
 
+      {/* Action bar */}
+      <FeedCardActions post={post} onHide={onHide} />
+
       {post.can_edit && (
         <div className="mt-3 flex items-center gap-2">
           <Link href={`/edit/${post.slug || post.id}`} className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[12px] font-medium transition-colors" style={{ color: 'var(--text-faint)', backgroundColor: 'var(--bg-elevated)', border: '1px solid var(--border-default)' }}>
             <ion-icon name="create-outline" style={{ fontSize: '13px' }} /> Edit
-          </Link>
-          <Link href={`/edit/${post.slug || post.id}?panel=settings`} className="flex items-center justify-center w-8 h-8 rounded-lg transition-colors" style={{ color: 'var(--text-faint)', backgroundColor: 'var(--bg-elevated)', border: '1px solid var(--border-default)' }} title="Blog settings">
-            <ion-icon name="settings-outline" style={{ fontSize: '14px' }} />
           </Link>
         </div>
       )}
@@ -467,7 +582,7 @@ export default function App() {
             {loading ? (
               <FeedSkeleton />
             ) : posts.length > 0 ? (
-              posts.map(post => <FeedCard key={post.id} post={post} />)
+              posts.map(post => <FeedCard key={post.id} post={post} onHide={(id) => setPosts(ps => ps.filter(p => p.id !== id))} />)
             ) : (
               <div className="my-8 rounded-2xl border border-dashed flex flex-col items-center text-center px-6 py-14" style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-surface)' }}>
                 <div className="h-14 w-14 rounded-full flex items-center justify-center mb-4" style={{ backgroundColor: 'var(--bg-elevated)' }}>

--- a/src/views/HandlePage.jsx
+++ b/src/views/HandlePage.jsx
@@ -13,6 +13,7 @@ import BlogRecommendations from '../components/BlogRecommendations';
 import AuthorAttribution from '../components/AuthorAttribution';
 import FollowListModal from '../components/FollowListModal';
 import BlogInviteOverlay from '../components/BlogInviteOverlay';
+import { STAFF_ORG_ID } from '../../lib/staff';
 import '../styles/editor/editor.css';
 import '../styles/katex-fonts.css';
 
@@ -186,12 +187,16 @@ function HandlePageInner({ path }) {
             coAuthorCount={blog.co_author_count || 0}
             coAuthors={blog.co_authors || []}
             wordCount={wc}
+            memberOnly={!!blog.member_only}
+            featured={blog.published_as === `org:${STAFF_ORG_ID}`}
+            publishedAt={blog.published_at}
             followSlot={!isAuthor ? (
               <>
                 {data.owner?.type === 'org' && <FollowToggle kind="org" handle={data.owner.slug} compact />}
                 {blog.author_username && <FollowToggle kind="user" handle={blog.author_username} compact />}
               </>
             ) : null}
+            headerActions={<BlogInteractionBar blogId={blog.id} blogAuthorId={blog.author_id} canRepost={!isAuthor} />}
           />
 
           {/* End-of-blog follow card — author (+ org) */}
@@ -199,9 +204,6 @@ function HandlePageInner({ path }) {
             author={{ username: blog.author_username, display_name: blog.author_name, avatar_url: blog.author_avatar }}
             org={data.owner?.type === 'org' ? { slug: data.owner.slug, name: data.owner.name, logo_url: data.owner.logo_url || data.owner.logo_r2_key } : null}
           />
-
-          {/* Interaction bar — like, clap, bookmark, share, views */}
-          <BlogInteractionBar blogId={blog.id} />
 
           {/* Comments section — always expanded */}
           <BlogComments blogId={blog.id} blogAuthorId={blog.author_id} />

--- a/src/views/WritePage.jsx
+++ b/src/views/WritePage.jsx
@@ -2219,6 +2219,20 @@ export default function WritePage({ slugid }) {
             );
           })()}
 
+          {/* Punchline (subtitle) — shown under the title on the published blog */}
+          <div>
+            <label className="text-[12px] font-medium mb-2 block" style={{ color: 'var(--text-muted)' }}>Punchline <span className="font-normal" style={{ color: 'var(--text-faint)' }}>— a short tagline shown under the title</span></label>
+            <textarea
+              value={subtitle}
+              onChange={(e) => setSubtitle(e.target.value.slice(0, 160))}
+              rows={2}
+              placeholder="e.g. Tested, ranked, and ready to use"
+              className="w-full text-[14px] rounded-lg px-3 py-2 outline-none resize-none"
+              style={{ backgroundColor: 'var(--bg-app)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
+            />
+            <p className="text-[11px] mt-1 text-right" style={{ color: 'var(--text-faint)' }}>{(subtitle || '').length}/160</p>
+          </div>
+
           {/* Tags */}
           <div>
             <label className="text-[12px] font-medium mb-2 block" style={{ color: 'var(--text-muted)' }}>Tags (up to 5) <span className="font-normal" style={{ color: 'var(--text-faint)' }}>— press Enter to attach</span></label>


### PR DESCRIPTION
## Changes Made

- `app/api/blogs/[slugid]/repost/route.js` — New edge API route for reposts: GET returns count + user state, POST creates a repost, DELETE undoes it. Own-blog and co-author reposts are blocked.
- `app/api/mutes/route.js` — New edge API route for per-user mutes (author / org / tag). GET lists mutes, POST adds one, DELETE removes one.
- `app/api/feed/route.js` — Added `filterMuted()` step after `enrichPosts()` so the feed drops posts from muted authors, orgs, or tags. Gracefully no-ops if the `mutes` table doesn't exist yet.
- `app/api/resolve/route.js` — Added `b.member_only` to the blog SELECT so the resolver returns the field for badge rendering.
- `migrations/0029_mutes.sql` — Creates `mutes` table with composite PK `(user_id, target_type, target_id)` and index on `user_id`.
- `migrations/0030_reposts.sql` — Creates `reposts` table with composite PK `(user_id, blog_id)` and indexes on both columns.
- `src/components/BlogInteractionBar.jsx` — Added repost button with optimistic toggle, count display, and auth redirect. Prop `canRepost` controls visibility (hidden for author/co-authors).
- `src/components/Editor/BlogPreview.jsx` — Added "Member-only story" and "Featured" badges above the title; replaced word-count with publish date in the author bar; added `headerActions` slot for the interaction bar below the byline.
- `src/index.jsx` — Reworked `FeedCard` with `AuthorStack` (stacked avatars for co-authors), `FeedCardMenu` ("…" dropdown with follow/mute/report actions), member-only and featured indicators on cards, and inline repost UI.

## Checklist

- [x] `export const runtime = 'edge'` on any new API route
- [x] No Node built-ins imported (crypto, fs, path, stream, Buffer)
- [x] New DB columns/tables have a migration in `src/workers/migrations/`
- [x] Rate-limit middleware on new public auth endpoints
- [x] `./biome.sh ci` clean
- [ ] Tested locally: <how>