### PR TITLE
[PATCH[: Updated the blogs to remove error on creation of the oranisations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lixblogs",
-  "version": "4.9.47",
+  "version": "4.9.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lixblogs",
-      "version": "4.9.47",
+      "version": "4.9.48",
       "license": "MIT",
       "dependencies": {
         "@blocknote/core": "^0.47.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lixblogs",
-  "version": "4.9.47",
+  "version": "4.9.48",
   "description": "A modern blogging platform with a rich block editor, AI writing tools, real-time collaboration, and organizations — deployed on Cloudflare's edge.",
   "author": "Elixpo <https://github.com/elixpo>",
   "license": "MIT",

--- a/src/views/StoriesPage.jsx
+++ b/src/views/StoriesPage.jsx
@@ -128,7 +128,7 @@ export default function StoriesPage() {
     setDeleting(true);
     try {
       const res = await fetch(`/api/blogs/${confirmTarget.id}`, { method: 'DELETE' });
-      if (res.ok) setBlogs(prev => prev.filter(b => b.id !== confirmTarget.id));
+      if (res.ok) setStories(prev => prev.filter(b => b.id !== confirmTarget.id));
     } catch {}
     setDeleting(false);
     setConfirmTarget(null);

--- a/src/views/settings/SettingsPage.jsx
+++ b/src/views/settings/SettingsPage.jsx
@@ -1114,7 +1114,7 @@ export default function SettingsPage() {
   const { user, loading, refetchUser } = useAuth();
   const searchParams = useSearchParams();
   const tabParam = searchParams.get('tab');
-  const initialTab = tabParam ? TABS.findIndex(t => t.toLowerCase() === tabParam.toLowerCase()) : 0;
+  const initialTab = tabParam ? TABS.findIndex(t => t.label.toLowerCase() === tabParam.toLowerCase()) : 0;
   const [activeTab, setActiveTab] = useState(initialTab >= 0 ? initialTab : 0);
 
   if (loading) {


### PR DESCRIPTION
## Changes Made
- Fixed `src/views/StoriesPage.jsx` — changed `setBlogs` to `setStories` in the delete handler so the state updater matches the actual state variable, preventing a runtime error when deleting a story.
- Fixed `src/views/settings/SettingsPage.jsx` — changed `t.toLowerCase()` to `t.label.toLowerCase()` when resolving the initial tab from URL params, since `TABS` entries are objects (not strings); this was causing a crash when navigating to the organizations tab via query param.

## Checklist
- [ ] No Node built-ins imported (crypto, fs, path, stream, Buffer)
- [ ] `./biome.sh ci` clean
- [ ] Tested locally: <how>