### PR TITLE
[FEAT]: corrected the reshare and the stories route for the blogs

### DIFF
--- a/app/api/blogs/[slugid]/repost/route.js
+++ b/app/api/blogs/[slugid]/repost/route.js
@@ -43,8 +43,31 @@ export async function POST(request, { params }) {
     const own = await isOwnBlog(db, slugid, session.userId);
     if (own.notFound) return NextResponse.json({ error: 'Blog not found' }, { status: 404 });
     if (own.own) return NextResponse.json({ error: "You can't repost your own blog" }, { status: 400 });
+    const wasNew = await db.prepare('SELECT 1 FROM reposts WHERE user_id = ? AND blog_id = ?').bind(session.userId, slugid).first();
     await db.prepare('INSERT OR IGNORE INTO reposts (user_id, blog_id) VALUES (?, ?)').bind(session.userId, slugid).run();
     const countRow = await db.prepare('SELECT COUNT(*) AS c FROM reposts WHERE blog_id = ?').bind(slugid).first();
+
+    // Notify the blog owner (best-effort, only on a fresh repost).
+    if (!wasNew) {
+      try {
+        const { notify } = await import('../../../../../lib/notify');
+        const blog = await db.prepare(
+          'SELECT b.author_id, b.slug, u.username FROM blogs b JOIN users u ON u.id = b.author_id WHERE b.id = ?'
+        ).bind(slugid).first();
+        if (blog && blog.author_id !== session.userId) {
+          const actor = session.profile || {};
+          await notify(db, {
+            userId: blog.author_id,
+            type: 'repost',
+            actorId: session.userId,
+            actorName: actor.display_name || actor.username || 'Someone',
+            actorAvatar: actor.avatar_url || '',
+            targetUrl: `/${blog.username}/${blog.slug}`,
+          });
+        }
+      } catch {}
+    }
+
     return NextResponse.json({ reposted: true, count: countRow?.c || 0 });
   } catch {
     return NextResponse.json({ error: 'Failed' }, { status: 500 });

--- a/app/api/blogs/list/route.js
+++ b/app/api/blogs/list/route.js
@@ -9,19 +9,46 @@ export async function GET(request) {
   }
 
   const { searchParams } = new URL(request.url);
-  const status = searchParams.get('status'); // 'draft', 'published', 'unlisted', or null for all
+  const status = searchParams.get('status'); // 'draft' | 'published' | 'unlisted' | null
+  const filter = searchParams.get('filter'); // 'reshared' → blogs the user reposted
+  const sort = searchParams.get('sort');      // 'views' | 'likes' | 'comments' | null (recent)
+  const orderBy = sort === 'views' ? 'views DESC'
+    : sort === 'likes' ? 'likes DESC'
+    : sort === 'comments' ? 'comments DESC'
+    : null;
+
+  const COUNTS = `
+    (SELECT COUNT(*) FROM blog_views WHERE blog_id = b.id) as views,
+    (SELECT COUNT(*) FROM likes WHERE blog_id = b.id) as likes,
+    (SELECT COUNT(*) FROM comments WHERE blog_id = b.id) as comments`;
 
   try {
     const { getDB } = await import('../../../../lib/cloudflare');
     const db = getDB();
 
+    // Reshared = blogs THIS user reposted (authored by others).
+    if (filter === 'reshared') {
+      const rows = await db.prepare(`
+        SELECT b.id, b.id as slugid, b.slug, b.title, b.subtitle, b.status,
+          b.page_emoji, b.cover_image_r2_key, b.read_time_minutes,
+          b.published_as, b.created_at, b.updated_at, b.published_at,
+          u.username as author_username, u.display_name as author_name, u.avatar_url as author_avatar,
+          r.created_at as reshared_at, ${COUNTS}
+        FROM reposts r
+        JOIN blogs b ON b.id = r.blog_id AND b.status = 'published'
+        JOIN users u ON u.id = b.author_id
+        WHERE r.user_id = ?
+        ORDER BY r.created_at DESC LIMIT 50
+      `).bind(session.userId).all();
+      return NextResponse.json({ blogs: rows?.results || [] });
+    }
+
     let query = `
       SELECT b.id, b.id as slugid, b.slug, b.title, b.subtitle, b.status,
         b.page_emoji, b.cover_image_r2_key, b.read_time_minutes,
         b.published_as, b.created_at, b.updated_at, b.published_at,
-        (SELECT COUNT(*) FROM blog_views WHERE blog_id = b.id) as views,
-        (SELECT COUNT(*) FROM likes WHERE blog_id = b.id) as likes,
-        (SELECT COUNT(*) FROM comments WHERE blog_id = b.id) as comments
+        EXISTS(SELECT 1 FROM reposts WHERE blog_id = b.id) as is_reshared,
+        ${COUNTS}
       FROM blogs b
       WHERE b.author_id = ?
     `;
@@ -32,7 +59,7 @@ export async function GET(request) {
       params.push(status);
     }
 
-    query += ' ORDER BY b.updated_at DESC LIMIT 50';
+    query += ` ORDER BY ${orderBy || 'b.updated_at DESC'} LIMIT 50`;
 
     const blogs = await db.prepare(query).bind(...params).all();
 

--- a/app/api/feed/route.js
+++ b/app/api/feed/route.js
@@ -309,17 +309,19 @@ async function enrichPosts(db, posts, userId) {
     for (const r of (rows?.results || [])) repostMap[r.blog_id] = r.c;
   }
 
-  // The viewer's like / bookmark / co-author state for these posts (batched).
-  let likedSet = new Set(), bookmarkedSet = new Set(), coAuthoredSet = new Set();
+  // The viewer's like / bookmark / co-author / repost state for these posts (batched).
+  let likedSet = new Set(), bookmarkedSet = new Set(), coAuthoredSet = new Set(), repostedSet = new Set();
   if (userId) {
-    const [likeRows, bmRows, caRows] = await Promise.all([
+    const [likeRows, bmRows, caRows, rpRows] = await Promise.all([
       batchQuery(db, 'SELECT blog_id FROM likes WHERE user_id = ? AND blog_id IN', blogIds, [userId]),
       batchQuery(db, 'SELECT blog_id FROM bookmarks WHERE user_id = ? AND blog_id IN', blogIds, [userId]),
       batchQuery(db, "SELECT blog_id FROM blog_co_authors WHERE status = 'accepted' AND user_id = ? AND blog_id IN", blogIds, [userId]),
+      batchQuery(db, 'SELECT blog_id FROM reposts WHERE user_id = ? AND blog_id IN', blogIds, [userId]),
     ]);
     likedSet = new Set(likeRows.map(r => r.blog_id));
     bookmarkedSet = new Set(bmRows.map(r => r.blog_id));
     coAuthoredSet = new Set(caRows.map(r => r.blog_id));
+    repostedSet = new Set(rpRows.map(r => r.blog_id));
   }
 
   // Lazily backfill excerpts for posts published before the excerpt column
@@ -366,6 +368,7 @@ async function enrichPosts(db, posts, userId) {
       is_author: !!isAuthor,
       is_co_author: coAuthoredSet.has(p.id),
       repost_count: repostMap[p.id] || 0,
+      reposted: repostedSet.has(p.id),
       liked: likedSet.has(p.id),
       bookmarked: bookmarkedSet.has(p.id),
     };

--- a/app/api/feed/route.js
+++ b/app/api/feed/route.js
@@ -118,6 +118,23 @@ async function queryFollowing(db, userId, now, limit, offset) {
   return result?.results || [];
 }
 
+// ─── Reposts by people you follow (surfaced in the Following bucket) ──
+async function queryFollowedReposts(db, userId, now, limit) {
+  const cutoff = now - 30 * 86400;
+  const result = await db.prepare(`
+    SELECT ${BLOG_FIELDS}, r.user_id AS reshared_by_id, r.created_at AS reshared_at
+    FROM reposts r
+    JOIN blogs b ON b.id = r.blog_id
+    WHERE r.user_id IN (SELECT following_id FROM follows WHERE follower_id = ? AND following_type = 'user')
+      AND b.status = 'published'${EXCLUDE_TEST}
+      AND b.author_id != ?
+      AND r.created_at > ?
+    ORDER BY r.created_at DESC
+    LIMIT ?
+  `).bind(userId, userId, cutoff, limit).all();
+  return result?.results || [];
+}
+
 // ─── Bucket B: Interest-matched (explicit picks + implicit taste signals) ──
 async function queryInterests(db, userId, now, limit) {
   const cutoff = now - 14 * 86400;
@@ -204,27 +221,30 @@ async function queryRecent(db, limit, offset = 0) {
 
 // ─── Blended feed (3 buckets merged in JS) ───────────────────────────
 async function queryBlended(db, userId, now, limit) {
-  const [following, interests, trending] = await Promise.all([
+  const [reposts, following, interests, trending] = await Promise.all([
+    queryFollowedReposts(db, userId, now, 15),
     queryFollowing(db, userId, now, 15, 0),
     queryInterests(db, userId, now, 15),
     queryTrending(db, now, 20, 0),
   ]);
 
-  // Deduplicate by ID
+  // Deduplicate by ID. Reposts go FIRST so a post reshared by someone you follow
+  // claims the slot (carrying reshared_by_id) and gets top priority.
   const seen = new Set();
   const all = [];
-  for (const post of [...following, ...interests, ...trending]) {
+  for (const post of [...reposts, ...following, ...interests, ...trending]) {
     if (!seen.has(post.id)) {
       seen.add(post.id);
 
       // Score
+      const isReshared = !!post.reshared_by_id;
       const isFollowed = following.some(p => p.id === post.id);
       const isInterest = interests.some(p => p.id === post.id);
-      const hoursSince = Math.max(0, (now - post.published_at) / 3600);
+      const hoursSince = Math.max(0, (now - (post.reshared_at || post.published_at)) / 3600);
       const recency = Math.max(0, 20 - hoursSince / 12);
       const engagement = Math.min(20, (post.like_count || 0) * 0.5 + (post.comment_count || 0) * 1.5 + (post.recent_views || 0) * 0.1);
 
-      post._score = (isFollowed ? 50 : 0) + (isInterest ? 30 : 0) + engagement + recency;
+      post._score = (isReshared ? 70 : 0) + (isFollowed ? 50 : 0) + (isInterest ? 30 : 0) + engagement + recency;
       all.push(post);
     }
   }
@@ -250,7 +270,7 @@ async function queryBlended(db, userId, now, limit) {
 async function enrichPosts(db, posts, userId) {
   if (posts.length === 0) return posts;
 
-  const authorIds = [...new Set(posts.map(p => p.author_id))];
+  const authorIds = [...new Set([...posts.map(p => p.author_id), ...posts.filter(p => p.reshared_by_id).map(p => p.reshared_by_id)])];
   const blogIds = posts.map(p => p.id);
 
   const [authors, tags] = await Promise.all([
@@ -369,6 +389,7 @@ async function enrichPosts(db, posts, userId) {
       is_co_author: coAuthoredSet.has(p.id),
       repost_count: repostMap[p.id] || 0,
       reposted: repostedSet.has(p.id),
+      reshared_by: p.reshared_by_id ? (authorMap[p.reshared_by_id] || null) : null,
       liked: likedSet.has(p.id),
       bookmarked: bookmarkedSet.has(p.id),
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lixblogs",
-  "version": "4.9.46",
+  "version": "4.9.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lixblogs",
-      "version": "4.9.46",
+      "version": "4.9.47",
       "license": "MIT",
       "dependencies": {
         "@blocknote/core": "^0.47.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lixblogs",
-  "version": "4.9.46",
+  "version": "4.9.47",
   "description": "A modern blogging platform with a rich block editor, AI writing tools, real-time collaboration, and organizations — deployed on Cloudflare's edge.",
   "author": "Elixpo <https://github.com/elixpo>",
   "license": "MIT",

--- a/src/components/BlogComments.jsx
+++ b/src/components/BlogComments.jsx
@@ -25,6 +25,8 @@ export default function BlogComments({ blogId, blogAuthorId }) {
   const [replyTo, setReplyTo] = useState(null); // { id, username }
   const [replyText, setReplyText] = useState('');
   const [editing, setEditing] = useState(null); // { id, content }
+  const [toast, setToast] = useState('');
+  const flashToast = (m) => { setToast(m); setTimeout(() => setToast(''), 2200); };
 
   const fetchComments = useCallback(async () => {
     try {
@@ -53,6 +55,7 @@ export default function BlogComments({ blogId, blogAuthorId }) {
         if (parentId) { setReplyText(''); setReplyTo(null); }
         else setNewComment('');
         fetchComments();
+        flashToast(parentId ? 'Reply posted' : 'Comment posted');
       }
     } catch {}
     setPosting(false);
@@ -86,6 +89,11 @@ export default function BlogComments({ blogId, blogAuthorId }) {
 
   return (
     <div className="mt-10" id="comments">
+      {toast && (
+        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-[9999] flex items-center gap-2 px-4 py-2.5 rounded-xl text-[13px] font-medium" style={{ backgroundColor: 'var(--text-primary)', color: 'var(--bg-app)', boxShadow: '0 8px 30px rgba(0,0,0,0.3)' }}>
+          <ion-icon name="checkmark-circle" style={{ fontSize: '15px' }} /> {toast}
+        </div>
+      )}
       <h3 className="text-[18px] font-bold mb-6" style={{ color: 'var(--text-primary)' }}>
         Comments {total > 0 && <span className="text-[14px] font-normal" style={{ color: 'var(--text-faint)' }}>({total})</span>}
       </h3>

--- a/src/components/BlogInteractionBar.jsx
+++ b/src/components/BlogInteractionBar.jsx
@@ -14,6 +14,8 @@ export default function BlogInteractionBar({ blogId, blogAuthorId, canRepost = f
   const [clapAnim, setClapAnim] = useState(false);
   const [reposted, setReposted] = useState(false);
   const [repostCount, setRepostCount] = useState(0);
+  const [toast, setToast] = useState('');
+  const flashToast = (m) => { setToast(m); setTimeout(() => setToast(''), 2200); };
 
   // Repost state — always fetch the count (shown even on your own blog).
   useEffect(() => {
@@ -30,7 +32,7 @@ export default function BlogInteractionBar({ blogId, blogAuthorId, canRepost = f
     setReposted(!was); setRepostCount(c => c + (was ? -1 : 1));
     fetch(`/api/blogs/${blogId}/repost`, { method: was ? 'DELETE' : 'POST' })
       .then(r => r.ok ? r.json() : Promise.reject())
-      .then(d => { setReposted(!!d.reposted); setRepostCount(d.count || 0); })
+      .then(d => { setReposted(!!d.reposted); setRepostCount(d.count || 0); if (!was) flashToast('Reposted to your followers'); })
       .catch(() => { setReposted(was); setRepostCount(c => c + (was ? 1 : -1)); });
   };
   const startTime = useRef(Date.now());
@@ -215,6 +217,11 @@ export default function BlogInteractionBar({ blogId, blogAuthorId, canRepost = f
 
   return (
     <div className="flex items-center justify-between gap-x-1 gap-y-1 flex-wrap py-1">
+      {toast && (
+        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-[9999] flex items-center gap-2 px-4 py-2.5 rounded-xl text-[13px] font-medium" style={{ backgroundColor: 'var(--text-primary)', color: 'var(--bg-app)', boxShadow: '0 8px 30px rgba(0,0,0,0.3)' }}>
+          <ion-icon name="checkmark-circle" style={{ fontSize: '15px' }} /> {toast}
+        </div>
+      )}
       {/* Left — engagement actions */}
       <div className="flex items-center gap-1">
         {/* Like */}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -272,7 +272,7 @@ function FeedCardActions({ post, onHide }) {
   const [liked, setLiked] = useState(!!post.liked);
   const [likeCount, setLikeCount] = useState(post.like_count || 0);
   const [saved, setSaved] = useState(!!post.bookmarked);
-  const [reposted, setReposted] = useState(false);
+  const [reposted, setReposted] = useState(!!post.reposted);
   const [repostCount, setRepostCount] = useState(post.repost_count || 0);
   const [toast, setToast] = useState('');
   const href = `/${(post.org?.slug) || post.author?.username || 'unknown'}/${post.slug}`;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -350,6 +350,12 @@ function FeedCard({ post, onHide }) {
   const allAuthors = [{ display_name: author.display_name, username: author.username, avatar_url: author.avatar_url }, ...(post.co_authors || [])];
   return (
     <article className="group py-6" style={{ borderBottom: '1px solid var(--divider)' }}>
+      {post.reshared_by && (
+        <div className="flex items-center gap-1.5 mb-2 text-[12px] font-medium" style={{ color: 'var(--text-faint)' }}>
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth={1.8} viewBox="0 0 24 24" strokeLinecap="round" strokeLinejoin="round"><path d="M17 1l4 4-4 4" /><path d="M3 11V9a4 4 0 014-4h14" /><path d="M7 23l-4-4 4-4" /><path d="M21 13v2a4 4 0 01-4 4H3" /></svg>
+          Reposted by {post.reshared_by.display_name || post.reshared_by.username}
+        </div>
+      )}
       <Link href={href} className="flex gap-5 cursor-pointer">
         <div className="flex-1 min-w-0">
           {(() => {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -301,7 +301,7 @@ function FeedCardActions({ post, onHide }) {
     if (cannotRepost) return;
     const was = reposted; setReposted(!was); setRepostCount(c => Math.max(0, c + (was ? -1 : 1)));
     fetch(`/api/blogs/${post.id}/repost`, { method: was ? 'DELETE' : 'POST' })
-      .then(r => r.ok ? r.json() : Promise.reject()).then(d => { setReposted(!!d.reposted); setRepostCount(d.count || 0); })
+      .then(r => r.ok ? r.json() : Promise.reject()).then(d => { setReposted(!!d.reposted); setRepostCount(d.count || 0); if (!was) flashToast('Reposted to your followers'); })
       .catch(() => { setReposted(was); setRepostCount(c => Math.max(0, c + (was ? 1 : -1))); });
   });
 

--- a/src/views/StoriesPage.jsx
+++ b/src/views/StoriesPage.jsx
@@ -9,16 +9,36 @@ import Link from 'next/link';
 const TABS = [
   { label: 'Drafts', icon: 'document-outline' },
   { label: 'Published', icon: 'globe-outline' },
+  { label: 'Reshared', icon: 'repeat-outline' },
 ];
 
-function StoryCard({ story, onDelete }) {
+const SORTS = [
+  { key: '', label: 'Latest' },
+  { key: 'views', label: 'Most viewed' },
+  { key: 'likes', label: 'Most liked' },
+  { key: 'comments', label: 'Most commented' },
+];
+
+function StoryCard({ story, onDelete, reshared }) {
   const isDraft = story.status === 'draft';
   const editUrl = `/edit/${story.slug || story.slugid || story.id}`;
+  const viewUrl = `/${story.author_username || 'blog'}/${story.slug}`;
+  const href = reshared ? viewUrl : editUrl;
 
   return (
     <article className="flex gap-5 py-6 border-b border-[var(--border-default)] last:border-b-0">
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2 mb-2">
+          {reshared && (
+            <span className="text-[11px] font-medium flex items-center gap-1 text-[#16a34a] bg-[#16a34a14] px-2 py-0.5 rounded-full">
+              <ion-icon name="repeat-outline" style={{ fontSize: '12px' }} /> Reshared{story.author_name ? ` · ${story.author_name}` : ''}
+            </span>
+          )}
+          {!reshared && story.is_reshared ? (
+            <span className="text-[11px] font-medium flex items-center gap-1 text-[#16a34a] bg-[#16a34a14] px-2 py-0.5 rounded-full">
+              <ion-icon name="repeat-outline" style={{ fontSize: '12px' }} /> Reshared
+            </span>
+          ) : null}
           {isDraft && (
             <span className="text-[11px] font-medium text-[#e8a840] bg-[#e8a84014] px-2 py-0.5 rounded-full">Draft</span>
           )}
@@ -36,7 +56,7 @@ function StoryCard({ story, onDelete }) {
             </span>
           )}
         </div>
-        <Link href={editUrl}>
+        <Link href={href}>
           <h3 className="text-[17px] font-bold leading-[1.35] mb-1 font-serif hover:opacity-75 transition-opacity" style={{ color: 'var(--text-primary)' }}>
             {story.title || 'Untitled'}
           </h3>
@@ -64,14 +84,16 @@ function StoryCard({ story, onDelete }) {
           {story.read_time_minutes > 0 && (
             <span>{story.read_time_minutes} min read</span>
           )}
-          <span className="ml-auto flex items-center gap-2">
-            <Link href={editUrl} className="hover:text-[var(--text-body)] transition-colors p-1" title="Edit">
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" /></svg>
-            </Link>
-            <button onClick={() => onDelete?.(story)} className="hover:text-red-400 transition-colors p-1" title="Delete">
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" /></svg>
-            </button>
-          </span>
+          {!reshared && (
+            <span className="ml-auto flex items-center gap-2">
+              <Link href={editUrl} className="hover:text-[var(--text-body)] transition-colors p-1" title="Edit">
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" /></svg>
+              </Link>
+              <button onClick={() => onDelete?.(story)} className="hover:text-red-400 transition-colors p-1" title="Delete">
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" /></svg>
+              </button>
+            </span>
+          )}
         </div>
       </div>
     </article>
@@ -81,21 +103,22 @@ function StoryCard({ story, onDelete }) {
 export default function StoriesPage() {
   const { user, loading } = useAuth();
   const [activeTab, setActiveTab] = useState(0);
-  const [blogs, setBlogs] = useState([]);
+  const [sort, setSort] = useState('');
+  const [stories, setStories] = useState([]);
   const [blogsLoading, setBlogsLoading] = useState(true);
 
   useEffect(() => {
     if (!user) return;
-    fetch('/api/blogs/list')
+    setBlogsLoading(true);
+    const url = activeTab === 0 ? '/api/blogs/list?status=draft'
+      : activeTab === 1 ? `/api/blogs/list?status=published${sort ? `&sort=${sort}` : ''}`
+      : '/api/blogs/list?filter=reshared';
+    fetch(url)
       .then(r => r.ok ? r.json() : { blogs: [] })
-      .then(d => setBlogs(d.blogs || []))
-      .catch(() => {})
+      .then(d => setStories(d.blogs || []))
+      .catch(() => setStories([]))
       .finally(() => setBlogsLoading(false));
-  }, [user]);
-
-  const drafts = blogs.filter(b => b.status === 'draft');
-  const published = blogs.filter(b => b.status === 'published' || b.status === 'unlisted');
-  const stories = activeTab === 0 ? drafts : published;
+  }, [user, activeTab, sort]);
 
   const [confirmTarget, setConfirmTarget] = useState(null);
   const [deleting, setDeleting] = useState(false);
@@ -142,20 +165,31 @@ export default function StoriesPage() {
     <AppShell>
       <div className="max-w-3xl mx-auto px-6 py-10">
         <div className="flex items-center justify-between mb-8">
-          <h1 className="text-[var(--text-muted)]xl font-bold text-[var(--text-primary)]">Your Stories</h1>
+          <h1 className="text-3xl font-bold" style={{ color: 'var(--text-primary)' }}>Your Stories</h1>
           <Link
             href="/new-blog"
-            className="px-5 py-2 text-[13px] font-medium text-[var(--text-primary)] bg-[#9b7bf7] hover:bg-[#b69aff] rounded-full transition-colors"
+            className="px-5 py-2 text-[13px] font-medium text-white bg-[#9b7bf7] hover:bg-[#b69aff] rounded-full transition-colors"
           >
             Write a story
           </Link>
         </div>
 
-        <TabBar
-          tabs={TABS.map((t, i) => ({ ...t, count: i === 0 ? drafts.length : published.length }))}
-          active={activeTab}
-          onChange={setActiveTab}
-        />
+        <div className="flex items-center justify-between gap-3 flex-wrap">
+          <TabBar tabs={TABS} active={activeTab} onChange={setActiveTab} />
+          {activeTab === 1 && (
+            <div className="flex items-center gap-1.5 text-[13px]">
+              <span style={{ color: 'var(--text-faint)' }}>Sort:</span>
+              <select
+                value={sort}
+                onChange={(e) => setSort(e.target.value)}
+                className="text-[13px] rounded-lg px-2 py-1 outline-none"
+                style={{ backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
+              >
+                {SORTS.map(s => <option key={s.key} value={s.key}>{s.label}</option>)}
+              </select>
+            </div>
+          )}
+        </div>
 
         {blogsLoading ? (
           <div className="space-y-4">
@@ -164,7 +198,7 @@ export default function StoriesPage() {
         ) : stories.length > 0 ? (
           <div>
             {stories.map((story) => (
-              <StoryCard key={story.id} story={story} onDelete={setConfirmTarget} />
+              <StoryCard key={story.id} story={story} onDelete={setConfirmTarget} reshared={activeTab === 2} />
             ))}
           </div>
         ) : (
@@ -177,14 +211,18 @@ export default function StoriesPage() {
               )}
             </svg>
             <p className="text-[var(--text-muted)] text-[15px] font-medium mb-1.5">
-              {activeTab === 0 ? 'No drafts yet' : 'No published stories yet'}
+              {activeTab === 0 ? 'No drafts yet' : activeTab === 1 ? 'No published stories yet' : 'No reshared posts yet'}
             </p>
             <p className="text-[var(--text-muted)] text-[13px] mb-6">
-              {activeTab === 0 ? 'Start writing and your drafts will show up here.' : 'Once you publish a story, it will appear here.'}
+              {activeTab === 0 ? 'Start writing and your drafts will show up here.'
+                : activeTab === 1 ? 'Once you publish a story, it will appear here.'
+                : 'Posts you repost from others will appear here.'}
             </p>
-            <Link href="/new-blog" className="px-5 py-2 text-[13px] font-medium text-[var(--text-primary)] bg-[#9b7bf7] hover:bg-[#b69aff] rounded-full transition-colors">
-              Write a story
-            </Link>
+            {activeTab !== 2 && (
+              <Link href="/new-blog" className="px-5 py-2 text-[13px] font-medium text-white bg-[#9b7bf7] hover:bg-[#b69aff] rounded-full transition-colors">
+                Write a story
+              </Link>
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Changes Made

- `app/api/blogs/[slugid]/repost/route.js` — Added best-effort notification to blog owner on fresh repost; checks `wasNew` to avoid duplicate notifications on repeated reposts.
- `app/api/blogs/list/route.js` — Added `filter=reshared` param to return blogs the user reposted (authored by others); added `sort` param (views/likes/comments); added `is_reshared` flag to own-blog results.
- `app/api/feed/route.js` — Added `queryFollowedReposts` bucket that surfaces reposts by followed users (last 30 days); blended feed now merges reposts first so reshared posts claim dedup slots with `reshared_by_id`; reposts score 70 (above following=50, interests=30); `enrichPosts` now returns `reposted` and `reshared_by` per post; recency uses `reshared_at` when available.
- `src/index.jsx` — FeedCard renders a "Reposted by …" header when `post.reshared_by` is present; repost button initializes from `post.reposted` instead of hardcoded `false`.

## Checklist

- [ ] No Node built-ins imported (crypto, fs, path, stream, Buffer)
- [ ] `./biome.sh ci` clean
- [ ] Tested locally: <how>