### PR TITLE
fix(ci): atomic version bump when LOCAL already on npm

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -62,15 +62,33 @@ jobs:
         working-directory: packages/lixeditor
         run: |
           LOCAL=$(node -p "require('./package.json').version")
-          REMOTE=$(npm view @elixpo/lixeditor version 2>/dev/null || echo "0.0.0")
+          # `npm view` can timeout / rate-limit and return "0.0.0" via the
+          # fallback below, which then makes the LOCAL == REMOTE check
+          # fail and skips the bump — even though LOCAL IS already on npm.
+          # Treat any non-semver REMOTE as unknown and fall back to a
+          # direct "is LOCAL already published?" probe as the truth source.
+          REMOTE=$(npm view @elixpo/lixeditor version 2>/dev/null || echo "unknown")
           BUMP="${{ github.event.inputs.bump || 'patch' }}"
 
           echo "Local  version: $LOCAL"
           echo "Remote version: $REMOTE"
           echo "Bump kind: $BUMP"
 
+          # Decide whether we need to bump. Three cases:
+          #   1. LOCAL == REMOTE                          → bump
+          #   2. LOCAL is already published (probe hit)   → bump (publish would 409)
+          #   3. LOCAL strictly ahead of REMOTE           → respect manual bump
+          NEEDS_BUMP=false
           if [ "$LOCAL" = "$REMOTE" ]; then
-            echo "Versions match — auto-bumping ($BUMP)."
+            NEEDS_BUMP=true
+          elif [ "$REMOTE" = "unknown" ]; then
+            if npm view "@elixpo/lixeditor@${LOCAL}" version >/dev/null 2>&1; then
+              echo "LOCAL ($LOCAL) already exists on npm — bumping."
+              NEEDS_BUMP=true
+            fi
+          fi
+
+          if [ "$NEEDS_BUMP" = "true" ]; then
             # `npm version` in a workspace emits "<pkg-name>\nv<x.y.z>"
             # to stdout — capturing that produces a multi-line shell var
             # that corrupts $GITHUB_OUTPUT. Bump silently and read the
@@ -81,7 +99,7 @@ jobs:
             echo "version=$NEW" >> "$GITHUB_OUTPUT"
             echo "auto_bumped=true" >> "$GITHUB_OUTPUT"
           else
-            echo "Local already differs from remote — using local ($LOCAL)."
+            echo "Local ($LOCAL) ahead of remote ($REMOTE) — using local as-is."
             echo "version=$LOCAL" >> "$GITHUB_OUTPUT"
             echo "auto_bumped=false" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
## What this does
Hardens the \`Compute next version\` step so it auto-bumps whenever the local \`package.json\` version already exists on the npm registry, not just when \`LOCAL == REMOTE\`.

## Why
The previous \`[ "\$LOCAL" = "\$REMOTE" ]\` check failed open whenever \`npm view\` timed out or hit a rate limit — the fallback returned \`"0.0.0"\`, so the comparison was false, the bump was skipped, and the subsequent \`npm publish\` 409'd because the version already existed. Same root cause as the recent \`E404\` chain we just untangled.

## Changes
- \`.github/workflows/publish-npm.yml\`:
  - \`npm view ... || echo "0.0.0"\` → \`npm view ... || echo "unknown"\` (semver-safe sentinel).
  - Introduced a \`NEEDS_BUMP\` decision tree with three cases:
    1. \`LOCAL == REMOTE\` → bump (matches before).
    2. \`REMOTE == "unknown"\` (npm view failed) → probe \`npm view @elixpo/lixeditor@\${LOCAL}\` directly; if that resolves, LOCAL is on npm and we bump anyway.
    3. \`LOCAL\` strictly ahead of \`REMOTE\` → respect manual bump, use as-is.
  - Mirrors the same change just applied to sketch.elixpo's publish workflow.

## Verification
- Next push under \`packages/lixeditor/**\` should auto-bump even if \`npm view\` returns nothing, then publish via \`NODE_AUTH_TOKEN\` (already fixed in #54), commit the bump back to main, and tag.