### PR TITLE
fix(ci): switch npm publish to NODE_AUTH_TOKEN env

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -87,9 +87,18 @@ jobs:
           fi
 
       # ── Publish to npmjs ────────────────────────────────────────────
+      # The `actions/setup-node@v4` step above with `registry-url` writes
+      # a project-level `.npmrc` that maps the registry to `${NODE_AUTH_
+      # TOKEN}`. Passing the auth via `NODE_AUTH_TOKEN` is the standard
+      # path (matches what npm-publish-action / Verdaccio docs recommend).
+      # Inline `--//registry/:_authToken=...` flags work in some setups
+      # but were producing E404 "Not Found - PUT" here — npm treats that
+      # as auth-failed and returns 404 rather than 403.
       - name: Publish to NPM
         working-directory: packages/lixeditor
-        run: npm publish --access public --registry https://registry.npmjs.org/ --//registry.npmjs.org/:_authToken=${{ secrets.NPM_LIXEDITOR_PUBLISH_TOKEN }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_LIXEDITOR_PUBLISH_TOKEN }}
+        run: npm publish --access public
 
       # ── Mirror to GitHub Packages ───────────────────────────────────
       # GitHub Packages requires `repository.url` to match the running


### PR DESCRIPTION
## What this does
Switches the lixeditor publish step from the inline `--//registry.npmjs.org/:_authToken=…` CLI flag to the standard `NODE_AUTH_TOKEN` env var that `actions/setup-node@v4` already wires through `.npmrc`.

## Why
The publish was failing with:
```
npm error 404 Not Found - PUT https://registry.npmjs.org/@elixpo%2flixeditor - Not found
```
That 404 is npm's "auth failed" response (it returns 404 instead of 403 to hide whether a package exists). Two probable causes were stacked:
1. The `--//registry/:_authToken=...` inline flag is fragile — works in some setups but the registry rejected this combo.
2. The token itself doesn't have the right scope/permissions.

This PR removes (1). If the publish still 404s after merging, the token is the blocker — see the verification checklist below.

## Changes
- `.github/workflows/publish-npm.yml`: dropped the inline auth flag; added an `env: NODE_AUTH_TOKEN: ${{ secrets.NPM_LIXEDITOR_PUBLISH_TOKEN }}` block on the publish step. This matches what npmjs / setup-node docs recommend.

## Verification
After merge, if publish still fails, the token needs fixing:
- [ ] On npmjs.com, the token type is **Automation** (not Classic / Legacy).
- [ ] The token owner has **maintainer** or **owner** rights on `@elixpo/lixeditor` (`npm access list packages` should list it).
- [ ] If the token has org/team-scoped permissions, the org `@elixpo` exists and the team has `Develop` or `Admin` access to the package.
- [ ] The `NPM_LIXEDITOR_PUBLISH_TOKEN` secret in this repo's settings (or org-level) matches the regenerated token verbatim — no trailing newline.