### PR TITLE
[FEAT]: Allow the emojies to be created using colon in comments

### DIFF
--- a/src/components/BlogComments.jsx
+++ b/src/components/BlogComments.jsx
@@ -113,7 +113,7 @@ export default function BlogComments({ blogId, blogAuthorId }) {
               value={newComment}
               onChange={e => setNewComment(e.target.value)}
               onKeyDown={e => { if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) { e.preventDefault(); postComment(newComment); } }}
-              placeholder="Add a comment... (@ to mention)"
+              placeholder="Add a comment... (@ to mention, :emoji:)"
               rows={2}
               className="w-full px-1 py-3 outline-none text-[14px] resize-none bg-transparent"
               style={{ borderBottom: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
@@ -213,7 +213,7 @@ export default function BlogComments({ blogId, blogAuthorId }) {
                       <MentionTextarea
                         value={replyText}
                         onChange={e => setReplyText(e.target.value)}
-                        placeholder={`Reply to ${replyTo.username}... (@ to mention)`}
+                        placeholder={`Reply to ${replyTo.username}... (@ to mention, :emoji:)`}
                         rows={2}
                         className="w-full rounded-lg px-3 py-2 outline-none text-[13px] resize-none"
                         style={{ flex: 1, backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}

--- a/src/components/FollowListModal.jsx
+++ b/src/components/FollowListModal.jsx
@@ -1,16 +1,18 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 
 // Modal listing a user's followers or following. Names link to their profile.
 // props: username, type ('followers' | 'following'), onClose
 export default function FollowListModal({ username, type, onClose }) {
   const [items, setItems] = useState(null);
+  const [query, setQuery] = useState('');
 
   useEffect(() => {
     let active = true;
     setItems(null);
+    setQuery('');
     fetch(`/api/users/${encodeURIComponent(username)}/follow-list?type=${type}`)
       .then(r => r.ok ? r.json() : { items: [] })
       .then(d => { if (active) setItems(d.items || []); })
@@ -20,32 +22,62 @@ export default function FollowListModal({ username, type, onClose }) {
 
   const title = type === 'following' ? 'Following' : 'Followers';
 
+  const filtered = useMemo(() => {
+    if (!items) return null;
+    const q = query.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter(it =>
+      (it.name || '').toLowerCase().includes(q) || (it.handle || '').toLowerCase().includes(q)
+    );
+  }, [items, query]);
+
   return (
     <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/50 px-4" onClick={onClose}>
       <div
-        className="w-full max-w-sm rounded-2xl overflow-hidden"
+        className="w-full max-w-md rounded-2xl overflow-hidden flex flex-col max-h-[80vh]"
         style={{ backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border-default)' }}
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between px-5 py-4 border-b border-[var(--border-default)]">
-          <h3 className="text-[15px] font-bold text-[var(--text-primary)]">{title}</h3>
+          <h3 className="text-[16px] font-bold text-[var(--text-primary)]">
+            {title}
+            {items && <span className="ml-2 text-[13px] font-normal" style={{ color: 'var(--text-muted)' }}>{items.length}</span>}
+          </h3>
           <button onClick={onClose} className="text-[var(--text-muted)] hover:text-[var(--text-primary)] p-1">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
           </button>
         </div>
 
-        <div className="max-h-[60vh] overflow-y-auto">
+        {/* Search bar */}
+        <div className="px-4 py-3 border-b border-[var(--border-default)]">
+          <div className="flex items-center gap-2 px-3 py-2 rounded-lg" style={{ backgroundColor: 'var(--bg-elevated)', border: '1px solid var(--border-default)' }}>
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ color: 'var(--text-muted)', flexShrink: 0 }}><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder={`Search ${title.toLowerCase()}`}
+              autoFocus
+              className="w-full bg-transparent outline-none text-[14px]"
+              style={{ color: 'var(--text-primary)' }}
+            />
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-y-auto">
           {items === null ? (
             <div className="p-5 space-y-3">
-              {[...Array(4)].map((_, i) => <div key={i} className="h-10 bg-[var(--bg-elevated)] animate-pulse rounded-lg" />)}
+              {[...Array(6)].map((_, i) => <div key={i} className="h-10 bg-[var(--bg-elevated)] animate-pulse rounded-lg" />)}
             </div>
-          ) : items.length === 0 ? (
+          ) : filtered.length === 0 ? (
             <p className="text-center text-[13px] text-[var(--text-muted)] py-10">
-              {type === 'following' ? 'Not following anyone yet.' : 'No followers yet.'}
+              {query.trim()
+                ? `No matches for "${query.trim()}"`
+                : (type === 'following' ? 'Not following anyone yet.' : 'No followers yet.')}
             </p>
           ) : (
             <ul>
-              {items.map((it, i) => (
+              {filtered.map((it, i) => (
                 <li key={i}>
                   <Link
                     href={`/${it.handle}`}

--- a/src/components/MentionTextarea.jsx
+++ b/src/components/MentionTextarea.jsx
@@ -1,28 +1,59 @@
 'use client';
 
 import { useState, useRef, useEffect, useCallback } from 'react';
+import { searchEmojiShortcodes, lookupEmojiShortcode } from '../data/emojiShortcodes';
 
-// A <textarea> with @username autocomplete (#10). Reuses /api/search?scope=users.
+// A <textarea> with @username autocomplete (#10) and :emoji: shortcodes.
+// Reuses /api/search?scope=users for mentions; emoji are resolved locally.
 // Drop-in: same value/onChange/placeholder/rows/className/style/onKeyDown props.
-// On select, replaces the active "@query" token with "@username ".
+//  - "@query" → menu of users; on select replaces with "@username ".
+//  - ":query" → menu of emoji; on select replaces with the emoji glyph.
+//  - typing a full ":name:" auto-converts to the emoji inline.
 export default function MentionTextarea({
   value, onChange, placeholder, rows = 2, className, style, onKeyDown, autoFocus,
 }) {
   const taRef = useRef(null);
-  const [menu, setMenu] = useState(null); // { query, start, results, active }
+  const [menu, setMenu] = useState(null); // { kind: 'mention'|'emoji', query, start, results, active }
   const debounceRef = useRef(null);
 
-  // Find an @token immediately before the caret (no whitespace inside).
+  // Find an @mention or :emoji: token immediately before the caret.
   const detect = useCallback((el) => {
     const caret = el.selectionStart;
     const upto = el.value.slice(0, caret);
-    const m = upto.match(/(?:^|\s)@([a-zA-Z0-9_-]*)$/);
-    if (!m) return null;
-    return { query: m[1], start: caret - m[1].length - 1 }; // index of '@'
+    const mention = upto.match(/(?:^|\s)@([a-zA-Z0-9_-]*)$/);
+    if (mention) return { kind: 'mention', query: mention[1], start: caret - mention[1].length - 1 };
+    const emoji = upto.match(/(?:^|\s):([a-zA-Z0-9_+-]+)$/);
+    if (emoji) return { kind: 'emoji', query: emoji[1], start: caret - emoji[1].length - 1 };
+    return null;
   }, []);
 
+  // Replace the textarea's current value[start..end] with `insert`, then place
+  // the caret after it. Slices against the live el.value (not the stale `value`
+  // prop) so mid-text conversions don't drop a character. `end` defaults to caret.
+  const replaceToken = useCallback((start, insert, end) => {
+    const el = taRef.current;
+    if (!el) return;
+    const src = el.value;
+    const endPos = end == null ? el.selectionStart : end;
+    const before = src.slice(0, start);
+    const after = src.slice(endPos);
+    const next = `${before}${insert}${after}`;
+    onChange({ target: { value: next } });
+    setMenu(null);
+    requestAnimationFrame(() => {
+      const pos = (before + insert).length;
+      try { el.focus(); el.setSelectionRange(pos, pos); } catch {}
+    });
+  }, [onChange]);
+
+  // Mention results come from the API (debounced); emoji results are local.
   useEffect(() => {
     if (!menu || menu.query == null) return;
+    if (menu.kind === 'emoji') {
+      if (menu.query.length < 2) { setMenu((p) => p && { ...p, results: [] }); return; }
+      setMenu((p) => p && { ...p, results: searchEmojiShortcodes(p.query), active: 0 });
+      return;
+    }
     clearTimeout(debounceRef.current);
     if (menu.query.length < 1) { setMenu((p) => p && { ...p, results: [] }); return; }
     debounceRef.current = setTimeout(async () => {
@@ -33,27 +64,32 @@ export default function MentionTextarea({
       } catch { setMenu((p) => p && { ...p, results: [] }); }
     }, 250);
     return () => clearTimeout(debounceRef.current);
-  }, [menu?.query]);
+  }, [menu?.query, menu?.kind]);
 
   const handleChange = (e) => {
     onChange(e);
-    const d = detect(e.target);
+    const el = e.target;
+
+    // Auto-convert a completed ":name:" token to its emoji.
+    const upto = el.value.slice(0, el.selectionStart);
+    const closed = upto.match(/(?:^|\s):([a-zA-Z0-9_+-]+):$/);
+    if (closed) {
+      const emoji = lookupEmojiShortcode(closed[1]);
+      if (emoji) {
+        const start = el.selectionStart - closed[1].length - 2; // first ':'
+        replaceToken(start, emoji, el.selectionStart);
+        return;
+      }
+    }
+
+    const d = detect(el);
     setMenu(d ? { ...d, results: [], active: 0 } : null);
   };
 
-  const pick = (u) => {
-    const el = taRef.current;
-    if (!el || !menu) return;
-    const before = value.slice(0, menu.start);
-    const after = value.slice(el.selectionStart);
-    const next = `${before}@${u.username} ${after}`;
-    // Synthesize a change event so the parent state updates.
-    onChange({ target: { value: next } });
-    setMenu(null);
-    requestAnimationFrame(() => {
-      const pos = (before + `@${u.username} `).length;
-      try { el.focus(); el.setSelectionRange(pos, pos); } catch {}
-    });
+  const pick = (item) => {
+    if (!menu) return;
+    if (menu.kind === 'emoji') replaceToken(menu.start, `${item.emoji} `);
+    else replaceToken(menu.start, `@${item.username} `);
   };
 
   const handleKeyDown = (e) => {
@@ -85,23 +121,36 @@ export default function MentionTextarea({
           className="absolute left-0 z-50 mt-1 w-64 rounded-lg overflow-hidden"
           style={{ top: '100%', background: 'var(--bg-surface)', border: '1px solid var(--border-default)', boxShadow: '0 12px 40px rgba(0,0,0,0.4)' }}
         >
-          {menu.results.map((u, i) => (
-            <button
-              key={u.id}
-              type="button"
-              onMouseDown={(e) => { e.preventDefault(); pick(u); }}
-              className="flex items-center gap-2 w-full px-3 py-2 text-left"
-              style={{ background: i === menu.active ? 'var(--bg-active)' : 'transparent' }}
-            >
-              {u.avatar_url
-                ? <img src={u.avatar_url} alt="" className="w-6 h-6 rounded-full object-cover" />
-                : <span className="w-6 h-6 rounded-full flex items-center justify-center text-[11px] font-bold" style={{ background: 'var(--bg-elevated)', color: 'var(--text-muted)' }}>{(u.display_name || u.username || '?')[0].toUpperCase()}</span>}
-              <span className="min-w-0">
-                <span className="block text-[13px] font-medium truncate" style={{ color: 'var(--text-primary)' }}>{u.display_name || u.username}</span>
-                <span className="block text-[11px] truncate" style={{ color: 'var(--text-faint)' }}>@{u.username}</span>
-              </span>
-            </button>
-          ))}
+          {menu.kind === 'emoji'
+            ? menu.results.map((em, i) => (
+                <button
+                  key={em.code}
+                  type="button"
+                  onMouseDown={(e) => { e.preventDefault(); pick(em); }}
+                  className="flex items-center gap-3 w-full px-3 py-2 text-left"
+                  style={{ background: i === menu.active ? 'var(--bg-active)' : 'transparent' }}
+                >
+                  <span className="text-[18px] leading-none w-6 text-center">{em.emoji}</span>
+                  <span className="text-[13px] truncate" style={{ color: 'var(--text-primary)' }}>:{em.code}:</span>
+                </button>
+              ))
+            : menu.results.map((u, i) => (
+                <button
+                  key={u.id}
+                  type="button"
+                  onMouseDown={(e) => { e.preventDefault(); pick(u); }}
+                  className="flex items-center gap-2 w-full px-3 py-2 text-left"
+                  style={{ background: i === menu.active ? 'var(--bg-active)' : 'transparent' }}
+                >
+                  {u.avatar_url
+                    ? <img src={u.avatar_url} alt="" className="w-6 h-6 rounded-full object-cover" />
+                    : <span className="w-6 h-6 rounded-full flex items-center justify-center text-[11px] font-bold" style={{ background: 'var(--bg-elevated)', color: 'var(--text-muted)' }}>{(u.display_name || u.username || '?')[0].toUpperCase()}</span>}
+                  <span className="min-w-0">
+                    <span className="block text-[13px] font-medium truncate" style={{ color: 'var(--text-primary)' }}>{u.display_name || u.username}</span>
+                    <span className="block text-[11px] truncate" style={{ color: 'var(--text-faint)' }}>@{u.username}</span>
+                  </span>
+                </button>
+              ))}
         </div>
       )}
     </div>

--- a/src/data/emojiShortcodes.js
+++ b/src/data/emojiShortcodes.js
@@ -1,0 +1,98 @@
+// Emoji shortcode map for the `:name:` syntax in comments (GitHub/Slack style).
+// Keep names lowercase; first key for an emoji is treated as its canonical name.
+export const EMOJI_SHORTCODES = {
+  // Smileys
+  grinning: '😀', smile: '😄', smiley: '😃', grin: '😁', laughing: '😆', satisfied: '😆',
+  sweat_smile: '😅', rofl: '🤣', joy: '😂', slightly_smiling_face: '🙂', upside_down_face: '🙃',
+  wink: '😉', blush: '😊', innocent: '😇', smiling_face_with_three_hearts: '🥰', heart_eyes: '😍',
+  star_struck: '🤩', kissing_heart: '😘', yum: '😋', stuck_out_tongue: '😛',
+  stuck_out_tongue_winking_eye: '😜', zany_face: '🤪', money_mouth_face: '🤑', hugs: '🤗',
+  thinking: '🤔', zipper_mouth_face: '🤐', neutral_face: '😐', expressionless: '😑',
+  no_mouth: '😶', smirk: '😏', unamused: '😒', roll_eyes: '🙄', grimacing: '😬',
+  relieved: '😌', pensive: '😔', sleepy: '😪', sleeping: '😴', mask: '😷',
+  face_with_thermometer: '🤒', nauseated_face: '🤢', vomiting: '🤮', hot_face: '🥵',
+  cold_face: '🥶', woozy_face: '🥴', dizzy_face: '😵', exploding_head: '🤯', mind_blown: '🤯',
+  cowboy_hat_face: '🤠', partying_face: '🥳', sunglasses: '😎', nerd_face: '🤓',
+  confused: '😕', worried: '😟', slightly_frowning_face: '🙁', open_mouth: '😮',
+  hushed: '😯', astonished: '😲', flushed: '😳', pleading_face: '🥺', frowning: '😦',
+  anguished: '😧', fearful: '😨', cold_sweat: '😰', cry: '😢', sob: '😭', scream: '😱',
+  confounded: '😖', disappointed: '😞', sweat: '😓', weary: '😩', tired_face: '😫',
+  yawning_face: '🥱', triumph: '😤', rage: '😡', angry: '😠', cursing_face: '🤬',
+  smiling_imp: '😈', imp: '👿', skull: '💀', poop: '💩', hankey: '💩', clown_face: '🤡',
+  ghost: '👻', alien: '👽', space_invader: '👾', robot: '🤖',
+  // Hands & people
+  wave: '👋', raised_hand: '✋', vulcan_salute: '🖖', ok_hand: '👌', pinching_hand: '🤏',
+  v: '✌️', victory: '✌️', crossed_fingers: '🤞', love_you_gesture: '🤟', metal: '🤘',
+  call_me_hand: '🤙', point_left: '👈', point_right: '👉', point_up_2: '👆', point_down: '👇',
+  middle_finger: '🖕', fu: '🖕', thumbsup: '👍', '+1': '👍', thumbsdown: '👎', '-1': '👎',
+  fist: '✊', facepunch: '👊', punch: '👊', fist_left: '🤛', fist_right: '🤜', clap: '👏',
+  raised_hands: '🙌', open_hands: '👐', handshake: '🤝', pray: '🙏', muscle: '💪',
+  // Hearts & symbols
+  heart: '❤️', orange_heart: '🧡', yellow_heart: '💛', green_heart: '💚', blue_heart: '💙',
+  purple_heart: '💜', black_heart: '🖤', white_heart: '🤍', brown_heart: '🤎',
+  broken_heart: '💔', heart_on_fire: '❤️‍🔥', two_hearts: '💕', sparkling_heart: '💖',
+  cupid: '💘', heartbeat: '💓', heartpulse: '💗', revolving_hearts: '💞',
+  hundred: '💯', '100': '💯', anger: '💢', boom: '💥', collision: '💥', dizzy: '💫',
+  sweat_drops: '💦', dash: '💨', fire: '🔥', star: '⭐', star2: '🌟', sparkles: '✨',
+  zap: '⚡', bulb: '💡', // ideas/energy
+  // Celebration & objects
+  tada: '🎉', confetti_ball: '🎊', balloon: '🎈', gift: '🎁', trophy: '🏆', medal: '🏅',
+  '1st_place_medal': '🥇', '2nd_place_medal': '🥈', '3rd_place_medal': '🥉',
+  dart: '🎯', rocket: '🚀', crown: '👑', gem: '💎', moneybag: '💰', dollar: '💵',
+  // Marks
+  white_check_mark: '✅', heavy_check_mark: '✔️', check: '✔️', x: '❌', negative_squared_cross_mark: '❎',
+  warning: '⚠️', no_entry: '⛔', no_entry_sign: '🚫', question: '❓', grey_question: '❔',
+  exclamation: '❗', bangbang: '‼️', stop_sign: '🛑', recycle: '♻️',
+  // Tech & work
+  computer: '💻', desktop_computer: '🖥️', keyboard: '⌨️', iphone: '📱', phone: '☎️',
+  email: '📧', envelope: '✉️', memo: '📝', pencil: '📝', book: '📖', books: '📚',
+  bookmark: '🔖', paperclip: '📎', lock: '🔒', unlock: '🔓', key: '🔑', mag: '🔍',
+  hourglass: '⌛', alarm_clock: '⏰', calendar: '📅', chart_with_upwards_trend: '📈',
+  bug: '🐛', wrench: '🔧', hammer: '🔨', gear: '⚙️', link: '🔗',
+  // Speech
+  speech_balloon: '💬', thought_balloon: '💭', eyes: '👀', wave_goodbye: '👋',
+  // Nature
+  sun: '☀️', sunny: '☀️', moon: '🌙', crescent_moon: '🌙', rainbow: '🌈', cloud: '☁️',
+  snowflake: '❄️', ocean: '🌊', droplet: '💧', earth_africa: '🌍', earth_americas: '🌎',
+  cherry_blossom: '🌸', rose: '🌹', sunflower: '🌻', hibiscus: '🌺', tulip: '🌷',
+  seedling: '🌱', evergreen_tree: '🌲', deciduous_tree: '🌳', palm_tree: '🌴',
+  cactus: '🌵', four_leaf_clover: '🍀', leaves: '🍃', maple_leaf: '🍁',
+  // Animals
+  dog: '🐶', cat: '🐱', mouse: '🐭', hamster: '🐹', rabbit: '🐰', fox_face: '🦊',
+  bear: '🐻', panda_face: '🐼', koala: '🐨', tiger: '🐯', lion: '🦁', cow: '🐮',
+  pig: '🐷', frog: '🐸', monkey_face: '🐵', chicken: '🐔', penguin: '🐧', bird: '🐦',
+  eagle: '🦅', owl: '🦉', unicorn: '🦄', bee: '🐝', butterfly: '🦋', snail: '🐌',
+  // Food & drink
+  apple: '🍎', green_apple: '🍏', banana: '🍌', watermelon: '🍉', grapes: '🍇',
+  strawberry: '🍓', peach: '🍑', pineapple: '🍍', avocado: '🥑', tomato: '🍅',
+  corn: '🌽', bread: '🍞', cheese: '🧀', egg: '🥚', bacon: '🥓', hamburger: '🍔',
+  fries: '🍟', pizza: '🍕', hotdog: '🌭', taco: '🌮', burrito: '🌯', popcorn: '🍿',
+  doughnut: '🍩', cookie: '🍪', birthday: '🎂', cake: '🍰', cupcake: '🧁',
+  chocolate_bar: '🍫', candy: '🍬', lollipop: '🍭', coffee: '☕', tea: '🍵',
+  beer: '🍺', beers: '🍻', wine_glass: '🍷', cocktail: '🍸', tropical_drink: '🍹',
+  champagne: '🍾', clinking_glasses: '🥂',
+  // Activities
+  soccer: '⚽', basketball: '🏀', football: '🏈', baseball: '⚾', tennis: '🎾',
+  volleyball: '🏐', '8ball': '🎱', ping_pong: '🏓', badminton: '🏸', goal_net: '🥅',
+  golf: '⛳', video_game: '🎮', game_die: '🎲', musical_note: '🎵', notes: '🎶',
+  microphone: '🎤', headphones: '🎧', guitar: '🎸', art: '🎨', clapper: '🎬',
+};
+
+// Search shortcodes by a partial query. Returns [{ code, emoji }] ordered so that
+// prefix matches come first. `limit` caps the result count.
+export function searchEmojiShortcodes(query, limit = 8) {
+  const q = (query || '').toLowerCase();
+  if (!q) return [];
+  const prefix = [];
+  const contains = [];
+  for (const [code, emoji] of Object.entries(EMOJI_SHORTCODES)) {
+    if (code.startsWith(q)) prefix.push({ code, emoji });
+    else if (code.includes(q)) contains.push({ code, emoji });
+  }
+  return [...prefix, ...contains].slice(0, limit);
+}
+
+// Exact shortcode lookup for `:name:` auto-conversion. Returns the emoji or null.
+export function lookupEmojiShortcode(name) {
+  return EMOJI_SHORTCODES[(name || '').toLowerCase()] || null;
+}


### PR DESCRIPTION
## Changes Made
- `src/components/MentionTextarea.jsx` — Added `:emoji:` shortcode autocomplete alongside existing @mention support. Detects `:query` tokens, shows emoji picker menu, and auto-converts closed `:name:` tokens inline. Extracted shared `replaceToken` helper to avoid duplication between mention and emoji insertion.
- `src/data/emojiShortcodes.js` — New local emoji shortcode map (~150 entries) with `searchEmojiShortcodes` (prefix fuzzy match) and `lookupEmojiShortcode` (exact lookup) exports. No API dependency.
- `src/components/BlogComments.jsx` — Updated comment and reply placeholder text from `@ to mention` to `@ to mention, :emoji:` so users know the syntax exists.
- `src/components/FollowListModal.jsx` — Added a search/filter bar to the followers/following modal with `useMemo`-based filtering on name and handle. Widened modal from `max-w-sm` to `max-w-md`, added scrollable container with `max-h-[80vh]`, and appended item count next to the title.

## Checklist
- [ ] No Node built-ins imported (crypto, fs, path, stream, Buffer)
- [ ] `./biome.sh ci` clean
- [ ] Tested locally: <how>