### PR TITLE
[FEAT]: Updated the hideHighlight state to be defined

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lixblogs",
-  "version": "4.9.32",
+  "version": "4.9.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lixblogs",
-      "version": "4.9.32",
+      "version": "4.9.33",
       "license": "MIT",
       "dependencies": {
         "@blocknote/core": "^0.47.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lixblogs",
-  "version": "4.9.32",
+  "version": "4.9.33",
   "description": "A modern blogging platform with a rich block editor, AI writing tools, real-time collaboration, and organizations — deployed on Cloudflare's edge.",
   "author": "Elixpo <https://github.com/elixpo>",
   "license": "MIT",

--- a/src/components/Editor/BlogPreview.jsx
+++ b/src/components/Editor/BlogPreview.jsx
@@ -329,7 +329,7 @@ function renderBlocksToHTML(blocks) {
   return html;
 }
 
-export default function BlogPreview({ title, subtitle, coverPreview, coverZoom, coverPos, pageEmoji, tags, html, blocks, user, org, coAuthorCount, coAuthors = [], wordCount, followSlot = null, memberOnly = false, featured = false, publishedAt = null, headerActions = null }) {
+export default function BlogPreview({ title, subtitle, coverPreview, coverZoom, coverPos, pageEmoji, tags, html, blocks, user, org, coAuthorCount, coAuthors = [], wordCount, followSlot = null, memberOnly = false, featured = false, publishedAt = null, headerActions = null, hideHighlights = false }) {
   const { isDark } = useTheme();
   const contentRef = useRef(null);
   const [showBackToTop, setShowBackToTop] = useState(false);


### PR DESCRIPTION
## Changes Made
- `src/components/Editor/BlogPreview.jsx` — Added `hideHighlights = false` as a destructured prop with default value to `BlogPreview`, making the previously undefined state explicitly declared and defaulting to `false`.

## Checklist
- [ ] No Node built-ins imported (crypto, fs, path, stream, Buffer)
- [ ] `./biome.sh ci` clean
- [ ] Tested locally: <how>