### PR TITLE
[FIX]: Corrected consistency of the blog read time in preview and featured

### DIFF
--- a/app/api/blogs/publish/route.js
+++ b/app/api/blogs/publish/route.js
@@ -2,6 +2,7 @@ export const runtime = 'edge';
 import { NextResponse } from 'next/server';
 import { getSession } from '../../../../lib/auth';
 import { requestTooLarge, byteLength, MAX_BLOG_CONTENT_BYTES, MAX_TITLE_LEN, MAX_SUBTITLE_LEN } from '../../../../lib/limits';
+import { readTimeFromWords } from '../../../../lib/readTime';
 
 export async function POST(request) {
   const session = await getSession();
@@ -55,7 +56,7 @@ export async function POST(request) {
     const { checkPublishSafety } = await import('../../../../lib/blog-version');
     const db = getDB();
     const now = Math.floor(Date.now() / 1000);
-    const readTime = Math.max(1, Math.ceil(countWords(editorContent) / 250));
+    const readTime = readTimeFromWords(countWords(editorContent));
     const compressedContent = editorContent ? compressBlogContent(editorContent) : '';
     const { excerptFromBlocks } = await import('../../../../lib/excerpt');
     const excerpt = editorContent ? excerptFromBlocks(editorContent) : '';

--- a/lib/readTime.js
+++ b/lib/readTime.js
@@ -1,0 +1,8 @@
+// Single source of truth for reading-time. Cards show the stored
+// `read_time_minutes`; the reader/editor compute with the SAME formula so the
+// number never disagrees across surfaces.
+export const READ_WPM = 250;
+
+export function readTimeFromWords(words) {
+  return Math.max(1, Math.ceil((Number(words) || 0) / READ_WPM));
+}

--- a/src/components/Editor/BlogPreview.jsx
+++ b/src/components/Editor/BlogPreview.jsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { useTheme } from '../../context/ThemeContext';
 import LinkPreviewTooltip, { useLinkPreview } from './LinkPreviewTooltip';
+import { readTimeFromWords } from '../../../lib/readTime';
 
 function FloatingTOC({ headings }) {
   const [activeId, setActiveId] = useState('');
@@ -329,7 +330,7 @@ function renderBlocksToHTML(blocks) {
   return html;
 }
 
-export default function BlogPreview({ title, subtitle, coverPreview, coverZoom, coverPos, pageEmoji, tags, html, blocks, user, org, coAuthorCount, coAuthors = [], wordCount, followSlot = null, memberOnly = false, featured = false, publishedAt = null, headerActions = null, hideHighlights = false }) {
+export default function BlogPreview({ title, subtitle, coverPreview, coverZoom, coverPos, pageEmoji, tags, html, blocks, user, org, coAuthorCount, coAuthors = [], wordCount, followSlot = null, memberOnly = false, featured = false, publishedAt = null, headerActions = null, hideHighlights = false, readTimeMinutes = 0 }) {
   const { isDark } = useTheme();
   const contentRef = useRef(null);
   const [showBackToTop, setShowBackToTop] = useState(false);
@@ -779,7 +780,7 @@ export default function BlogPreview({ title, subtitle, coverPreview, coverZoom, 
                 <span className="text-[var(--text-faint)]">+ {moreNames} more</span>
               )}
               <span className="text-[var(--text-faint)]">·</span>
-              <span>{Math.max(1, Math.ceil((wordCount || 0) / 200))} min read</span>
+              <span>{readTimeMinutes > 0 ? readTimeMinutes : readTimeFromWords(wordCount)} min read</span>
               {publishedAt && (
                 <>
                   <span className="text-[var(--text-faint)]">·</span>

--- a/src/views/HandlePage.jsx
+++ b/src/views/HandlePage.jsx
@@ -200,6 +200,7 @@ function HandlePageInner({ path }) {
             coAuthorCount={blog.co_author_count || 0}
             coAuthors={blog.co_authors || []}
             wordCount={wc}
+            readTimeMinutes={blog.read_time_minutes || 0}
             memberOnly={!!blog.member_only}
             featured={blog.published_as === `org:${STAFF_ORG_ID}`}
             publishedAt={blog.published_at}

--- a/src/views/WritePage.jsx
+++ b/src/views/WritePage.jsx
@@ -11,6 +11,7 @@ import '@blocknote/mantine/style.css';
 import '../styles/editor/editor.css';
 import '../styles/katex-fonts.css';
 import { compressCoverImage } from '../utils/compressImage';
+import { readTimeFromWords } from '../../lib/readTime';
 import { IMAGE_ACCEPT_ATTR, isAllowedImage } from '../utils/allowedImageTypes';
 import { generatePixelAvatar } from '../utils/pixelAvatar';
 import { useCollaboration } from '../hooks/useCollaboration';
@@ -1251,7 +1252,7 @@ export default function WritePage({ slugid }) {
     } catch { /* silent */ }
   };
 
-  const readTime = Math.max(1, Math.ceil(wordCount / 250));
+  const readTime = readTimeFromWords(wordCount);
 
   const formatSavedTime = (ts) => {
     if (!ts) return null;
@@ -1974,7 +1975,7 @@ export default function WritePage({ slugid }) {
                     <div className="flex items-center gap-2 text-[15px] text-[var(--text-faint)]">
                       <span className="text-[var(--text-muted)] font-medium">{user?.display_name || user?.username || 'Author'}</span>
                       <span className="text-[var(--text-faint)]">·</span>
-                      <span>{Math.max(1, Math.ceil(wordCount / 200))} min read</span>
+                      <span>{readTimeFromWords(wordCount)} min read</span>
                       <span className="text-[var(--text-faint)]">·</span>
                       <span>{wordCount} {wordCount === 1 ? 'word' : 'words'}</span>
                     </div>


### PR DESCRIPTION
## Changes Made
- Added `lib/readTime.js` — single source of truth for reading-time calculation (`READ_WPM = 250`, `readTimeFromWords()`) so all surfaces agree on the same formula.
- `app/api/blogs/publish/route.js` — replaced inline `Math.ceil(countWords / 250)` with `readTimeFromWords()` so the server stores the same value the client computes.
- `src/components/Editor/BlogPreview.jsx` — added `readTimeMinutes` prop; displays the stored `read_time_minutes` when available (published posts) and falls back to `readTimeFromWords()` for drafts; removed hardcoded 200 WPM calculation that disagreed with the 250 WPM used at publish.
- `src/views/HandlePage.jsx` — passes `blog.read_time_minutes` into `BlogPreview` so featured/published cards show the persisted value instead of recomputing with a different formula.
- `src/views/WritePage.jsx` — replaced two separate inline read-time calculations (one at 250 WPM, one at 200 WPM) with `readTimeFromWords()`, eliminating the discrepancy between the editor header and the preview pane.

## Checklist
- [ ] No Node built-ins imported (crypto, fs, path, stream, Buffer)
- [ ] `./biome.sh ci` clean
- [ ] Tested locally: <how>