### PR TITLE
[FEAT]: Cosmetic changes to the UI across the feed and publish route

### DIFF
--- a/app/api/blogs/draft/route.js
+++ b/app/api/blogs/draft/route.js
@@ -137,6 +137,8 @@ export async function POST(request) {
 
     // Compress content before storing
     const compressedContent = editorContent ? compressBlogContent(editorContent) : '';
+    const { excerptFromBlocks } = await import('../../../../lib/excerpt');
+    const excerpt = editorContent ? excerptFromBlocks(editorContent) : '';
 
     // Check if blog exists
     const existing = await db.prepare('SELECT id, author_id FROM blogs WHERE id = ?').bind(slugid).first();
@@ -147,11 +149,11 @@ export async function POST(request) {
       const perm = await canEditBlog(db, slugid, session.userId);
       if (!perm.ok) return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
       await db.prepare(`
-        UPDATE blogs SET title = ?, subtitle = ?, content = ?, published_as = ?,
+        UPDATE blogs SET title = ?, subtitle = ?, content = ?, excerpt = ?, published_as = ?,
           page_emoji = ?, cover_image_r2_key = ?, cover_pos_x = ?, cover_pos_y = ?, cover_zoom = ?, updated_at = ?
         WHERE id = ?
       `).bind(
-        title || '', subtitle || '', compressedContent, publishAs || 'personal',
+        title || '', subtitle || '', compressedContent, excerpt, publishAs || 'personal',
         pageEmoji || '', coverPreview || '', posX, posY, zoom, now, slugid
       ).run();
       // Throttled version snapshot (≤ 1 / 5 min) so history accrues as people edit (#11 E).
@@ -166,10 +168,10 @@ export async function POST(request) {
         publishAs: publishAs || 'personal',
       });
       await db.prepare(`
-        INSERT INTO blogs (id, slug, title, subtitle, content, author_id, published_as, status, page_emoji, cover_image_r2_key, cover_pos_x, cover_pos_y, cover_zoom, created_at, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, 'draft', ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO blogs (id, slug, title, subtitle, content, excerpt, author_id, published_as, status, page_emoji, cover_image_r2_key, cover_pos_x, cover_pos_y, cover_zoom, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'draft', ?, ?, ?, ?, ?, ?, ?)
       `).bind(
-        slugid, slug, title || '', subtitle || '', compressedContent,
+        slugid, slug, title || '', subtitle || '', compressedContent, excerpt,
         session.userId, publishAs || 'personal', pageEmoji || '', coverPreview || '', posX, posY, zoom, now, now
       ).run();
     }

