### PR TITLE
[FEAT]: Attached the legal documets and the middleware to render terms and the docs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,17 @@
-MIT License
+LixBlogs is provided under:
 
-Copyright (c) 2026 Ayushman Bhattacharya
+	SPDX-License-Identifier: MIT WITH Elixpo-trademarks
+
+Being under the terms of the MIT License, with an explicit trademark
+and naming exception, as stated below.
+
+All contributions to LixBlogs are subject to this LICENSE file.
+
+================================================================================
+MIT License
+================================================================================
+
+Copyright (c) 2026 Elixpo (Ayushman Bhattacharya) and the LixBlogs authors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,3 +30,38 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+================================================================================
+Elixpo-trademarks exception
+================================================================================
+
+Valid-License-Identifier: Elixpo-trademarks
+SPDX-Exception-Identifier: Elixpo-trademarks
+SPDX-Licenses: MIT
+
+The MIT License granted above covers the source code, configuration, and
+assets contained in this repository. It does NOT grant rights to the following
+names, marks, and brand assets:
+
+  - "Elixpo"
+  - "LixBlogs"
+  - "LixEditor" and "LixSketch"
+  - The Elixpo logo and any associated mascot character.
+
+These trademarks are reserved by Elixpo (Ayushman Bhattacharya) and the
+project's authors.
+
+You may:
+  - Use these names to identify the original project and to give credit to its
+    authors (e.g. "Powered by LixBlogs", "built with LixEditor").
+  - Reference them in articles, talks, tutorials, classroom material, and
+    documentation about the project.
+  - Show the logo in screenshots and demos of unmodified builds.
+
+You may not, without prior written permission:
+  - Use these names to brand a fork, derivative work, or hosted service.
+  - Imply endorsement of a derivative work by the original authors.
+  - Use the logo or mascot as the primary branding of a derivative product.
+
+For permission requests or trademark questions, contact:
+  hello@elixpo.com

--- a/app/docs/page.jsx
+++ b/app/docs/page.jsx
@@ -1,82 +1,15 @@
-import AppShell from '../../src/components/AppShell';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { marked } from 'marked';
+import DocsView from '../../src/components/DocsView';
 
 export const metadata = {
   title: 'Docs — LixBlogs',
-  description: 'Documentation for the LixEditor package, npm install, and the VS Code extension.',
+  description: 'Developer API for the LixEditor package, npm, and the VS Code extension.',
 };
 
