### PR TITLE
chore(release): bump @elixpo/lixeditor to v2.6.7

### DIFF
--- a/packages/lixeditor/package.json
+++ b/packages/lixeditor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elixpo/lixeditor",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "description": "A rich WYSIWYG block editor and renderer built on BlockNote — equations, mermaid diagrams, code highlighting, and more.",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
Records the 2.6.7 release that was just published to npm from CLI (controlled-theme prop from #53).