--- a/app/api/blogs/publish/route.js
+++ b/app/api/blogs/publish/route.js
@@ -57,6 +57,8 @@ export async function POST(request) {
     const now = Math.floor(Date.now() / 1000);
     const readTime = Math.max(1, Math.ceil(countWords(editorContent) / 250));
     const compressedContent = editorContent ? compressBlogContent(editorContent) : '';
+    const { excerptFromBlocks } = await import('../../../../lib/excerpt');
+    const excerpt = editorContent ? excerptFromBlocks(editorContent) : '';
 
     const existing = await db.prepare('SELECT id, author_id, status, published_as, slug FROM blogs WHERE id = ?').bind(slugid).first();
 
@@ -120,8 +122,6 @@ export async function POST(request) {
         ? (existing.status === 'draft' ? now : null)
         : null;
 
-      const { excerptFromBlocks } = await import('../../../../lib/excerpt');
-      const excerpt = editorContent ? excerptFromBlocks(editorContent) : '';
       let query = `
         UPDATE blogs SET title = ?, subtitle = ?, slug = ?, content = ?, excerpt = ?, published_as = ?,
           status = ?, page_emoji = ?, cover_image_r2_key = ?, cover_pos_x = ?, cover_pos_y = ?, cover_zoom = ?,
@@ -141,11 +141,11 @@ export async function POST(request) {
     } else {
       // Create and publish in one step
       await db.prepare(`
-        INSERT INTO blogs (id, slug, title, subtitle, content, author_id, published_as, status,
+        INSERT INTO blogs (id, slug, title, subtitle, content, excerpt, author_id, published_as, status,
           page_emoji, cover_image_r2_key, cover_pos_x, cover_pos_y, cover_zoom, read_time_minutes, created_at, updated_at, published_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `).bind(
-        slugid, slug, title, subtitle || '', compressedContent,
+        slugid, slug, title, subtitle || '', compressedContent, excerpt,
         session.userId, publishAs || 'personal', targetStatus,
         pageEmoji || '', coverUrl || '', posX, posY, zoom, readTime, now, now,
         (targetStatus === 'published' || targetStatus === 'unlisted') ? now : null

--- a/app/api/blogs/publish/route.js
+++ b/app/api/blogs/publish/route.js
@@ -120,12 +120,14 @@ export async function POST(request) {
         ? (existing.status === 'draft' ? now : null)
         : null;
 
+      const { excerptFromBlocks } = await import('../../../../lib/excerpt');
+      const excerpt = editorContent ? excerptFromBlocks(editorContent) : '';
       let query = `
-        UPDATE blogs SET title = ?, subtitle = ?, slug = ?, content = ?, published_as = ?,
+        UPDATE blogs SET title = ?, subtitle = ?, slug = ?, content = ?, excerpt = ?, published_as = ?,
           status = ?, page_emoji = ?, cover_image_r2_key = ?, cover_pos_x = ?, cover_pos_y = ?, cover_zoom = ?,
           read_time_minutes = ?, updated_at = ?
       `;
-      const params = [title, subtitle || '', slug, compressedContent, publishAs || 'personal',
+      const params = [title, subtitle || '', slug, compressedContent, excerpt, publishAs || 'personal',
         targetStatus, pageEmoji || '', coverUrl || '', posX, posY, zoom, readTime, now];
 
       if (publishedAt) {

--- a/app/api/feed/route.js
+++ b/app/api/feed/route.js
@@ -3,7 +3,7 @@ import { NextResponse } from 'next/server';
 import { getSession } from '../../../lib/auth';
 import { STAFF_ORG_ID } from '../../../lib/staff';
 
-const BLOG_FIELDS = `b.id, b.slug, b.title, b.subtitle, b.cover_image_r2_key, b.page_emoji,
+const BLOG_FIELDS = `b.id, b.slug, b.title, b.subtitle, b.excerpt, b.cover_image_r2_key, b.page_emoji,
   b.author_id, b.published_as, b.published_at, b.read_time_minutes,
   b.like_count, b.clap_total, b.comment_count, b.view_count`;
 
@@ -301,6 +301,14 @@ async function enrichPosts(db, posts, userId) {
     orgMemberSet = new Set(memberRows.map(r => r.key));
   }
 
+  // Reshare counts for these posts (batched).
+  const repostMap = {};
+  if (blogIds.length) {
+    const ph = blogIds.map(() => '?').join(',');
+    const rows = await db.prepare(`SELECT blog_id, COUNT(*) AS c FROM reposts WHERE blog_id IN (${ph}) GROUP BY blog_id`).bind(...blogIds).all();
+    for (const r of (rows?.results || [])) repostMap[r.blog_id] = r.c;
+  }
+
   // The viewer's like / bookmark / co-author state for these posts (batched).
   let likedSet = new Set(), bookmarkedSet = new Set(), coAuthoredSet = new Set();
   if (userId) {
@@ -331,6 +339,7 @@ async function enrichPosts(db, posts, userId) {
       can_edit: !!(isAuthor || isOrgMember),
       is_author: !!isAuthor,
       is_co_author: coAuthoredSet.has(p.id),
+      repost_count: repostMap[p.id] || 0,
       liked: likedSet.has(p.id),
       bookmarked: bookmarkedSet.has(p.id),
     };

--- a/lib/excerpt.js
+++ b/lib/excerpt.js
@@ -1,0 +1,21 @@
+// Extract a short plain-text excerpt ("starting lines") from BlockNote blocks.
+export function excerptFromBlocks(blocks, max = 200) {
+  if (!Array.isArray(blocks)) return '';
+  const out = [];
+  const walk = (list) => {
+    for (const b of list || []) {
+      if (out.join(' ').length >= max) return;
+      // Skip non-prose blocks.
+      if (b?.type && ['image', 'video', 'audio', 'file', 'codeBlock', 'table', 'equation'].includes(b.type)) continue;
+      const txt = (b?.content || [])
+        .map((c) => (typeof c === 'string' ? c : c?.text || ''))
+        .join('')
+        .trim();
+      if (txt) out.push(txt);
+      if (b?.children?.length) walk(b.children);
+    }
+  };
+  walk(blocks);
+  const text = out.join(' ').replace(/\s+/g, ' ').trim();
+  return text.length > max ? text.slice(0, max).replace(/\s+\S*$/, '') + '…' : text;
+}

--- a/migrations/0031_blog_excerpt.sql
+++ b/migrations/0031_blog_excerpt.sql
@@ -1,0 +1,2 @@
+-- Cached plain-text excerpt ("starting lines") shown under the title in the feed.
+ALTER TABLE blogs ADD COLUMN excerpt TEXT;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lixblogs",
-  "version": "4.9.34",
+  "version": "4.9.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lixblogs",
-      "version": "4.9.34",
+      "version": "4.9.35",
       "license": "MIT",
       "dependencies": {
         "@blocknote/core": "^0.47.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lixblogs",
-  "version": "4.9.33",
+  "version": "4.9.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lixblogs",
-      "version": "4.9.33",
+      "version": "4.9.34",
       "license": "MIT",
       "dependencies": {
         "@blocknote/core": "^0.47.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lixblogs",
-  "version": "4.9.35",
+  "version": "4.9.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lixblogs",
-      "version": "4.9.35",
+      "version": "4.9.36",
       "license": "MIT",
       "dependencies": {
         "@blocknote/core": "^0.47.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lixblogs",
-  "version": "4.9.33",
+  "version": "4.9.34",
   "description": "A modern blogging platform with a rich block editor, AI writing tools, real-time collaboration, and organizations — deployed on Cloudflare's edge.",
   "author": "Elixpo <https://github.com/elixpo>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lixblogs",
-  "version": "4.9.35",
+  "version": "4.9.36",
   "description": "A modern blogging platform with a rich block editor, AI writing tools, real-time collaboration, and organizations — deployed on Cloudflare's edge.",
   "author": "Elixpo <https://github.com/elixpo>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lixblogs",
-  "version": "4.9.34",
+  "version": "4.9.35",
   "description": "A modern blogging platform with a rich block editor, AI writing tools, real-time collaboration, and organizations — deployed on Cloudflare's edge.",
   "author": "Elixpo <https://github.com/elixpo>",
   "license": "MIT",

--- a/src/components/AppShell.jsx
+++ b/src/components/AppShell.jsx
@@ -426,18 +426,19 @@ export default function AppShell({ children }) {
               </>
             ) : (
               <>
+                {/* "Sign In" text is hidden on phones — the icon button below covers it */}
                 <Link
                   href="/sign-in"
-                  className="text-[14px] transition-colors px-3 py-1.5 rounded-lg"
+                  className="hidden sm:block text-[14px] transition-colors px-3 py-1.5 rounded-lg"
                   style={{ color: 'var(--text-muted)' }}
                   onMouseEnter={e => { e.currentTarget.style.backgroundColor = 'var(--bg-hover)'; e.currentTarget.style.color = 'var(--text-primary)'; }}
                   onMouseLeave={e => { e.currentTarget.style.backgroundColor = 'transparent'; e.currentTarget.style.color = 'var(--text-muted)'; }}
                 >
                   Sign In
                 </Link>
-                <button onClick={handleLogin} className="text-[14px] font-medium text-white bg-[#9b7bf7] hover:bg-[#8b6ae6] transition-colors rounded-full px-2.5 py-2 sm:px-4 sm:py-1.5 flex items-center justify-center">
+                <button onClick={handleLogin} className="text-[14px] font-medium text-white bg-[#9b7bf7] hover:bg-[#8b6ae6] transition-colors rounded-full flex items-center justify-center w-9 h-9 sm:w-auto sm:h-auto sm:px-4 sm:py-1.5" title="Get started">
                   <span className="hidden sm:inline">Get Started</span>
-                  <span className="sm:hidden"><ion-icon name="log-in-outline" style={{ fontSize: '18px' }} /></span>
+                  <span className="sm:hidden flex items-center justify-center"><ion-icon name="log-in-outline" style={{ fontSize: '18px' }} /></span>
                 </button>
               </>
             )}

--- a/src/components/BlogInteractionBar.jsx
+++ b/src/components/BlogInteractionBar.jsx
@@ -15,15 +15,16 @@ export default function BlogInteractionBar({ blogId, blogAuthorId, canRepost = f
   const [reposted, setReposted] = useState(false);
   const [repostCount, setRepostCount] = useState(0);
 
-  // Repost state
+  // Repost state — always fetch the count (shown even on your own blog).
   useEffect(() => {
-    if (!blogId || !canRepost) return;
+    if (!blogId) return;
     fetch(`/api/blogs/${blogId}/repost`).then(r => r.ok ? r.json() : null).then(d => {
       if (!d) return; setReposted(!!d.reposted); setRepostCount(d.count || 0);
     }).catch(() => {});
-  }, [blogId, canRepost]);
+  }, [blogId]);
 
   const toggleRepost = () => {
+    if (!canRepost) return;
     if (!user) { window.location.href = `/sign-in?next=${typeof window !== 'undefined' ? window.location.pathname : '/'}`; return; }
     const was = reposted;
     setReposted(!was); setRepostCount(c => c + (was ? -1 : 1));
@@ -213,7 +214,7 @@ export default function BlogInteractionBar({ blogId, blogAuthorId, canRepost = f
   };
 
   return (
-    <div className="flex items-center justify-between py-4 mt-8" style={{ borderTop: '1px solid var(--divider)', borderBottom: '1px solid var(--divider)' }}>
+    <div className="flex items-center justify-between gap-x-1 gap-y-1 flex-wrap py-1">
       {/* Left — engagement actions */}
       <div className="flex items-center gap-1">
         {/* Like */}
@@ -256,18 +257,17 @@ export default function BlogInteractionBar({ blogId, blogAuthorId, canRepost = f
           {interactions.commentCount > 0 && <span>{fmt(interactions.commentCount)}</span>}
         </div>
 
-        {/* Repost — hidden for the author / co-authors */}
-        {canRepost && (
-          <button
-            onClick={toggleRepost}
-            className="flex items-center gap-1.5 px-3 py-2 rounded-full text-[13px] font-medium transition-colors"
-            style={{ color: reposted ? '#16a34a' : 'var(--text-muted)', backgroundColor: reposted ? '#16a34a14' : 'transparent' }}
-            title={reposted ? 'Undo repost' : 'Repost to your followers'}
-          >
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"><path d="M17 1l4 4-4 4"/><path d="M3 11V9a4 4 0 014-4h14"/><path d="M7 23l-4-4 4-4"/><path d="M21 13v2a4 4 0 01-4 4H3"/></svg>
-            {repostCount > 0 && <span>{fmt(repostCount)}</span>}
-          </button>
-        )}
+        {/* Repost — greyed/disabled for the author and co-authors; count shows when > 0 */}
+        <button
+          onClick={toggleRepost}
+          disabled={!canRepost}
+          className="flex items-center gap-1.5 px-3 py-2 rounded-full text-[13px] font-medium transition-colors"
+          style={{ color: reposted ? '#16a34a' : 'var(--text-muted)', backgroundColor: reposted ? '#16a34a14' : 'transparent', opacity: canRepost ? 1 : 0.4, cursor: canRepost ? 'pointer' : 'not-allowed' }}
+          title={!canRepost ? "You can't repost your own blog" : (reposted ? 'Undo repost' : 'Repost to your followers')}
+        >
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"><path d="M17 1l4 4-4 4"/><path d="M3 11V9a4 4 0 014-4h14"/><path d="M7 23l-4-4 4-4"/><path d="M21 13v2a4 4 0 01-4 4H3"/></svg>
+          {repostCount > 0 && <span>{fmt(repostCount)}</span>}
+        </button>
       </div>
 
       {/* Right — utility actions */}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -273,6 +273,8 @@ function FeedCardActions({ post, onHide }) {
   const [likeCount, setLikeCount] = useState(post.like_count || 0);
   const [saved, setSaved] = useState(!!post.bookmarked);
   const [reposted, setReposted] = useState(false);
+  const [repostCount, setRepostCount] = useState(post.repost_count || 0);
+  const [toast, setToast] = useState('');
   const href = `/${(post.org?.slug) || post.author?.username || 'unknown'}/${post.slug}`;
   // Author / co-authors / org members can't repost their own blog.
   const cannotRepost = !!(post.is_author || post.is_co_author || post.can_edit);
@@ -288,17 +290,19 @@ function FeedCardActions({ post, onHide }) {
       .then(r => r.ok ? r.json() : Promise.reject()).then(d => { setLiked(!!d.liked); setLikeCount(d.count || 0); })
       .catch(() => { setLiked(was); setLikeCount(c => Math.max(0, c + (was ? 1 : -1))); });
   });
+  const flashToast = (m) => { setToast(m); setTimeout(() => setToast(''), 2200); };
   const save = guard(() => {
     const was = saved; setSaved(!was);
     (was ? fetch(`/api/library/bookmarks/${post.id}`, { method: 'DELETE' })
          : fetch('/api/library/bookmarks', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ blogId: post.id }) }))
-      .then(r => { if (!r.ok) throw new Error(); }).catch(() => setSaved(was));
+      .then(r => { if (!r.ok) throw new Error(); if (!was) flashToast('Saved to your reading list'); }).catch(() => setSaved(was));
   });
   const repost = guard(() => {
     if (cannotRepost) return;
-    const was = reposted; setReposted(!was);
+    const was = reposted; setReposted(!was); setRepostCount(c => Math.max(0, c + (was ? -1 : 1)));
     fetch(`/api/blogs/${post.id}/repost`, { method: was ? 'DELETE' : 'POST' })
-      .then(r => r.ok ? r.json() : Promise.reject()).then(d => setReposted(!!d.reposted)).catch(() => setReposted(was));
+      .then(r => r.ok ? r.json() : Promise.reject()).then(d => { setReposted(!!d.reposted); setRepostCount(d.count || 0); })
+      .catch(() => { setReposted(was); setRepostCount(c => Math.max(0, c + (was ? 1 : -1))); });
   });
 
   return (
@@ -322,6 +326,7 @@ function FeedCardActions({ post, onHide }) {
         style={{ color: reposted ? '#16a34a' : 'var(--text-muted)', opacity: cannotRepost ? 0.4 : 1, cursor: cannotRepost ? 'not-allowed' : 'pointer' }}
       >
         <svg className="w-[18px] h-[18px]" fill="none" stroke="currentColor" strokeWidth={1.6} viewBox="0 0 24 24" strokeLinecap="round" strokeLinejoin="round"><path d="M17 1l4 4-4 4" /><path d="M3 11V9a4 4 0 014-4h14" /><path d="M7 23l-4-4 4-4" /><path d="M21 13v2a4 4 0 01-4 4H3" /></svg>
+        {repostCount > 0 && <span>{repostCount}</span>}
       </button>
       <div className="ml-auto flex items-center gap-1">
         <button onClick={save} className="flex items-center justify-center w-8 h-8 rounded-full transition-colors" style={{ color: saved ? '#9b7bf7' : 'var(--text-faint)' }} title="Save to reading list" onMouseEnter={e => e.currentTarget.style.backgroundColor = 'var(--bg-hover)'} onMouseLeave={e => e.currentTarget.style.backgroundColor = 'transparent'}>
@@ -329,6 +334,11 @@ function FeedCardActions({ post, onHide }) {
         </button>
         <FeedCardMenu post={post} onHide={onHide} />
       </div>
+      {toast && (
+        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-[9999] flex items-center gap-2 px-4 py-2.5 rounded-xl text-[13px] font-medium" style={{ backgroundColor: 'var(--text-primary)', color: 'var(--bg-app)', boxShadow: '0 8px 30px rgba(0,0,0,0.3)' }}>
+          <ion-icon name="bookmark" style={{ fontSize: '15px' }} /> {toast}
+        </div>
+      )}
     </div>
   );
 }
@@ -342,28 +352,38 @@ function FeedCard({ post, onHide }) {
     <article className="group py-6" style={{ borderBottom: '1px solid var(--divider)' }}>
       <Link href={href} className="flex gap-5 cursor-pointer">
         <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 mb-2 text-[13px]" style={{ color: 'var(--text-secondary)' }}>
-            <AuthorStack authors={allAuthors} />
-            <span className="truncate">
-              {post.org && <>In <span className="font-medium" style={{ color: 'var(--text-primary)' }}>{post.org.name}</span> by </>}
-              <span className="font-medium" style={{ color: 'var(--text-primary)' }}>{author.display_name || author.username}</span>
-              {allAuthors.length > 1 && <span style={{ color: 'var(--text-faint)' }}> +{allAuthors.length - 1}</span>}
-            </span>
-            {post.is_staff && (
-              <span className="text-[9px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded flex-shrink-0" style={{ backgroundColor: '#9b7bf718', color: '#9b7bf7', border: '1px solid #9b7bf730' }}>Staff</span>
-            )}
-          </div>
+          {(() => {
+            const names = allAuthors.slice(0, 3).map(a => a.display_name || a.username);
+            const moreN = allAuthors.length - names.length;
+            const namesStr = names.join(' and ') + (moreN > 0 ? ` + ${moreN} more` : '');
+            const dateStr = post.published_at ? new Date(post.published_at * 1000).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) : '';
+            return (
+              <div className="flex items-center gap-2 mb-2 text-[14px]" style={{ color: 'var(--text-secondary)' }}>
+                <AuthorStack authors={allAuthors} />
+                <span className="truncate">
+                  {post.org && <>in <span className="font-medium" style={{ color: 'var(--text-primary)' }}>{post.org.name}</span> </>}
+                  by <span className="font-medium" style={{ color: 'var(--text-primary)' }}>{namesStr}</span>
+                  {dateStr && <span style={{ color: 'var(--text-faint)' }}> · {dateStr}</span>}
+                </span>
+                {post.is_staff && (
+                  <span className="text-[9px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded flex-shrink-0" style={{ backgroundColor: '#9b7bf718', color: '#9b7bf7', border: '1px solid #9b7bf730' }}>Staff</span>
+                )}
+              </div>
+            );
+          })()}
 
           <h2 className="text-[20px] font-extrabold leading-[1.25] mb-1 group-hover:opacity-80 transition-opacity tracking-[-0.01em]" style={{ color: 'var(--text-primary)', fontFamily: "'Source Serif 4', Georgia, serif" }}>
             {post.title || 'Untitled'}
           </h2>
           {post.subtitle && (
-            <p className="text-[15px] leading-[1.5] line-clamp-2 mb-2" style={{ color: 'var(--text-muted)' }}>{post.subtitle}</p>
+            <p className="text-[15px] font-medium leading-[1.5] line-clamp-1 mb-1" style={{ color: 'var(--text-muted)' }}>{post.subtitle}</p>
           )}
-          <div className="flex items-center gap-3 text-[12px]" style={{ color: 'var(--text-faint)' }}>
-            <span>{timeAgo(post.published_at)}</span>
+          {post.excerpt && (
+            <p className="text-[14px] leading-[1.55] line-clamp-2 mb-2" style={{ color: 'var(--text-faint)' }}>{post.excerpt}</p>
+          )}
+          <div className="flex items-center gap-3 text-[13px]" style={{ color: 'var(--text-faint)' }}>
             {(post.tags || []).slice(0, 1).map(tag => (
-              <span key={tag} className="text-[11px] px-2 py-0.5 rounded-full font-medium" style={{ backgroundColor: 'var(--bg-elevated)', color: 'var(--text-body)' }}>{tag}</span>
+              <span key={tag} className="text-[12px] px-2 py-0.5 rounded-full font-medium" style={{ backgroundColor: 'var(--bg-elevated)', color: 'var(--text-body)' }}>{tag}</span>
             ))}
             {post.read_time_minutes > 0 && <span>{post.read_time_minutes} min read</span>}
           </div>

--- a/src/styles/editor/editor.css
+++ b/src/styles/editor/editor.css
@@ -19,3 +19,20 @@
   background-color: transparent !important;
   background-image: none !important;
 }
+
+/* Prevent wide content (code, tables, images, embeds) from overflowing the
+   viewport on mobile in the blog reader. */
+.blog-preview-content img,
+.blog-preview-content table,
+.blog-preview-content iframe,
+.blog-preview-content video,
+.blog-preview-content pre {
+  max-width: 100%;
+}
+.blog-preview-content pre {
+  overflow-x: auto;
+}
+.blog-preview-content {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}

--- a/src/views/HandlePage.jsx
+++ b/src/views/HandlePage.jsx
@@ -162,7 +162,7 @@ function HandlePageInner({ path }) {
 
     return (
       <AppShell>
-        <div className="max-w-3xl mx-auto px-6 py-8">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 py-8 w-full overflow-x-hidden">
           {canEdit && (
             <div className="flex items-center justify-end mb-4">
               <Link
@@ -203,7 +203,7 @@ function HandlePageInner({ path }) {
               <BlogInteractionBar
                 blogId={blog.id}
                 blogAuthorId={blog.author_id}
-                canRepost={!isAuthor}
+                canRepost={!isAuthor && !myCoRole}
                 dotsMenu={
                   <BlogDotsMenu
                     blogId={blog.id}

--- a/src/views/WritePage.jsx
+++ b/src/views/WritePage.jsx
@@ -1908,9 +1908,9 @@ export default function WritePage({ slugid }) {
                   {/* Author bar — above title */}
                   <div className="flex items-center gap-3 mt-2 mb-2">
                     <div className="flex -space-x-2">
-                      <AvatarImg src={user?.avatar_url} name={user?.display_name || user?.username} size={28} />
+                      <AvatarImg src={user?.avatar_url} name={user?.display_name || user?.username} size={30} />
                     </div>
-                    <div className="flex items-center gap-2 text-[13px] text-[var(--text-faint)]">
+                    <div className="flex items-center gap-2 text-[15px] text-[var(--text-faint)]">
                       <span className="text-[var(--text-muted)] font-medium">{user?.display_name || user?.username || 'Author'}</span>
                       <span className="text-[var(--text-faint)]">·</span>
                       <span>{Math.max(1, Math.ceil(wordCount / 200))} min read</span>
@@ -1918,15 +1918,6 @@ export default function WritePage({ slugid }) {
                       <span>{wordCount} {wordCount === 1 ? 'word' : 'words'}</span>
                     </div>
                   </div>
-
-                  {/* Tags — shown under author bar */}
-                  {tags.length > 0 && (
-                    <div className="flex flex-wrap gap-1.5 mb-0">
-                      {tags.map((tag) => (
-                        <span key={tag} className="px-2.5 py-0.5 bg-[#9b7bf70a] rounded-full text-[12px] text-[#9b7bf7]">#{tag}</span>
-                      ))}
-                    </div>
-                  )}
 
                   {/* 30px gap before title */}
                   <div style={{ height: '30px' }} />
@@ -1967,6 +1958,15 @@ export default function WritePage({ slugid }) {
                           )
                         ))}
                       </div>
+                    )}
+                  </div>
+
+                  {/* Tags — always shown under the title (edit + publish) */}
+                  <div className="flex flex-wrap gap-1.5 mt-1 mb-2 min-h-[24px]">
+                    {tags.length > 0 ? tags.map((tag) => (
+                      <span key={tag} className="px-2.5 py-0.5 bg-[#9b7bf70a] rounded-full text-[13px] text-[#9b7bf7]">#{tag}</span>
+                    )) : (
+                      <span className="text-[12px]" style={{ color: 'var(--text-faint)' }}>Add tags from the publish panel →</span>
                     )}
                   </div>
 


### PR DESCRIPTION
## Changes Made
- `lib/excerpt.js` — New utility extracting a plain-text excerpt (≤200 chars) from BlockNote blocks, skipping non-prose types like images and code blocks
- `migrations/0031_blog_excerpt.sql` — Adds `excerpt TEXT` column to the `blogs` table
- `app/api/blogs/draft/route.js` — Computes and persists excerpt on draft save (both insert and update paths)
- `app/api/blogs/publish/route.js` — Computes and persists excerpt on publish (both insert and update paths)
- `app/api/feed/route.js` — Includes `b.excerpt` in feed query fields; adds batched repost count to feed enrichment
- `src/components/AppShell.jsx` — Hides "Sign In" link on mobile; renders "Get Started" as a round icon button on small screens
- `src/components/BlogInteractionBar.jsx` — Shows repost button for all users (disabled/greyed for authors and co-authors, count still visible); removes border dividers; switches to flex-wrap layout
- `src/index.jsx` — Displays repost count on feed cards; adds toast notification on save; tracks local repost count optimistically

## Checklist
- [ ] No Node built-ins imported (crypto, fs, path, stream, Buffer)
- [ ] New DB columns/tables have a migration in `src/workers/migrations/`
- [ ] `./biome.sh ci` clean
- [ ] Tested locally: <how>