### PR TITLE
feat(lixeditor): controlled-mode theme prop for LixThemeProvider

### DIFF
--- a/packages/lixeditor/src/hooks/useLixTheme.js
+++ b/packages/lixeditor/src/hooks/useLixTheme.js
@@ -8,30 +8,78 @@ const LixThemeContext = createContext(null);
  * Theme provider for the LixEditor package.
  * Manages light/dark theme and applies it to the document.
  *
+ * Two modes:
+ *   1. **Controlled** — pass `theme` (and optionally `onThemeChange`). The
+ *      consumer owns the theme state; storage / internal state are ignored.
+ *      Use this when an external store (Zustand, Redux, etc.) already
+ *      tracks theme — e.g. when embedding the editor inside an app whose
+ *      own theme toggle should drive the editor too.
+ *   2. **Uncontrolled** — pass `defaultTheme`. Initial value is read from
+ *      `localStorage[storageKey]` if present, otherwise from `defaultTheme`.
+ *      `toggleTheme` / `setTheme` mutate internal state and persist to
+ *      storage. This was the only mode before — fully backwards-compatible.
+ *
  * @param {Object} props
- * @param {'light'|'dark'} [props.defaultTheme='light'] - Initial theme
- * @param {string} [props.storageKey='lixeditor_theme'] - localStorage key for persistence
+ * @param {'light'|'dark'} [props.theme] - Controlled theme. When set, the
+ *        provider becomes controlled and ignores storage / defaultTheme.
+ * @param {(t: 'light'|'dark') => void} [props.onThemeChange] - Called by
+ *        `toggleTheme` / `setTheme` when controlled, so the consumer can
+ *        update its own store. No-op if absent.
+ * @param {'light'|'dark'} [props.defaultTheme='light'] - Initial theme for
+ *        the uncontrolled mode.
+ * @param {string|null} [props.storageKey='lixeditor_theme'] - localStorage
+ *        key for persistence (uncontrolled only). Pass `null` to disable
+ *        persistence entirely.
  * @param {React.ReactNode} props.children
  */
-export function LixThemeProvider({ children, defaultTheme = 'light', storageKey = 'lixeditor_theme' }) {
-  const [theme, setTheme] = useState(defaultTheme);
+export function LixThemeProvider({
+  children,
+  theme: controlledTheme,
+  onThemeChange,
+  defaultTheme = 'light',
+  storageKey = 'lixeditor_theme',
+}) {
+  const isControlled = controlledTheme !== undefined;
+  const [internalTheme, setInternalTheme] = useState(defaultTheme);
   const [mounted, setMounted] = useState(false);
 
+  // Hydrate internal state from storage on mount (uncontrolled only).
   useEffect(() => {
-    if (storageKey) {
-      const saved = localStorage.getItem(storageKey);
-      if (saved === 'dark' || saved === 'light') setTheme(saved);
+    if (!isControlled && storageKey) {
+      try {
+        const saved = localStorage.getItem(storageKey);
+        if (saved === 'dark' || saved === 'light') setInternalTheme(saved);
+      } catch {}
     }
     setMounted(true);
-  }, [storageKey]);
+    // Intentionally only on first mount — storage is the *initial* source
+    // of truth, not a live binding. Subsequent updates flow through
+    // setTheme/toggleTheme/controlled-prop changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
+  // Controlled prop wins; otherwise internal state.
+  const theme = isControlled ? controlledTheme : internalTheme;
+
+  // Apply theme to <html> + persist (uncontrolled). Controlled mode also
+  // persists so a later switch to uncontrolled mode picks up where the
+  // controlled value left off — that's a nicer consumer experience.
   useEffect(() => {
     if (!mounted) return;
     document.documentElement.setAttribute('data-theme', theme);
-    if (storageKey) localStorage.setItem(storageKey, theme);
+    if (storageKey) {
+      try { localStorage.setItem(storageKey, theme); } catch {}
+    }
   }, [theme, mounted, storageKey]);
 
-  const toggleTheme = () => setTheme(t => t === 'dark' ? 'light' : 'dark');
+  const setTheme = (next) => {
+    if (isControlled) {
+      if (typeof onThemeChange === 'function') onThemeChange(next);
+      return;
+    }
+    setInternalTheme(next);
+  };
+  const toggleTheme = () => setTheme(theme === 'dark' ? 'light' : 'dark');
   const isDark = theme === 'dark';
 
   return (


### PR DESCRIPTION
## What this does
Adds a controlled mode to `LixThemeProvider`. Consumers can now pass `theme` (with optional `onThemeChange`) and the provider will use it as the truth — storage and `defaultTheme` are ignored. Uncontrolled mode is unchanged: `defaultTheme` + storage continue to work exactly as before for any existing consumer.

## Why
The sketch.elixpo canvas embeds the editor and tracks the canvas/docs theme in its own Zustand store. With the old uncontrolled-only API, a stale `localStorage[storageKey]` from a previous session always beat `defaultTheme` on mount, so the editor was pinned to whatever theme the user toggled last — even if the embedding app had a fresh value to apply. Controlled mode gives the embedder full authority.

## Changes
- `packages/lixeditor/src/hooks/useLixTheme.js`:
  - New props: `theme` (controlled value) and `onThemeChange` (callback fired by `setTheme` / `toggleTheme` so the consumer can update its own store).
  - When `theme !== undefined`, provider runs in controlled mode: internal `useState` value is ignored, storage hydration is skipped, `setTheme` / `toggleTheme` forward to `onThemeChange` instead of mutating internal state.
  - Storage `setItem` still runs on theme changes so a later switch from controlled → uncontrolled picks up where the controlled value left off (nicer consumer DX).
  - `localStorage` reads/writes are now wrapped in `try { } catch` to be safe in environments where storage is restricted.
  - JSDoc rewritten to describe both modes.

## Verification
- Backwards-compatible: existing call sites with `<LixThemeProvider defaultTheme="dark" storageKey="...">` keep their old behavior.
- Controlled mode unblocks the sketch.elixpo follow-up that's been working around this via a manual `localStorage.setItem` before mount.