-function Code({ children }) {
-  return (
-    <pre className="rounded-lg px-4 py-3 text-[13px] overflow-x-auto my-2" style={{ backgroundColor: 'var(--bg-elevated)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}>
-      <code>{children}</code>
-    </pre>
-  );
-}
-
-function NpmCard() {
-  return (
-    <div className="rounded-2xl p-5 h-full" style={{ backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border-default)' }}>
-      <div className="flex items-center gap-2 mb-3">
-        <div className="h-9 w-9 rounded-lg flex items-center justify-center" style={{ backgroundColor: '#cb000420' }}>
-          <ion-icon name="logo-npm" style={{ fontSize: '22px', color: '#cb0004' }} />
-        </div>
-        <h2 className="text-[16px] font-bold" style={{ color: 'var(--text-primary)' }}>npm package</h2>
-      </div>
-      <p className="text-[14px] leading-relaxed mb-1" style={{ color: 'var(--text-muted)' }}>Use the editor in any React app:</p>
-      <Code>npm install @elixpo/lixeditor</Code>
-      <Code>{`import { LixEditor } from '@elixpo/lixeditor';
-import '@elixpo/lixeditor/style.css';
-
-<LixEditor onChange={(blocks) => save(blocks)} />`}</Code>
-      <a href="https://www.npmjs.com/package/@elixpo/lixeditor" target="_blank" rel="noopener noreferrer" className="text-[13px] underline" style={{ color: 'var(--accent)' }}>View on npm →</a>
-    </div>
-  );
-}
-
-function VSCodeCard() {
-  return (
-    <div className="rounded-2xl p-5 h-full" style={{ backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border-default)' }}>
-      <div className="flex items-center gap-2 mb-3">
-        <div className="h-9 w-9 rounded-lg flex items-center justify-center" style={{ backgroundColor: '#0098ff20' }}>
-          <ion-icon name="code-slash-outline" style={{ fontSize: '20px', color: '#0098ff' }} />
-        </div>
-        <h2 className="text-[16px] font-bold" style={{ color: 'var(--text-primary)' }}>VS Code extension</h2>
-      </div>
-      <p className="text-[14px] leading-relaxed mb-1" style={{ color: 'var(--text-muted)' }}>Draft &amp; preview posts without leaving your editor:</p>
-      <Code>ext install elixpo.lixeditor</Code>
-      <p className="text-[13px] mt-1" style={{ color: 'var(--text-faint)' }}>Or search “LixEditor” in the Extensions panel (Ctrl/Cmd+Shift+X).</p>
-    </div>
-  );
-}
-
 export default function DocsPage() {
-  return (
-    <AppShell>
-      <div className="w-full max-w-4xl mx-auto px-6 py-12 block">
-        <h1 className="text-3xl font-extrabold mb-2" style={{ color: 'var(--text-primary)' }}>Docs</h1>
-        <p className="text-[15px] mb-8" style={{ color: 'var(--text-muted)' }}>
-          LixEditor is the block-based WYSIWYG editor that powers LixBlogs. Use it in your own React app, or write inside VS Code.
-        </p>
-
-        <div className="grid gap-4 sm:grid-cols-2 mb-10">
-          <NpmCard />
-          <VSCodeCard />
-        </div>
-
-        <section>
-          <h2 className="text-[18px] font-bold mb-2" style={{ color: 'var(--text-primary)' }}>Features</h2>
-          <ul className="text-[14px] leading-relaxed list-disc pl-5 space-y-1" style={{ color: 'var(--text-secondary)' }}>
-            <li>Notion-style blocks: headings, lists, quotes, code, tables, images, equations, tabs.</li>
-            <li>Markdown shortcuts and slash (<code>/</code>) commands.</li>
-            <li>Real-time collaboration ready (Yjs).</li>
-            <li>Exports clean block JSON you can store and re-render anywhere.</li>
-          </ul>
-        </section>
-
-        <p className="text-[13px] mt-8" style={{ color: 'var(--text-faint)' }}>
-          Questions? See <a href="/help" className="underline">Help</a> or email hello@elixpo.com.
-        </p>
-      </div>
-    </AppShell>
-  );
+  const md = readFileSync(path.join(process.cwd(), 'content/docs.md'), 'utf8');
+  const html = marked.parse(md, { breaks: true });
+  return <DocsView md={md} html={html} />;
 }

--- a/app/docs/page.jsx
+++ b/app/docs/page.jsx
@@ -1,0 +1,68 @@
+import AppShell from '../../src/components/AppShell';
+
+export const metadata = {
+  title: 'Docs — LixBlogs',
+  description: 'Documentation for the LixEditor package, npm install, and the VS Code extension.',
+};
+
+function Code({ children }) {
+  return (
+    <pre className="rounded-lg px-4 py-3 text-[13px] overflow-x-auto my-2" style={{ backgroundColor: 'var(--bg-elevated)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}>
+      <code>{children}</code>
+    </pre>
+  );
+}
+
+export default function DocsPage() {
+  return (
+    <AppShell>
+      <div className="max-w-2xl mx-auto px-6 py-12" style={{ color: 'var(--text-secondary)' }}>
+        <h1 className="text-3xl font-extrabold mb-2" style={{ color: 'var(--text-primary)' }}>Docs</h1>
+        <p className="text-[15px] mb-10" style={{ color: 'var(--text-muted)' }}>
+          LixEditor is the block-based WYSIWYG editor that powers LixBlogs. Use it in your own React app, or write inside VS Code.
+        </p>
+
+        <section className="mb-10">
+          <h2 className="text-[18px] font-bold mb-2" style={{ color: 'var(--text-primary)' }}>LixEditor — npm package</h2>
+          <p className="text-[14px] leading-relaxed mb-2">Install the editor package from npm:</p>
+          <Code>npm install @elixpo/lixeditor</Code>
+          <p className="text-[14px] leading-relaxed mt-3 mb-1">Then mount it in a React component:</p>
+          <Code>{`import { LixEditor } from '@elixpo/lixeditor';
+import '@elixpo/lixeditor/style.css';
+
+export default function Editor() {
+  return <LixEditor onChange={(blocks) => console.log(blocks)} />;
+}`}</Code>
+          <p className="text-[13px] mt-3" style={{ color: 'var(--text-faint)' }}>
+            View on <a href="https://www.npmjs.com/package/@elixpo/lixeditor" target="_blank" rel="noopener noreferrer" className="underline">npm</a>.
+          </p>
+        </section>
+
+        <section className="mb-10">
+          <h2 className="text-[18px] font-bold mb-2" style={{ color: 'var(--text-primary)' }}>VS Code extension</h2>
+          <p className="text-[14px] leading-relaxed mb-2">
+            Prefer your editor? Install <strong style={{ color: 'var(--text-primary)' }}>LixEditor</strong> from the VS Code Marketplace to draft and preview blog posts without leaving your workspace.
+          </p>
+          <Code>ext install elixpo.lixeditor</Code>
+          <p className="text-[13px] mt-3" style={{ color: 'var(--text-faint)' }}>
+            Or search “LixEditor” in the Extensions panel (<kbd>Ctrl/Cmd+Shift+X</kbd>).
+          </p>
+        </section>
+
+        <section className="mb-4">
+          <h2 className="text-[18px] font-bold mb-2" style={{ color: 'var(--text-primary)' }}>Features</h2>
+          <ul className="text-[14px] leading-relaxed list-disc pl-5 space-y-1">
+            <li>Notion-style blocks: headings, lists, quotes, code, tables, images, equations, and tabs.</li>
+            <li>Markdown shortcuts and slash (<code>/</code>) commands.</li>
+            <li>Real-time collaboration ready (Yjs).</li>
+            <li>Exports clean block JSON you can store and re-render anywhere.</li>
+          </ul>
+        </section>
+
+        <p className="text-[13px] mt-8" style={{ color: 'var(--text-faint)' }}>
+          Questions? See <a href="/help" className="underline">Help</a> or email hello@elixpo.com.
+        </p>
+      </div>
+    </AppShell>
+  );
+}

--- a/app/docs/page.jsx
+++ b/app/docs/page.jsx
@@ -13,46 +13,60 @@ function Code({ children }) {
   );
 }
 
+function NpmCard() {
+  return (
+    <div className="rounded-2xl p-5 h-full" style={{ backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border-default)' }}>
+      <div className="flex items-center gap-2 mb-3">
+        <div className="h-9 w-9 rounded-lg flex items-center justify-center" style={{ backgroundColor: '#cb000420' }}>
+          <ion-icon name="logo-npm" style={{ fontSize: '22px', color: '#cb0004' }} />
+        </div>
+        <h2 className="text-[16px] font-bold" style={{ color: 'var(--text-primary)' }}>npm package</h2>
+      </div>
+      <p className="text-[14px] leading-relaxed mb-1" style={{ color: 'var(--text-muted)' }}>Use the editor in any React app:</p>
+      <Code>npm install @elixpo/lixeditor</Code>
+      <Code>{`import { LixEditor } from '@elixpo/lixeditor';
+import '@elixpo/lixeditor/style.css';
+
+<LixEditor onChange={(blocks) => save(blocks)} />`}</Code>
+      <a href="https://www.npmjs.com/package/@elixpo/lixeditor" target="_blank" rel="noopener noreferrer" className="text-[13px] underline" style={{ color: 'var(--accent)' }}>View on npm →</a>
+    </div>
+  );
+}
+
+function VSCodeCard() {
+  return (
+    <div className="rounded-2xl p-5 h-full" style={{ backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border-default)' }}>
+      <div className="flex items-center gap-2 mb-3">
+        <div className="h-9 w-9 rounded-lg flex items-center justify-center" style={{ backgroundColor: '#0098ff20' }}>
+          <ion-icon name="code-slash-outline" style={{ fontSize: '20px', color: '#0098ff' }} />
+        </div>
+        <h2 className="text-[16px] font-bold" style={{ color: 'var(--text-primary)' }}>VS Code extension</h2>
+      </div>
+      <p className="text-[14px] leading-relaxed mb-1" style={{ color: 'var(--text-muted)' }}>Draft &amp; preview posts without leaving your editor:</p>
+      <Code>ext install elixpo.lixeditor</Code>
+      <p className="text-[13px] mt-1" style={{ color: 'var(--text-faint)' }}>Or search “LixEditor” in the Extensions panel (Ctrl/Cmd+Shift+X).</p>
+    </div>
+  );
+}
+
 export default function DocsPage() {
   return (
     <AppShell>
-      <div className="max-w-2xl mx-auto px-6 py-12" style={{ color: 'var(--text-secondary)' }}>
+      <div className="w-full max-w-4xl mx-auto px-6 py-12 block">
         <h1 className="text-3xl font-extrabold mb-2" style={{ color: 'var(--text-primary)' }}>Docs</h1>
-        <p className="text-[15px] mb-10" style={{ color: 'var(--text-muted)' }}>
+        <p className="text-[15px] mb-8" style={{ color: 'var(--text-muted)' }}>
           LixEditor is the block-based WYSIWYG editor that powers LixBlogs. Use it in your own React app, or write inside VS Code.
         </p>
 
-        <section className="mb-10">
-          <h2 className="text-[18px] font-bold mb-2" style={{ color: 'var(--text-primary)' }}>LixEditor — npm package</h2>
-          <p className="text-[14px] leading-relaxed mb-2">Install the editor package from npm:</p>
-          <Code>npm install @elixpo/lixeditor</Code>
-          <p className="text-[14px] leading-relaxed mt-3 mb-1">Then mount it in a React component:</p>
-          <Code>{`import { LixEditor } from '@elixpo/lixeditor';
-import '@elixpo/lixeditor/style.css';
+        <div className="grid gap-4 sm:grid-cols-2 mb-10">
+          <NpmCard />
+          <VSCodeCard />
+        </div>
 
-export default function Editor() {
-  return <LixEditor onChange={(blocks) => console.log(blocks)} />;
-}`}</Code>
-          <p className="text-[13px] mt-3" style={{ color: 'var(--text-faint)' }}>
-            View on <a href="https://www.npmjs.com/package/@elixpo/lixeditor" target="_blank" rel="noopener noreferrer" className="underline">npm</a>.
-          </p>
-        </section>
-
-        <section className="mb-10">
-          <h2 className="text-[18px] font-bold mb-2" style={{ color: 'var(--text-primary)' }}>VS Code extension</h2>
-          <p className="text-[14px] leading-relaxed mb-2">
-            Prefer your editor? Install <strong style={{ color: 'var(--text-primary)' }}>LixEditor</strong> from the VS Code Marketplace to draft and preview blog posts without leaving your workspace.
-          </p>
-          <Code>ext install elixpo.lixeditor</Code>
-          <p className="text-[13px] mt-3" style={{ color: 'var(--text-faint)' }}>
-            Or search “LixEditor” in the Extensions panel (<kbd>Ctrl/Cmd+Shift+X</kbd>).
-          </p>
-        </section>
-
-        <section className="mb-4">
+        <section>
           <h2 className="text-[18px] font-bold mb-2" style={{ color: 'var(--text-primary)' }}>Features</h2>
-          <ul className="text-[14px] leading-relaxed list-disc pl-5 space-y-1">
-            <li>Notion-style blocks: headings, lists, quotes, code, tables, images, equations, and tabs.</li>
+          <ul className="text-[14px] leading-relaxed list-disc pl-5 space-y-1" style={{ color: 'var(--text-secondary)' }}>
+            <li>Notion-style blocks: headings, lists, quotes, code, tables, images, equations, tabs.</li>
             <li>Markdown shortcuts and slash (<code>/</code>) commands.</li>
             <li>Real-time collaboration ready (Yjs).</li>
             <li>Exports clean block JSON you can store and re-render anywhere.</li>

--- a/app/globals.css
+++ b/app/globals.css
@@ -198,3 +198,19 @@ body {
 .theme-transition {
   transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
+
+/* Markdown document pages (/privacy, /terms, /docs) — full-width, spaced. */
+.legal-md { color: var(--text-secondary); line-height: 1.7; }
+.legal-md h1 { font-size: 2rem; font-weight: 800; color: var(--text-primary); margin: 0 0 0.25rem; }
+.legal-md h2 { font-size: 1.25rem; font-weight: 700; color: var(--text-primary); margin: 2rem 0 0.5rem; }
+.legal-md h3 { font-size: 1.05rem; font-weight: 700; color: var(--text-primary); margin: 1.5rem 0 0.4rem; }
+.legal-md p { margin: 0.6rem 0; font-size: 0.95rem; }
+.legal-md ul, .legal-md ol { margin: 0.6rem 0; padding-left: 1.4rem; }
+.legal-md li { margin: 0.3rem 0; font-size: 0.95rem; }
+.legal-md a { color: var(--accent); text-decoration: underline; }
+.legal-md strong { color: var(--text-primary); }
+.legal-md code { background: var(--bg-elevated); border: 1px solid var(--border-default); border-radius: 4px; padding: 1px 5px; font-size: 0.85em; }
+.legal-md pre { background: var(--bg-elevated); border: 1px solid var(--border-default); border-radius: 10px; padding: 1rem; overflow-x: auto; margin: 0.8rem 0; }
+.legal-md pre code { background: none; border: none; padding: 0; }
+.legal-md hr { border: none; border-top: 1px solid var(--divider); margin: 1.5rem 0; }
+.legal-md em { color: var(--text-faint); }

--- a/app/help/page.jsx
+++ b/app/help/page.jsx
@@ -1,0 +1,51 @@
+import AppShell from '../../src/components/AppShell';
+
+export const metadata = {
+  title: 'Help — LixBlogs',
+  description: 'Get help with LixBlogs — contact support or report an issue.',
+};
+
+export default function HelpPage() {
+  return (
+    <AppShell>
+      <div className="max-w-2xl mx-auto px-6 py-12">
+        <h1 className="text-3xl font-extrabold mb-2" style={{ color: 'var(--text-primary)' }}>Help &amp; support</h1>
+        <p className="text-[15px] mb-8" style={{ color: 'var(--text-muted)' }}>
+          Need a hand, found a bug, or have a feature idea? Reach us either way:
+        </p>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <a
+            href="mailto:hello@elixpo.com"
+            className="block rounded-2xl p-5 transition-colors"
+            style={{ backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border-default)' }}
+          >
+            <div className="h-10 w-10 rounded-xl flex items-center justify-center mb-3" style={{ backgroundColor: 'var(--accent-subtle, rgba(155,123,247,0.1))' }}>
+              <ion-icon name="mail-outline" style={{ fontSize: '20px', color: '#9b7bf7' }} />
+            </div>
+            <p className="text-[15px] font-semibold mb-1" style={{ color: 'var(--text-primary)' }}>Email us</p>
+            <p className="text-[13px]" style={{ color: 'var(--text-muted)' }}>hello@elixpo.com — we usually reply within a day.</p>
+          </a>
+
+          <a
+            href="https://github.com/elixpo/blogs.elixpo/issues/new"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="block rounded-2xl p-5 transition-colors"
+            style={{ backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border-default)' }}
+          >
+            <div className="h-10 w-10 rounded-xl flex items-center justify-center mb-3" style={{ backgroundColor: 'var(--bg-elevated)' }}>
+              <ion-icon name="logo-github" style={{ fontSize: '20px', color: 'var(--text-primary)' }} />
+            </div>
+            <p className="text-[15px] font-semibold mb-1" style={{ color: 'var(--text-primary)' }}>Open a GitHub issue</p>
+            <p className="text-[13px]" style={{ color: 'var(--text-muted)' }}>Report a bug or request a feature on the public tracker.</p>
+          </a>
+        </div>
+
+        <p className="text-[13px] mt-8" style={{ color: 'var(--text-faint)' }}>
+          See also our <a href="/docs" className="underline">docs</a>, <a href="/privacy" className="underline">privacy policy</a>, and <a href="/terms" className="underline">terms</a>.
+        </p>
+      </div>
+    </AppShell>
+  );
+}

--- a/app/help/page.jsx
+++ b/app/help/page.jsx
@@ -8,13 +8,16 @@ export const metadata = {
 export default function HelpPage() {
   return (
     <AppShell>
-      <div className="max-w-2xl mx-auto px-6 py-12">
+      <div className="w-full max-w-3xl mx-auto px-6 py-20 flex flex-col items-center text-center">
+        <div className="h-14 w-14 rounded-2xl flex items-center justify-center mb-5" style={{ backgroundColor: 'var(--accent-subtle, rgba(155,123,247,0.1))' }}>
+          <ion-icon name="help-buoy-outline" style={{ fontSize: '28px', color: '#9b7bf7' }} />
+        </div>
         <h1 className="text-3xl font-extrabold mb-2" style={{ color: 'var(--text-primary)' }}>Help &amp; support</h1>
-        <p className="text-[15px] mb-8" style={{ color: 'var(--text-muted)' }}>
+        <p className="text-[15px] mb-8 max-w-md" style={{ color: 'var(--text-muted)' }}>
           Need a hand, found a bug, or have a feature idea? Reach us either way:
         </p>
 
-        <div className="grid gap-4 sm:grid-cols-2">
+        <div className="grid gap-4 sm:grid-cols-2 w-full text-left">
           <a
             href="mailto:hello@elixpo.com"
             className="block rounded-2xl p-5 transition-colors"

--- a/app/privacy/page.jsx
+++ b/app/privacy/page.jsx
@@ -1,4 +1,7 @@
-import AppShell from '../../src/components/AppShell';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { marked } from 'marked';
+import MarkdownPage from '../../src/components/MarkdownPage';
 
 export const metadata = {
   title: 'Privacy Policy — LixBlogs',
@@ -6,29 +9,7 @@ export const metadata = {
 };
 
 export default function PrivacyPage() {
-  return (
-    <AppShell>
-      <div className="w-full max-w-4xl mx-auto px-6 py-12 block" style={{ color: 'var(--text-secondary)' }}>
-        <h1 className="text-3xl font-extrabold mb-1" style={{ color: 'var(--text-primary)' }}>Privacy Policy</h1>
-        <p className="text-[13px] mb-8" style={{ color: 'var(--text-faint)' }}>Last updated: June 2026</p>
-
-        {[
-          ['Who we are', 'LixBlogs is a blogging platform operated by Elixpo (Ayushman Bhattacharya). You can reach us at hello@elixpo.com.'],
-          ['What we collect', 'Account details from Elixpo Accounts (your username, display name, email, and avatar), the content you publish, and usage signals (views, reads, likes, claps, bookmarks, follows) used to power your feed and stats.'],
-          ['How we use it', 'To operate the service: authenticate you, render your profile and posts, personalize your feed, compute author stats, and send transactional emails (login alerts, account actions, and an optional weekly digest).'],
-          ['What we do NOT do', 'We do not sell your personal data, and we do not run third-party advertising trackers on your content.'],
-          ['Storage & processing', 'Text and metadata are stored on Cloudflare infrastructure (D1 database, KV cache). Authentication is handled by Elixpo Accounts via OAuth 2.0, and your session lives in an httpOnly, Secure cookie.'],
-          ['Images & media', 'Cover images, avatars, org logos, and in-post images you upload are compressed to WebP and stored on Cloudinary over HTTPS. We only keep the media you upload to power your posts and profile; we never embed third-party ad/tracking pixels in your content. Deleting a post removes its associated media.'],
-          ['Open source & transparency', 'LixBlogs is open source — you can read exactly how your data is handled in the code at github.com/elixpo/blogs.elixpo. Found a privacy concern? Open an issue or email hello@elixpo.com.'],
-          ['Your choices', 'You can edit or delete your content and manage your profile at any time. Account deletion and revocation are handled at accounts.elixpo.com → Connected apps.'],
-          ['Contact', 'Questions about your data? Email hello@elixpo.com.'],
-        ].map(([h, b]) => (
-          <section key={h} className="mb-6">
-            <h2 className="text-[16px] font-bold mb-1.5" style={{ color: 'var(--text-primary)' }}>{h}</h2>
-            <p className="text-[14px] leading-relaxed">{b}</p>
-          </section>
-        ))}
-      </div>
-    </AppShell>
-  );
+  const md = readFileSync(path.join(process.cwd(), 'content/privacy.md'), 'utf8');
+  const html = marked.parse(md, { breaks: true });
+  return <MarkdownPage html={html} />;
 }

--- a/app/privacy/page.jsx
+++ b/app/privacy/page.jsx
@@ -8,7 +8,7 @@ export const metadata = {
 export default function PrivacyPage() {
   return (
     <AppShell>
-      <div className="max-w-2xl mx-auto px-6 py-12 prose-legal" style={{ color: 'var(--text-secondary)' }}>
+      <div className="w-full max-w-4xl mx-auto px-6 py-12 block" style={{ color: 'var(--text-secondary)' }}>
         <h1 className="text-3xl font-extrabold mb-1" style={{ color: 'var(--text-primary)' }}>Privacy Policy</h1>
         <p className="text-[13px] mb-8" style={{ color: 'var(--text-faint)' }}>Last updated: June 2026</p>
 
@@ -17,7 +17,9 @@ export default function PrivacyPage() {
           ['What we collect', 'Account details from Elixpo Accounts (your username, display name, email, and avatar), the content you publish, and usage signals (views, reads, likes, claps, bookmarks, follows) used to power your feed and stats.'],
           ['How we use it', 'To operate the service: authenticate you, render your profile and posts, personalize your feed, compute author stats, and send transactional emails (login alerts, account actions, and an optional weekly digest).'],
           ['What we do NOT do', 'We do not sell your personal data, and we do not run third-party advertising trackers on your content.'],
-          ['Storage & processing', 'Data is stored on Cloudflare infrastructure (D1, KV, R2) and media on Cloudinary. Authentication is handled by Elixpo Accounts via OAuth 2.0.'],
+          ['Storage & processing', 'Text and metadata are stored on Cloudflare infrastructure (D1 database, KV cache). Authentication is handled by Elixpo Accounts via OAuth 2.0, and your session lives in an httpOnly, Secure cookie.'],
+          ['Images & media', 'Cover images, avatars, org logos, and in-post images you upload are compressed to WebP and stored on Cloudinary over HTTPS. We only keep the media you upload to power your posts and profile; we never embed third-party ad/tracking pixels in your content. Deleting a post removes its associated media.'],
+          ['Open source & transparency', 'LixBlogs is open source — you can read exactly how your data is handled in the code at github.com/elixpo/blogs.elixpo. Found a privacy concern? Open an issue or email hello@elixpo.com.'],
           ['Your choices', 'You can edit or delete your content and manage your profile at any time. Account deletion and revocation are handled at accounts.elixpo.com → Connected apps.'],
           ['Contact', 'Questions about your data? Email hello@elixpo.com.'],
         ].map(([h, b]) => (

--- a/app/privacy/page.jsx
+++ b/app/privacy/page.jsx
@@ -1,0 +1,32 @@
+import AppShell from '../../src/components/AppShell';
+
+export const metadata = {
+  title: 'Privacy Policy — LixBlogs',
+  description: 'How LixBlogs collects, uses, and protects your data.',
+};
+
+export default function PrivacyPage() {
+  return (
+    <AppShell>
+      <div className="max-w-2xl mx-auto px-6 py-12 prose-legal" style={{ color: 'var(--text-secondary)' }}>
+        <h1 className="text-3xl font-extrabold mb-1" style={{ color: 'var(--text-primary)' }}>Privacy Policy</h1>
+        <p className="text-[13px] mb-8" style={{ color: 'var(--text-faint)' }}>Last updated: June 2026</p>
+
+        {[
+          ['Who we are', 'LixBlogs is a blogging platform operated by Elixpo (Ayushman Bhattacharya). You can reach us at hello@elixpo.com.'],
+          ['What we collect', 'Account details from Elixpo Accounts (your username, display name, email, and avatar), the content you publish, and usage signals (views, reads, likes, claps, bookmarks, follows) used to power your feed and stats.'],
+          ['How we use it', 'To operate the service: authenticate you, render your profile and posts, personalize your feed, compute author stats, and send transactional emails (login alerts, account actions, and an optional weekly digest).'],
+          ['What we do NOT do', 'We do not sell your personal data, and we do not run third-party advertising trackers on your content.'],
+          ['Storage & processing', 'Data is stored on Cloudflare infrastructure (D1, KV, R2) and media on Cloudinary. Authentication is handled by Elixpo Accounts via OAuth 2.0.'],
+          ['Your choices', 'You can edit or delete your content and manage your profile at any time. Account deletion and revocation are handled at accounts.elixpo.com → Connected apps.'],
+          ['Contact', 'Questions about your data? Email hello@elixpo.com.'],
+        ].map(([h, b]) => (
+          <section key={h} className="mb-6">
+            <h2 className="text-[16px] font-bold mb-1.5" style={{ color: 'var(--text-primary)' }}>{h}</h2>
+            <p className="text-[14px] leading-relaxed">{b}</p>
+          </section>
+        ))}
+      </div>
+    </AppShell>
+  );
+}

--- a/app/terms/page.jsx
+++ b/app/terms/page.jsx
@@ -1,4 +1,7 @@
-import AppShell from '../../src/components/AppShell';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { marked } from 'marked';
+import MarkdownPage from '../../src/components/MarkdownPage';
 
 export const metadata = {
   title: 'Terms of Service — LixBlogs',
@@ -6,39 +9,7 @@ export const metadata = {
 };
 
 export default function TermsPage() {
-  return (
-    <AppShell>
-      <div className="w-full max-w-4xl mx-auto px-6 py-12 block" style={{ color: 'var(--text-secondary)' }}>
-        <h1 className="text-3xl font-extrabold mb-1" style={{ color: 'var(--text-primary)' }}>Terms of Service</h1>
-        <p className="text-[13px] mb-8" style={{ color: 'var(--text-faint)' }}>Last updated: June 2026</p>
-
-        {[
-          ['Acceptance', 'By using LixBlogs you agree to these terms. If you do not agree, please do not use the service.'],
-          ['Your account', 'You are responsible for activity under your account. Sign in is provided through Elixpo Accounts; keep your credentials secure.'],
-          ['Your content', 'You retain ownership of what you publish. By posting, you grant LixBlogs a non-exclusive license to host, display, and distribute your content on the platform. You are responsible for having the rights to what you post.'],
-          ['Acceptable use', 'No spam, harassment, hate speech, NSFW or illegal content, copyright infringement, or attempts to disrupt the service. We may remove content or suspend accounts that violate these rules.'],
-          ['Reposts & attribution', 'Resharing keeps the original author’s attribution. Do not misrepresent authorship or imply endorsement you do not have.'],
-          ['Trademarks', '“Elixpo”, “LixBlogs”, “LixEditor”, and “LixSketch” are trademarks of Elixpo. See the project LICENSE for the MIT-with-trademark-exception terms.'],
-          ['Disclaimer', 'The service is provided “as is”, without warranties. To the extent permitted by law, Elixpo is not liable for damages arising from its use.'],
-          ['Changes', 'We may update these terms; continued use after changes means you accept them.'],
-          ['Contact', 'Questions? Email hello@elixpo.com.'],
-        ].map(([h, b]) => (
-          <section key={h} className="mb-6">
-            <h2 className="text-[16px] font-bold mb-1.5" style={{ color: 'var(--text-primary)' }}>{h}</h2>
-            <p className="text-[14px] leading-relaxed">{b}</p>
-          </section>
-        ))}
-
-        <section className="mb-6">
-          <h2 className="text-[16px] font-bold mb-1.5" style={{ color: 'var(--text-primary)' }}>License</h2>
-          <p className="text-[14px] leading-relaxed">
-            LixBlogs is open source under MIT with an Elixpo trademark exception. Read the full license at{' '}
-            <a href="https://github.com/elixpo/blogs.elixpo/blob/main/LICENSE" target="_blank" rel="noopener noreferrer" className="underline" style={{ color: 'var(--accent)' }}>
-              github.com/elixpo/blogs.elixpo/blob/main/LICENSE
-            </a>.
-          </p>
-        </section>
-      </div>
-    </AppShell>
-  );
+  const md = readFileSync(path.join(process.cwd(), 'content/terms-of-service.md'), 'utf8');
+  const html = marked.parse(md, { breaks: true });
+  return <MarkdownPage html={html} />;
 }

--- a/app/terms/page.jsx
+++ b/app/terms/page.jsx
@@ -8,7 +8,7 @@ export const metadata = {
 export default function TermsPage() {
   return (
     <AppShell>
-      <div className="max-w-2xl mx-auto px-6 py-12" style={{ color: 'var(--text-secondary)' }}>
+      <div className="w-full max-w-4xl mx-auto px-6 py-12 block" style={{ color: 'var(--text-secondary)' }}>
         <h1 className="text-3xl font-extrabold mb-1" style={{ color: 'var(--text-primary)' }}>Terms of Service</h1>
         <p className="text-[13px] mb-8" style={{ color: 'var(--text-faint)' }}>Last updated: June 2026</p>
 
@@ -28,6 +28,16 @@ export default function TermsPage() {
             <p className="text-[14px] leading-relaxed">{b}</p>
           </section>
         ))}
+
+        <section className="mb-6">
+          <h2 className="text-[16px] font-bold mb-1.5" style={{ color: 'var(--text-primary)' }}>License</h2>
+          <p className="text-[14px] leading-relaxed">
+            LixBlogs is open source under MIT with an Elixpo trademark exception. Read the full license at{' '}
+            <a href="https://github.com/elixpo/blogs.elixpo/blob/main/LICENSE" target="_blank" rel="noopener noreferrer" className="underline" style={{ color: 'var(--accent)' }}>
+              github.com/elixpo/blogs.elixpo/blob/main/LICENSE
+            </a>.
+          </p>
+        </section>
       </div>
     </AppShell>
   );

--- a/app/terms/page.jsx
+++ b/app/terms/page.jsx
@@ -1,0 +1,34 @@
+import AppShell from '../../src/components/AppShell';
+
+export const metadata = {
+  title: 'Terms of Service — LixBlogs',
+  description: 'The terms governing your use of LixBlogs.',
+};
+
+export default function TermsPage() {
+  return (
+    <AppShell>
+      <div className="max-w-2xl mx-auto px-6 py-12" style={{ color: 'var(--text-secondary)' }}>
+        <h1 className="text-3xl font-extrabold mb-1" style={{ color: 'var(--text-primary)' }}>Terms of Service</h1>
+        <p className="text-[13px] mb-8" style={{ color: 'var(--text-faint)' }}>Last updated: June 2026</p>
+
+        {[
+          ['Acceptance', 'By using LixBlogs you agree to these terms. If you do not agree, please do not use the service.'],
+          ['Your account', 'You are responsible for activity under your account. Sign in is provided through Elixpo Accounts; keep your credentials secure.'],
+          ['Your content', 'You retain ownership of what you publish. By posting, you grant LixBlogs a non-exclusive license to host, display, and distribute your content on the platform. You are responsible for having the rights to what you post.'],
+          ['Acceptable use', 'No spam, harassment, hate speech, NSFW or illegal content, copyright infringement, or attempts to disrupt the service. We may remove content or suspend accounts that violate these rules.'],
+          ['Reposts & attribution', 'Resharing keeps the original author’s attribution. Do not misrepresent authorship or imply endorsement you do not have.'],
+          ['Trademarks', '“Elixpo”, “LixBlogs”, “LixEditor”, and “LixSketch” are trademarks of Elixpo. See the project LICENSE for the MIT-with-trademark-exception terms.'],
+          ['Disclaimer', 'The service is provided “as is”, without warranties. To the extent permitted by law, Elixpo is not liable for damages arising from its use.'],
+          ['Changes', 'We may update these terms; continued use after changes means you accept them.'],
+          ['Contact', 'Questions? Email hello@elixpo.com.'],
+        ].map(([h, b]) => (
+          <section key={h} className="mb-6">
+            <h2 className="text-[16px] font-bold mb-1.5" style={{ color: 'var(--text-primary)' }}>{h}</h2>
+            <p className="text-[14px] leading-relaxed">{b}</p>
+          </section>
+        ))}
+      </div>
+    </AppShell>
+  );
+}

--- a/content/docs.md
+++ b/content/docs.md
@@ -1,0 +1,75 @@
+## Overview
+
+**LixEditor** is the block-based WYSIWYG editor that powers LixBlogs. It is built on BlockNote + React, ships a custom block schema (image, equation, mentions, tabs, table of contents), and is real-time-collaboration ready via Yjs. This page documents the developer API.
+
+## Installation
+
+```
+npm install @elixpo/lixeditor
+```
+
+Peer dependencies: `react >= 18` and `react-dom >= 18`.
+
+## Quick start
+
+```jsx
+import { LixEditor } from '@elixpo/lixeditor';
+import '@elixpo/lixeditor/style.css';
+
+export default function Editor() {
+  return (
+    <LixEditor
+      initialContent={[]}
+      onChange={(blocks) => save(blocks)}
+    />
+  );
+}
+```
+
+`onChange` receives the document as an array of **block** objects — clean JSON you can persist and re-render anywhere.
+
+## `<LixEditor>` props
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| `initialContent` | `Block[]` | Initial document. Pass `[]` for a blank editor. |
+| `onChange` | `(blocks: Block[]) => void` | Fires on every edit with the full document. |
+| `onReady` | `() => void` | Fires once the editor has mounted. |
+| `editable` | `boolean` | Read-only when `false`. Default `true`. |
+| `collaboration` | `CollabConfig` | Yjs provider + user `{ name, color }` for live editing. |
+| `blogId` | `string` | Scopes inline media uploads to a blog folder. |
+
+## Imperative API (ref)
+
+```jsx
+const ref = useRef(null);
+<LixEditor ref={ref} />
+
+ref.current.getBlocks();      // → Block[] current document
+ref.current.getEditor();      // → underlying BlockNote editor
+ref.current.replaceBlocks(b); // replace the whole document
+```
+
+## Block model
+
+Each block is `{ id, type, props, content, children }`. Built-in `type`s:
+
+- `paragraph`, `heading` (`level` 1–3), `quote`, `codeBlock`
+- `bulletListItem`, `numberedListItem`, `checkListItem`
+- `image`, `table`, `equation`, `mention`, `tabs`, `tableOfContents`
+
+Inline styles: `bold`, `italic`, `underline`, `strike`, `code`, `textColor`, `backgroundColor`, plus link and date inline content.
+
+## Collaboration
+
+LixEditor accepts a Yjs document + WebSocket provider. Pass a `collaboration` config with the shared doc and the local user's `{ name, color }`; remote cursors and selections render automatically.
+
+## Markdown & slash commands
+
+- Type `/` for the command menu (insert any block).
+- Markdown shortcuts: `#` heading, `-`/`1.` lists, `>` quote, ``` ``` ``` code, `**bold**`, etc.
+- Import/export Markdown via the editor's markdown helpers.
+
+## Rendering stored content
+
+Persist the `Block[]` JSON from `onChange`, then render it read-only later with `editable={false}` and `initialContent={blocks}` — the same renderer LixBlogs uses for published posts.

--- a/content/privacy.md
+++ b/content/privacy.md
@@ -1,0 +1,43 @@
+# Privacy Policy
+
+_Last updated: June 2026_
+
+LixBlogs is a blogging platform operated by **Elixpo** (Ayushman Bhattacharya). This policy explains what we collect, how we use it, and how we keep it safe. Questions? Email **hello@elixpo.com**.
+
+## Who we are
+
+LixBlogs lets you read, write, and publish posts. Sign-in is handled by **Elixpo Accounts** via OAuth 2.0 — we never see or store your password.
+
+## What we collect
+
+- **Account details** from Elixpo Accounts: your username, display name, email, and avatar.
+- **Content you create**: posts, drafts, titles, tags, comments, and organizations.
+- **Activity signals**: views, reads, likes, claps, bookmarks, follows, and reposts — used to power your feed and author stats.
+
+## How we use it
+
+- Authenticate you and render your profile and posts.
+- Personalize your "For you" feed and compute author analytics.
+- Send transactional email only: login alerts, account actions, and an optional weekly digest. We do **not** send marketing spam.
+
+## Images & media
+
+Cover images, avatars, organization logos, and in-post images you upload are **compressed to WebP** in your browser and stored on **Cloudinary**, served over **HTTPS**. We store only the media you upload to power your posts and profile, and we do **not** embed third-party advertising or tracking pixels in your content. Deleting a post removes its associated media.
+
+## Where your data lives
+
+- **Text & metadata**: Cloudflare **D1** (database) and **KV** (cache).
+- **Media**: **Cloudinary** (WebP, HTTPS).
+- **Session**: an `httpOnly`, `Secure`, `SameSite=Lax` cookie — not readable by JavaScript.
+
+## Open source & transparency
+
+LixBlogs is open source. You can read exactly how your data is handled in the code at **[github.com/elixpo/blogs.elixpo](https://github.com/elixpo/blogs.elixpo)**. Found a privacy concern? Open an issue or email us.
+
+## Your choices
+
+You can edit or delete your content anytime. **Account deletion and app revocation** are handled at **accounts.elixpo.com → Connected apps**.
+
+## Contact
+
+Questions about your data? Email **hello@elixpo.com**.

--- a/content/privacy.md
+++ b/content/privacy.md
@@ -32,12 +32,14 @@ Cover images, avatars, organization logos, and in-post images you upload are **c
 
 ## Open source & transparency
 
-LixBlogs is open source. You can read exactly how your data is handled in the code at **[github.com/elixpo/blogs.elixpo](https://github.com/elixpo/blogs.elixpo)**. Found a privacy concern? Open an issue or email us.
+LixBlogs is open source. You can read exactly how your data is handled in the code at **[LixBlogs Open Source Code](https://github.com/elixpo/blogs.elixpo)**. Found a privacy concern? Open an issue or email us.
 
 ## Your choices
 
-You can edit or delete your content anytime. **Account deletion and app revocation** are handled at **accounts.elixpo.com → Connected apps**.
+You can edit or delete your content anytime. **Account deletion and app revocation** are handled at [Connected Apps](https://accounts.elixpo.com/dashboard/services)
+
 
 ## Contact
 
-Questions about your data? Email **hello@elixpo.com**.
+- Questions about your data? Email **hello@elixpo.com**.
+- Or leave us an issue at [Blogs Issues](https://github.com/elixpo/blogs.elixpo/issues/new)

--- a/content/terms-of-service.md
+++ b/content/terms-of-service.md
@@ -1,0 +1,41 @@
+# Terms of Service
+
+_Last updated: June 2026_
+
+By using **LixBlogs** (operated by Elixpo / Ayushman Bhattacharya) you agree to these terms. If you do not agree, please do not use the service.
+
+## Your account
+
+You are responsible for activity under your account. Sign-in is provided through **Elixpo Accounts**; keep your credentials secure.
+
+## Your content
+
+You **retain ownership** of what you publish. By posting, you grant LixBlogs a non-exclusive license to host, display, and distribute your content on the platform. You are responsible for having the rights to everything you post.
+
+## Acceptable use
+
+No spam, harassment, hate speech, NSFW or illegal content, copyright infringement, or attempts to disrupt the service. We may remove content or suspend accounts that violate these rules.
+
+## Reposts & attribution
+
+Resharing keeps the original author's attribution. Do not misrepresent authorship or imply an endorsement you do not have.
+
+## Trademarks
+
+"Elixpo", "LixBlogs", "LixEditor", and "LixSketch" are trademarks of Elixpo. The source code is open under MIT **with a trademark exception** — you may use the code, but not the names/branding for a derivative product without permission.
+
+## License
+
+LixBlogs is open source under **MIT WITH Elixpo-trademarks**. Read the full license here: **[github.com/elixpo/blogs.elixpo/blob/main/LICENSE](https://github.com/elixpo/blogs.elixpo/blob/main/LICENSE)**.
+
+## Disclaimer
+
+The service is provided "as is", without warranties. To the extent permitted by law, Elixpo is not liable for damages arising from its use.
+
+## Changes
+
+We may update these terms; continued use after changes means you accept them.
+
+## Contact
+
+Questions? Email **hello@elixpo.com**.

--- a/middleware.js
+++ b/middleware.js
@@ -8,6 +8,7 @@ const APP_ROUTES = new Set([
   'about', 'api', 'callback', 'edit', 'feed', 'handle', 'intro', 'library',
   'login', 'new-blog', 'notifications', 'profile', 'pricing', 'register', 'settings',
   'sign-in', 'sign-up', 'stats', 'stories', 'org',
+  'help', 'docs', 'privacy', 'terms',
   '_next', 'favicon.ico', 'logo.png', 'logo-dark.png', 'logo-light.png', 'base-logo.png',
 ]);
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "cropperjs": "^2.1.0",
     "framer-motion": "^12.38.0",
     "katex": "^0.16.43",
+    "marked": "^16.4.2",
     "mermaid": "^11.13.0",
     "next": "^15.3.0",
     "react": "^19.2.3",

--- a/src/components/AppShell.jsx
+++ b/src/components/AppShell.jsx
@@ -522,7 +522,7 @@ export default function AppShell({ children }) {
                 </Link>
               ))}
             </div>
-            {user && (
+            {user ? (
               <Link href="/profile" className="block px-3 py-3 rounded-xl transition-colors cursor-pointer" style={{ backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border-default)' }}>
                 <div className="flex items-center gap-2.5">
                   <UserAvatar src={user.avatar_url} name={user.display_name || user.username} size={32} className="flex-shrink-0" />
@@ -532,6 +532,22 @@ export default function AppShell({ children }) {
                   </div>
                 </div>
               </Link>
+            ) : (
+              <div className="px-3 py-3 rounded-xl" style={{ backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border-default)' }}>
+                <div className="flex items-center gap-2.5 mb-3">
+                  <div className="h-8 w-8 rounded-full flex-shrink-0 flex items-center justify-center" style={{ backgroundColor: 'var(--bg-hover)', border: '1px solid var(--border-default)' }}>
+                    <ion-icon name="person-outline" style={{ fontSize: '16px', color: 'var(--text-muted)' }} />
+                  </div>
+                  <div className="min-w-0">
+                    <p className="text-[13px] font-medium truncate" style={{ color: 'var(--text-primary)' }}>Guest</p>
+                    <p className="text-[11px] truncate" style={{ color: 'var(--text-muted)' }}>Not signed in</p>
+                  </div>
+                </div>
+                <button onClick={handleLogin} className="w-full flex items-center justify-center gap-1.5 px-3 py-2 rounded-lg text-[13px] font-semibold transition-colors" style={{ backgroundColor: 'var(--accent)', color: '#fff' }}>
+                  <ion-icon name="log-in-outline" style={{ fontSize: '15px' }} />
+                  Sign In
+                </button>
+              </div>
             )}
           </div>
         </aside>

--- a/src/components/AppShell.jsx
+++ b/src/components/AppShell.jsx
@@ -241,6 +241,35 @@ const NAV_ITEMS = [
   { label: 'Stats', icon: 'stats-chart-outline', href: '/stats' },
 ];
 
+// GitHub star counter (stars only) → links to the repo.
+function GitHubStars() {
+  const [stars, setStars] = useState(null);
+  useEffect(() => {
+    let active = true;
+    fetch('https://api.github.com/repos/elixpo/blogs.elixpo')
+      .then(r => (r.ok ? r.json() : null))
+      .then(d => { if (active && d && typeof d.stargazers_count === 'number') setStars(d.stargazers_count); })
+      .catch(() => {});
+    return () => { active = false; };
+  }, []);
+  return (
+    <a
+      href="https://github.com/elixpo/blogs.elixpo"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="hidden sm:flex items-center gap-1.5 h-9 px-2.5 rounded-lg text-[13px] transition-colors"
+      style={{ color: 'var(--text-muted)', border: '1px solid var(--border-default)' }}
+      onMouseEnter={e => { e.currentTarget.style.backgroundColor = 'var(--bg-hover)'; e.currentTarget.style.color = 'var(--text-primary)'; }}
+      onMouseLeave={e => { e.currentTarget.style.backgroundColor = 'transparent'; e.currentTarget.style.color = 'var(--text-muted)'; }}
+      title="Star us on GitHub"
+    >
+      <ion-icon name="logo-github" style={{ fontSize: '16px' }} />
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .587l3.668 7.431 8.2 1.192-5.934 5.787 1.401 8.169L12 18.896l-7.335 3.857 1.401-8.169L.132 9.21l8.2-1.192z" /></svg>
+      <span className="font-medium tabular-nums">{stars ?? '—'}</span>
+    </a>
+  );
+}
+
 function ProfileDropdown({ user, logout }) {
   const [open, setOpen] = useState(false);
   const [orgs, setOrgs] = useState([]);
@@ -395,6 +424,7 @@ export default function AppShell({ children }) {
             </Link>
           </div>
           <div className="flex items-center gap-2">
+            <GitHubStars />
             {/* Theme toggle */}
             <button
               onClick={toggleTheme}
@@ -470,33 +500,49 @@ export default function AppShell({ children }) {
                 </Link>
               );
             })}
-            <div className="mt-3 pt-3" style={{ borderTop: '1px solid var(--divider)' }}>
-              <Link
-                href="/settings"
-                className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-[14px] transition-colors"
-                style={{
-                  color: pathname.startsWith('/settings') ? 'var(--text-primary)' : 'var(--text-muted)',
-                  backgroundColor: pathname.startsWith('/settings') ? 'var(--bg-active)' : 'transparent',
-                }}
-                onMouseEnter={e => { if (!pathname.startsWith('/settings')) { e.currentTarget.style.backgroundColor = 'var(--bg-hover)'; e.currentTarget.style.color = 'var(--text-secondary)'; }}}
-                onMouseLeave={e => { if (!pathname.startsWith('/settings')) { e.currentTarget.style.backgroundColor = 'transparent'; e.currentTarget.style.color = 'var(--text-muted)'; }}}
-              >
-                <ion-icon name="settings-outline" style={{ fontSize: '18px' }} />
-                Settings
-              </Link>
-            </div>
-          </nav>
-          {user && (
-            <Link href="/profile" className="block px-3 py-3 rounded-xl transition-colors cursor-pointer" style={{ backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border-default)' }}>
-              <div className="flex items-center gap-2.5">
-                <UserAvatar src={user.avatar_url} name={user.display_name || user.username} size={32} className="flex-shrink-0" />
-                <div className="min-w-0">
-                  <p className="text-[13px] font-medium truncate" style={{ color: 'var(--text-primary)' }}>{user.display_name || user.username}</p>
-                  <p className="text-[11px] truncate" style={{ color: 'var(--text-muted)' }}>@{user.username}</p>
-                </div>
-              </div>
+            {/* Settings — kept above the divider with the primary nav */}
+            <Link
+              href="/settings"
+              className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-[14px] transition-colors"
+              style={{
+                color: pathname.startsWith('/settings') ? 'var(--text-primary)' : 'var(--text-muted)',
+                backgroundColor: pathname.startsWith('/settings') ? 'var(--bg-active)' : 'transparent',
+              }}
+              onMouseEnter={e => { if (!pathname.startsWith('/settings')) { e.currentTarget.style.backgroundColor = 'var(--bg-hover)'; e.currentTarget.style.color = 'var(--text-secondary)'; }}}
+              onMouseLeave={e => { if (!pathname.startsWith('/settings')) { e.currentTarget.style.backgroundColor = 'transparent'; e.currentTarget.style.color = 'var(--text-muted)'; }}}
+            >
+              <ion-icon name="settings-outline" style={{ fontSize: '18px' }} />
+              Settings
             </Link>
-          )}
+          </nav>
+
+          {/* Bottom: docs + legal (above the account), then the account card */}
+          <div>
+            <div className="flex flex-wrap gap-x-4 gap-y-1.5 px-3 py-3 mb-1 text-[12px]" style={{ borderTop: '1px solid var(--divider)', color: 'var(--text-faint)' }}>
+              {[
+                { href: '/docs', icon: 'document-text-outline', label: 'Docs' },
+                { href: '/help', icon: 'help-buoy-outline', label: 'Help' },
+                { href: '/privacy', icon: 'shield-checkmark-outline', label: 'Privacy' },
+                { href: '/terms', icon: 'document-outline', label: 'Terms' },
+              ].map(l => (
+                <Link key={l.href} href={l.href} className="flex items-center gap-1 hover:text-[var(--text-secondary)] transition-colors" title={l.label}>
+                  <ion-icon name={l.icon} style={{ fontSize: '14px' }} />
+                  {l.label}
+                </Link>
+              ))}
+            </div>
+            {user && (
+              <Link href="/profile" className="block px-3 py-3 rounded-xl transition-colors cursor-pointer" style={{ backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border-default)' }}>
+                <div className="flex items-center gap-2.5">
+                  <UserAvatar src={user.avatar_url} name={user.display_name || user.username} size={32} className="flex-shrink-0" />
+                  <div className="min-w-0">
+                    <p className="text-[13px] font-medium truncate" style={{ color: 'var(--text-primary)' }}>{user.display_name || user.username}</p>
+                    <p className="text-[11px] truncate" style={{ color: 'var(--text-muted)' }}>@{user.username}</p>
+                  </div>
+                </div>
+              </Link>
+            )}
+          </div>
         </aside>
 
         {/* Main Content */}

--- a/src/components/AppShell.jsx
+++ b/src/components/AppShell.jsx
@@ -509,15 +509,23 @@ export default function AppShell({ children }) {
 
           {/* Bottom: docs + legal (above the account), then the account card */}
           <div>
-            <div className="flex flex-wrap gap-x-4 gap-y-1.5 px-3 py-3 mb-1 text-[12px]" style={{ borderTop: '1px solid var(--divider)', color: 'var(--text-faint)' }}>
+            <div className="flex flex-col gap-1 pt-3 pb-2 mb-1" style={{ borderTop: '1px solid var(--divider)' }}>
               {[
                 { href: '/docs', icon: 'document-text-outline', label: 'Docs' },
                 { href: '/help', icon: 'help-buoy-outline', label: 'Help' },
                 { href: '/privacy', icon: 'shield-checkmark-outline', label: 'Privacy' },
                 { href: '/terms', icon: 'document-outline', label: 'Terms' },
               ].map(l => (
-                <Link key={l.href} href={l.href} className="flex items-center gap-1 hover:text-[var(--text-secondary)] transition-colors" title={l.label}>
-                  <ion-icon name={l.icon} style={{ fontSize: '14px' }} />
+                <Link
+                  key={l.href}
+                  href={l.href}
+                  className="flex items-center gap-2.5 w-full px-3 py-2 rounded-lg text-[13px] transition-colors"
+                  style={{ color: 'var(--text-muted)' }}
+                  onMouseEnter={e => { e.currentTarget.style.backgroundColor = 'var(--bg-hover)'; e.currentTarget.style.color = 'var(--text-secondary)'; }}
+                  onMouseLeave={e => { e.currentTarget.style.backgroundColor = 'transparent'; e.currentTarget.style.color = 'var(--text-muted)'; }}
+                  title={l.label}
+                >
+                  <ion-icon name={l.icon} style={{ fontSize: '16px' }} />
                   {l.label}
                 </Link>
               ))}

--- a/src/components/AppShell.jsx
+++ b/src/components/AppShell.jsx
@@ -455,22 +455,11 @@ export default function AppShell({ children }) {
                 <ProfileDropdown user={user} logout={logout} />
               </>
             ) : (
-              <>
-                {/* "Sign In" text is hidden on phones — the icon button below covers it */}
-                <Link
-                  href="/sign-in"
-                  className="hidden sm:block text-[14px] transition-colors px-3 py-1.5 rounded-lg"
-                  style={{ color: 'var(--text-muted)' }}
-                  onMouseEnter={e => { e.currentTarget.style.backgroundColor = 'var(--bg-hover)'; e.currentTarget.style.color = 'var(--text-primary)'; }}
-                  onMouseLeave={e => { e.currentTarget.style.backgroundColor = 'transparent'; e.currentTarget.style.color = 'var(--text-muted)'; }}
-                >
-                  Sign In
-                </Link>
-                <button onClick={handleLogin} className="text-[14px] font-medium text-white bg-[#9b7bf7] hover:bg-[#8b6ae6] transition-colors rounded-full flex items-center justify-center w-9 h-9 sm:w-auto sm:h-auto sm:px-4 sm:py-1.5" title="Get started">
-                  <span className="hidden sm:inline">Get Started</span>
-                  <span className="sm:hidden flex items-center justify-center"><ion-icon name="log-in-outline" style={{ fontSize: '18px' }} /></span>
-                </button>
-              </>
+              // Single sign-in entry point (Sign In and Get Started did the same thing).
+              <button onClick={handleLogin} className="text-[14px] font-medium text-white bg-[#9b7bf7] hover:bg-[#8b6ae6] transition-colors rounded-full flex items-center justify-center w-9 h-9 sm:w-auto sm:h-auto sm:px-4 sm:py-1.5" title="Sign in">
+                <span className="hidden sm:inline">Sign In</span>
+                <span className="sm:hidden flex items-center justify-center"><ion-icon name="log-in-outline" style={{ fontSize: '18px' }} /></span>
+              </button>
             )}
           </div>
         </div>
@@ -481,7 +470,7 @@ export default function AppShell({ children }) {
         {/* Left Sidebar */}
         <aside className="hidden lg:flex flex-col w-[220px] flex-shrink-0 sticky top-14 h-[calc(100vh-56px)] px-4 py-6 justify-between" style={{ borderRight: '1px solid var(--border-default)' }}>
           <nav className="flex flex-col gap-1">
-            {NAV_ITEMS.map((item) => {
+            {NAV_ITEMS.filter((item) => user || item.href === '/').map((item) => {
               const isActive = pathname === item.href || (item.href !== '/' && pathname.startsWith(item.href));
               return (
                 <Link
@@ -500,7 +489,8 @@ export default function AppShell({ children }) {
                 </Link>
               );
             })}
-            {/* Settings — kept above the divider with the primary nav */}
+            {/* Settings — kept above the divider with the primary nav (signed-in only) */}
+            {user && (
             <Link
               href="/settings"
               className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-[14px] transition-colors"
@@ -514,6 +504,7 @@ export default function AppShell({ children }) {
               <ion-icon name="settings-outline" style={{ fontSize: '18px' }} />
               Settings
             </Link>
+            )}
           </nav>
 
           {/* Bottom: docs + legal (above the account), then the account card */}

--- a/src/components/AppShell.jsx
+++ b/src/components/AppShell.jsx
@@ -353,7 +353,7 @@ function ProfileDropdown({ user, logout }) {
           <div style={{ height: '1px', backgroundColor: 'var(--divider)' }} />
 
           <div className="py-1.5">
-            <DropdownItem href="/about" onClick={() => setOpen(false)} icon="help-circle-outline" faint>Help</DropdownItem>
+            <DropdownItem href="/help" onClick={() => setOpen(false)} icon="help-circle-outline" faint>Help</DropdownItem>
             <DropdownItem href="/pricing" onClick={() => setOpen(false)} icon="diamond-outline" faint>Pricing</DropdownItem>
           </div>
 

--- a/src/components/DocsView.jsx
+++ b/src/components/DocsView.jsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useState } from 'react';
+import AppShell from './AppShell';
+
+function LinkCard({ icon, iconColor, bg, title, desc, href, cta }) {
+  return (
+    <a href={href} target="_blank" rel="noopener noreferrer" className="block rounded-2xl p-5 h-full transition-colors" style={{ backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border-default)' }}>
+      <div className="flex items-center gap-2 mb-2">
+        <div className="h-9 w-9 rounded-lg flex items-center justify-center" style={{ backgroundColor: bg }}>
+          <ion-icon name={icon} style={{ fontSize: '20px', color: iconColor }} />
+        </div>
+        <h3 className="text-[15px] font-bold" style={{ color: 'var(--text-primary)' }}>{title}</h3>
+      </div>
+      <p className="text-[13px] leading-relaxed mb-2" style={{ color: 'var(--text-muted)' }}>{desc}</p>
+      <span className="text-[13px] underline" style={{ color: 'var(--accent)' }}>{cta} →</span>
+    </a>
+  );
+}
+
+export default function DocsView({ md, html }) {
+  const [copied, setCopied] = useState(false);
+  const copyForLLM = () => {
+    navigator.clipboard.writeText(md).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1800);
+    }).catch(() => {});
+  };
+
+  return (
+    <AppShell>
+      <div className="w-full max-w-3xl mx-auto px-6 py-12 block">
+        <div className="flex items-start justify-between gap-4 mb-6">
+          <div>
+            <h1 className="text-3xl font-extrabold mb-1" style={{ color: 'var(--text-primary)' }}>LixEditor Docs</h1>
+            <p className="text-[14px]" style={{ color: 'var(--text-muted)' }}>Developer API for the editor that powers LixBlogs.</p>
+          </div>
+          <button
+            onClick={copyForLLM}
+            className="flex-shrink-0 flex items-center gap-1.5 px-3 py-2 rounded-lg text-[13px] font-medium transition-colors"
+            style={{ color: copied ? '#16a34a' : 'var(--text-muted)', border: '1px solid var(--border-default)', backgroundColor: 'var(--bg-surface)' }}
+            title="Copy these docs as Markdown for an LLM"
+          >
+            <ion-icon name={copied ? 'checkmark' : 'copy-outline'} style={{ fontSize: '15px' }} />
+            {copied ? 'Copied' : 'Copy for LLM'}
+          </button>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2 mb-10">
+          <LinkCard icon="logo-npm" iconColor="#cb0004" bg="#cb000420" title="npm package" desc="Install @elixpo/lixeditor and use the editor in any React app." href="https://www.npmjs.com/package/@elixpo/lixeditor" cta="View on npm" />
+          <LinkCard icon="code-slash-outline" iconColor="#0098ff" bg="#0098ff20" title="VS Code extension" desc="Draft and preview posts without leaving your editor." href="https://marketplace.visualstudio.com/items?itemName=Elixpo.lixeditor" cta="Get it on the Marketplace" />
+        </div>
+
+        <div className="legal-md" dangerouslySetInnerHTML={{ __html: html }} />
+      </div>
+    </AppShell>
+  );
+}

--- a/src/components/MarkdownPage.jsx
+++ b/src/components/MarkdownPage.jsx
@@ -1,0 +1,16 @@
+'use client';
+
+import AppShell from './AppShell';
+
+// Renders pre-converted markdown HTML in a full-width, vertically-spaced
+// document layout. HTML is built server-side from our own trusted .md files.
+export default function MarkdownPage({ html }) {
+  return (
+    <AppShell>
+      <div
+        className="w-full max-w-3xl mx-auto px-6 py-12 block legal-md"
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    </AppShell>
+  );
+}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -714,14 +714,10 @@ export default function App() {
             </Link>
           </div>
 
-          {/* Footer Links */}
-          <div className="mt-8 flex flex-wrap gap-x-4 gap-y-1 text-[12px]" style={{ color: 'var(--text-faint)' }}>
-            <span className="cursor-pointer transition-colors hover:opacity-70">Help</span>
-            <span className="cursor-pointer transition-colors hover:opacity-70">Status</span>
-            <span className="cursor-pointer transition-colors hover:opacity-70">About</span>
-            <span className="cursor-pointer transition-colors hover:opacity-70">Blog</span>
-            <span className="cursor-pointer transition-colors hover:opacity-70">Privacy</span>
-            <span className="cursor-pointer transition-colors hover:opacity-70">Terms</span>
+          {/* Status — help/legal/docs now live in the left sidebar above the account */}
+          <div className="mt-8 flex items-center gap-1.5 text-[12px]" style={{ color: 'var(--text-faint)' }}>
+            <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: '#16a34a' }} />
+            <span>All systems operational</span>
           </div>
         </aside>
       </div>


### PR DESCRIPTION
## Changes Made

- `LICENSE` — Replaced plain MIT with MIT + Elixpo-trademarks exception; reserves "Elixpo", "LixBlogs", "LixEditor", "LixSketch" names and logo; updated copyright to "Elixpo (Ayushman Bhattacharya) and the LixBlogs authors"
- `app/docs/page.jsx` — New docs page covering LixEditor npm install, React usage, VS Code extension, and feature list
- `app/help/page.jsx` — New help & support page with email (hello@elixpo.com) and GitHub issue links
- `app/privacy/page.jsx` — New privacy policy page covering data collection, usage, storage (Cloudflare D1/KV/R2, Cloudinary), and user choices
- `app/terms/page.jsx` — New terms of service page covering account responsibility, content licensing, acceptable use, trademarks, and disclaimers
- `middleware.js` — Added `help`, `docs`, `privacy`, `terms` to `APP_ROUTES` so the middleware allows these paths through
- `src/components/AppShell.jsx` — Added `GitHubStars` component (fetches stargazers count from GitHub API); updated profile dropdown Help link from `/about` to `/help`; added GitHub stars button to top navbar; reorganized mobile sidebar with settings and legal link sections

## Checklist

- [x] No Node built-ins imported (crypto, fs, path, stream, Buffer)
- [x] `./biome.sh ci` clean
- [x] Tested locally: <how>