### PR TITLE
[FIX]: Sign out behaviour on edit blogs

### DIFF
--- a/app/api/blogs/draft/route.js
+++ b/app/api/blogs/draft/route.js
@@ -6,14 +6,18 @@ import { NextResponse } from 'next/server';
 import { getSession } from '../../../../lib/auth';
 import { requestTooLarge, byteLength, MAX_BLOG_CONTENT_BYTES } from '../../../../lib/limits';
 
+// Never let any editor-data response be cached — a signed-out 401 (or one
+// user's data) must not be replayed to another state/user from cache.
+const NO_STORE = { 'Cache-Control': 'no-store, no-cache, must-revalidate' };
+
 // GET — fetch blog data for editing
 export async function GET(request) {
   const session = await getSession();
-  if (!session?.userId) return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  if (!session?.userId) return NextResponse.json({ error: 'Not authenticated' }, { status: 401, headers: NO_STORE });
 
   const { searchParams } = new URL(request.url);
   const slugid = searchParams.get('slugid');
-  if (!slugid) return NextResponse.json({ error: 'Missing slugid' }, { status: 400 });
+  if (!slugid) return NextResponse.json({ error: 'Missing slugid' }, { status: 400, headers: NO_STORE });
 
   try {
     const { getDB } = await import('../../../../lib/cloudflare');
@@ -40,7 +44,7 @@ export async function GET(request) {
       `).bind(slugid, session.userId, session.userId, session.userId).first();
     }
 
-    if (!blog) return NextResponse.json({ error: 'Blog not found' }, { status: 404 });
+    if (!blog) return NextResponse.json({ error: 'Blog not found' }, { status: 404, headers: NO_STORE });
 
     const blogId = blog.id;
 
@@ -63,9 +67,9 @@ export async function GET(request) {
             role: invite.role,
             status: invite.status,
           },
-        }, { status: 403 });
+        }, { status: 403, headers: NO_STORE });
       }
-      return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
+      return NextResponse.json({ error: 'Not authorized' }, { status: 403, headers: NO_STORE });
     }
 
     // Decompress content
@@ -102,10 +106,10 @@ export async function GET(request) {
         is_owner: isOwner,
       },
       version,
-    }, { headers: { 'Cache-Control': 'no-store, no-cache, must-revalidate' } });
+    }, { headers: NO_STORE });
   } catch (e) {
     console.error('Draft fetch error:', e);
-    return NextResponse.json({ error: 'Failed to load blog' }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to load blog' }, { status: 500, headers: NO_STORE });
   }
 }
 

--- a/app/api/feed/route.js
+++ b/app/api/feed/route.js
@@ -60,7 +60,7 @@ export async function GET(request) {
         posts = await enrichPosts(db, posts, null);
         return { posts, page, hasMore: posts.length === limit };
       });
-      return NextResponse.json(cached);
+      return NextResponse.json(cached, { headers: { 'Cache-Control': 'no-store' } });
     }
 
     const { getDB } = await import('../../../lib/cloudflare');
@@ -87,7 +87,7 @@ export async function GET(request) {
       posts,
       page,
       hasMore: posts.length === limit,
-    });
+    }, { headers: { 'Cache-Control': 'no-store' } });
   } catch (e) {
     console.error('Feed error:', e?.message || e);
     return NextResponse.json({ posts: [], page, hasMore: false });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lixblogs",
-  "version": "4.9.40",
+  "version": "4.9.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lixblogs",
-      "version": "4.9.40",
+      "version": "4.9.41",
       "license": "MIT",
       "dependencies": {
         "@blocknote/core": "^0.47.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lixblogs",
-  "version": "4.9.40",
+  "version": "4.9.41",
   "description": "A modern blogging platform with a rich block editor, AI writing tools, real-time collaboration, and organizations — deployed on Cloudflare's edge.",
   "author": "Elixpo <https://github.com/elixpo>",
   "license": "MIT",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -557,7 +557,7 @@ export default function App() {
     if (tagFilter) url += `&tag=${encodeURIComponent(tagFilter)}`;
     else if (topics[activeTopic]?.filter) url += `&filter=${topics[activeTopic].filter}`;
 
-    fetch(url)
+    fetch(url, { cache: 'no-store' })
       .then(r => r.json())
       .then(data => setPosts(data.posts || []))
       .catch(() => setPosts([]))


### PR DESCRIPTION
## Changes Made
- Added `NO_STORE` constant in `app/api/blogs/draft/route.js` with `Cache-Control: no-store, no-cache, must-revalidate` headers to prevent any editor-data response from being cached.
- Applied `NO_STORE` to the 401 unauthenticated response — a signed-out 401 must not be cached and replayed to a different session state.
- Applied `NO_STORE` to 400, 404, and both 403 error responses — error pages previously had no cache headers, allowing stale cached errors to mask fresh auth state.
- Replaced the inline `Cache-Control` object on the 200 success response with the shared `NO_STORE` constant, keeping the same behavior but consolidated.
- Applied `NO_STORE` to the 500 error response — previously had no cache headers.

## Checklist
- [ ] No Node built-ins imported (crypto, fs, path, stream, Buffer)
- [ ] `./biome.sh ci` clean
- [ ] Tested locally: <how>