### PR TITLE
[FIX]: UX for the write page and new loading page color 

### DIFF
--- a/app/api/blogs/draft/route.js
+++ b/app/api/blogs/draft/route.js
@@ -1,4 +1,7 @@
 export const runtime = 'edge';
+// Per-user editor data — must never be cached (CDN or browser), or one user can
+// get a stale/empty copy and the editor falls back to a local draft.
+export const dynamic = 'force-dynamic';
 import { NextResponse } from 'next/server';
 import { getSession } from '../../../../lib/auth';
 import { requestTooLarge, byteLength, MAX_BLOG_CONTENT_BYTES } from '../../../../lib/limits';
@@ -99,7 +102,7 @@ export async function GET(request) {
         is_owner: isOwner,
       },
       version,
-    });
+    }, { headers: { 'Cache-Control': 'no-store, no-cache, must-revalidate' } });
   } catch (e) {
     console.error('Draft fetch error:', e);
     return NextResponse.json({ error: 'Failed to load blog' }, { status: 500 });

--- a/app/new-blog/page.jsx
+++ b/app/new-blog/page.jsx
@@ -31,7 +31,7 @@ export default function New() {
   }, [router]);
 
   return (
-    <div className="min-h-screen bg-[#131922] flex items-center justify-center">
+    <div className="min-h-screen bg-[var(--bg-app)] flex items-center justify-center">
       <div className="w-6 h-6 border-2 border-[#9b7bf7] border-t-transparent rounded-full animate-spin" />
     </div>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lixblogs",
-  "version": "4.9.39",
+  "version": "4.9.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lixblogs",
-      "version": "4.9.39",
+      "version": "4.9.40",
       "license": "MIT",
       "dependencies": {
         "@blocknote/core": "^0.47.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lixblogs",
-  "version": "4.9.39",
+  "version": "4.9.40",
   "description": "A modern blogging platform with a rich block editor, AI writing tools, real-time collaboration, and organizations — deployed on Cloudflare's edge.",
   "author": "Elixpo <https://github.com/elixpo>",
   "license": "MIT",

--- a/src/views/WritePage.jsx
+++ b/src/views/WritePage.jsx
@@ -435,6 +435,7 @@ export default function WritePage({ slugid }) {
   const [hasUnsavedEdits, setHasUnsavedEdits] = useState(false);
   const settingsSnapshotRef = useRef(''); // publish-settings as of load / last publish — for the no-change Update shortcut
   const titleTextareaRef = useRef(null);
+  const loadedRef = useRef(false); // true once the initial cloud/local load has populated state
   const hadUserGestureRef = useRef(false);
   const bypassUnloadRef = useRef(false); // set during publish redirect to skip the leave prompt
   const dirtyRef = useRef(false); // true when there are edits not yet flushed to the cloud
@@ -771,8 +772,11 @@ export default function WritePage({ slugid }) {
         // Content: use the server copy unless localStorage holds strictly newer
         // unsaved edits (saved after the last cloud sync). This restores published
         // posts (incl. mentions) reliably while still preserving local work.
+        // Only prefer the local draft when we have a known cloud timestamp AND the
+        // local copy is strictly newer. Without a cloud time, trust the server copy
+        // (otherwise a stale localStorage draft hides the real title/tags/subtitle).
         const cloudUpdatedMs = (version?.updatedAt || 0) * 1000;
-        const localNewer = local?.editorContent && (local.savedAt || 0) > cloudUpdatedMs + 1500;
+        const localNewer = local?.editorContent && cloudUpdatedMs > 0 && (local.savedAt || 0) > cloudUpdatedMs + 1500;
         if (localNewer) {
           if (local.title) setTitle(local.title);
           if (local.subtitle) setSubtitle(local.subtitle);
@@ -800,11 +804,15 @@ export default function WritePage({ slugid }) {
         setEditorContent(local.editorContent);
       }
       setDraftLoading(false);
+      // Defer so the state updates above don't trip the autosave effect as "edits".
+      setTimeout(() => { loadedRef.current = true; }, 0);
     }, 80);
     return () => clearTimeout(timer);
   }, [slugid]);
 
   useEffect(() => {
+    // Ignore the state changes from the initial load — only real edits are dirty.
+    if (!loadedRef.current) return;
     if (autoSaveTimer.current) clearTimeout(autoSaveTimer.current);
     setHasUnsavedEdits(true);
     dirtyRef.current = true;

--- a/src/views/WritePage.jsx
+++ b/src/views/WritePage.jsx
@@ -729,12 +729,17 @@ export default function WritePage({ slugid }) {
   }, [hasUnsavedEdits]);
 
   useEffect(() => {
+    // Re-arm the load guard so that, if the editor ever stays mounted across a
+    // slugid change, the next blog's initial load isn't treated as user edits,
+    // and the no-change snapshot re-captures for the new blog.
+    loadedRef.current = false;
+    settingsSnapshotRef.current = '';
     const timer = setTimeout(async () => {
       // Resolve the URL param (slug or id) against the server, which returns the
       // canonical blog id. localStorage is keyed by that id, so look it up after.
       let cloud = null, version = null;
       try {
-        const res = await fetch(`/api/blogs/draft?slugid=${encodeURIComponent(slugid)}`);
+        const res = await fetch(`/api/blogs/draft?slugid=${encodeURIComponent(slugid)}`, { cache: 'no-store' });
         if (res.ok) {
           const data = await res.json();
           cloud = data.blog || null;


### PR DESCRIPTION
## Changes Made
- `app/new-blog/page.jsx` — Replaced hardcoded `bg-[#131922]` with `bg-[var(--bg-app)]` so the loading spinner page respects the app's CSS variable theme instead of a fixed dark color.
- `src/views/WritePage.jsx` — Added `loadedRef` to track when the initial cloud/local load has finished populating state.
- `src/views/WritePage.jsx` — Fixed stale-local-draft logic: now requires `cloudUpdatedMs > 0` before preferring a localStorage draft over the server copy, preventing a stale local draft from overwriting the real title/tags/subtitle when no cloud timestamp exists.
- `src/views/WritePage.jsx` — Guarded the autosave/dirty effect with `if (!loadedRef.current) return` so state changes from the initial load don't incorrectly mark the document as having unsaved edits.

## Checklist
- [ ] No Node built-ins imported (crypto, fs, path, stream, Buffer)
- [ ] `./biome.sh ci` clean
- [ ] Tested locally: <how>