### PR TITLE
[FEAT]: Attach the tags correctly to and UX fixes + name sanitation 

### DIFF
--- a/app/api/orgs/collections/route.js
+++ b/app/api/orgs/collections/route.js
@@ -37,7 +37,11 @@ export async function POST(request) {
     return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
   }
 
-  const cleanSlug = slug.toLowerCase().replace(/[^\w-]/g, '').slice(0, 40);
+  // Sanitize + validate the collection slug (alphanumeric, single hyphens, 6–48 chars).
+  const { validateSlug } = await import('../../../../lib/slugify');
+  const slugCheck = validateSlug(slug, { label: 'Collection slug' });
+  if (!slugCheck.ok) return NextResponse.json({ error: slugCheck.error }, { status: 400 });
+  const cleanSlug = slugCheck.slug;
 
   try {
     const { getDB } = await import('../../../../lib/cloudflare');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lixblogs",
-  "version": "4.9.38",
+  "version": "4.9.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lixblogs",
-      "version": "4.9.38",
+      "version": "4.9.39",
       "license": "MIT",
       "dependencies": {
         "@blocknote/core": "^0.47.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lixblogs",
-  "version": "4.9.38",
+  "version": "4.9.39",
   "description": "A modern blogging platform with a rich block editor, AI writing tools, real-time collaboration, and organizations — deployed on Cloudflare's edge.",
   "author": "Elixpo <https://github.com/elixpo>",
   "license": "MIT",

--- a/src/views/WritePage.jsx
+++ b/src/views/WritePage.jsx
@@ -434,6 +434,7 @@ export default function WritePage({ slugid }) {
   const [userOrgs, setUserOrgs] = useState([]);
   const [hasUnsavedEdits, setHasUnsavedEdits] = useState(false);
   const settingsSnapshotRef = useRef(''); // publish-settings as of load / last publish — for the no-change Update shortcut
+  const titleTextareaRef = useRef(null);
   const hadUserGestureRef = useRef(false);
   const bypassUnloadRef = useRef(false); // set during publish redirect to skip the leave prompt
   const dirtyRef = useRef(false); // true when there are edits not yet flushed to the cloud
@@ -775,7 +776,7 @@ export default function WritePage({ slugid }) {
         if (localNewer) {
           if (local.title) setTitle(local.title);
           if (local.subtitle) setSubtitle(local.subtitle);
-          if (local.tags) setTags(local.tags);
+          if (local.tags?.length) setTags(local.tags);
           if (local.coverPreview) setCoverPreview(local.coverPreview);
           if (local.coverPos) setCoverPos(local.coverPos);
           if (Number.isFinite(local.coverZoom)) setCoverZoom(local.coverZoom);
@@ -789,7 +790,7 @@ export default function WritePage({ slugid }) {
         // Brand-new blog not yet on the server — use the local buffer.
         if (local.title) setTitle(local.title);
         if (local.subtitle) setSubtitle(local.subtitle);
-        if (local.tags) setTags(local.tags);
+        if (local.tags?.length) setTags(local.tags);
         if (local.publishAs) setPublishAs(local.publishAs);
         if (local.coverPreview) setCoverPreview(local.coverPreview);
         if (local.coverPos) setCoverPos(local.coverPos);
@@ -1104,6 +1105,13 @@ export default function WritePage({ slugid }) {
       console.error('Failed to import markdown:', err);
     }
   }, []);
+
+  // Grow the title textarea to fit its content (on load + whenever title changes),
+  // not just on keystroke — otherwise long titles get clipped to one row.
+  useEffect(() => {
+    const el = titleTextareaRef.current;
+    if (el) { el.style.height = 'auto'; el.style.height = el.scrollHeight + 'px'; }
+  }, [title]);
 
   // Serialized publish-settings, used to detect "nothing changed" on Update.
   const settingsKey = () => JSON.stringify({ title, subtitle, tags, publishAs, pageEmoji, coverPreview, coverPos, coverZoom, slug });
@@ -1945,6 +1953,7 @@ export default function WritePage({ slugid }) {
                   {/* Title */}
                   <div className="relative">
                     <textarea
+                      ref={titleTextareaRef}
                       value={title}
                       onChange={(e) => {
                         setTitle(e.target.value);

--- a/src/views/WritePage.jsx
+++ b/src/views/WritePage.jsx
@@ -2055,7 +2055,7 @@ export default function WritePage({ slugid }) {
                       This blog already has the maximum of 5 live editors — you're viewing in read-only until a slot frees up.
                     </div>
                   )}
-                  <div className="min-h-[60vh] pb-[100px] relative">
+                  <div className="min-h-[60vh] mt-6 pb-[100px] relative">
                     <BlockNoteEditor
                       ref={editorRef}
                       onChange={handleEditorChange}

--- a/src/views/WritePage.jsx
+++ b/src/views/WritePage.jsx
@@ -1457,11 +1457,12 @@ export default function WritePage({ slugid }) {
                         if (!canPublish) return;
                         if (isPublished) {
                           // No edits since publish → skip the update entirely, just view it.
+                          // Otherwise open the publish panel; the final confirm happens there.
                           if (hasNoChanges()) {
                             bypassUnloadRef.current = true;
                             window.location.href = publishedUrl;
                           } else {
-                            setShowPublishConfirm(true);
+                            setShowPublishPanel(true);
                           }
                         } else {
                           setShowPublishPanel(!showPublishPanel);
@@ -2311,7 +2312,7 @@ export default function WritePage({ slugid }) {
         {/* Bottom actions */}
         <div className="p-5 space-y-2" style={{ borderTop: '1px solid var(--border-default)' }}>
           <button
-            onClick={handlePublish}
+            onClick={() => { if (isPublished) setShowPublishConfirm(true); else handlePublish(); }}
             disabled={!title.trim() || publishing || !hasUnsavedEdits}
             className="w-full py-2.5 bg-[#9b7bf7] text-white font-bold rounded-xl text-[13px] hover:bg-[#b69aff] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
           >
@@ -2416,7 +2417,7 @@ export default function WritePage({ slugid }) {
             ? 'This will push your changes live. Readers will see the updated version immediately.'
             : 'Your blog will be visible to everyone. You can unpublish it later from the publish settings.'}
           confirmLabel={isPublished ? 'Update' : 'Publish'}
-          onConfirm={() => { setShowPublishConfirm(false); setShowPublishPanel(true); }}
+          onConfirm={() => { setShowPublishConfirm(false); handlePublish(); }}
           onCancel={() => setShowPublishConfirm(false)}
         />
       )}


### PR DESCRIPTION
## Changes Made
- `app/api/orgs/collections/route.js` — Replaced ad-hoc slug sanitization with `validateSlug()` from `lib/slugify`; now validates length (6–48), single-hyphen rules, and returns a structured error instead of silently trimming.
- `src/views/WritePage.jsx` — Tag restore guards changed from `if (local.tags)` to `if (local.tags?.length)` so empty arrays no longer overwrite the server value with `[]`.
- `src/views/WritePage.jsx` — Added `titleTextareaRef` and a `useEffect` on `title` to auto-grow the title textarea on load and change, preventing long titles from being clipped to one row.
- `src/views/WritePage.jsx` — Published-blog "Update" button now opens the publish panel (`setShowPublishPanel`) instead of the confirm dialog, so the author can review settings before confirming.
- `src/views/WritePage.jsx` — Publish panel bottom button: for published blogs, clicking opens the confirm modal first; the confirm modal's `onConfirm` now calls `handlePublish()` directly instead of re-opening the publish panel.
- `src/views/WritePage.jsx` — Added `mt-6` above the editor container to give breathing room between title area and editor.
- `package.json` — Version bump 4.9.38 → 4.9.39.

## Checklist
- [ ] No Node built-ins imported (crypto, fs, path, stream, Buffer)
- [ ] `./biome.sh ci` clean
- [ ] Tested locally: <how>