### PR TITLE
[FEAT] : Allow users to pub in orgs and collections

### DIFF
--- a/app/api/blogs/publish/route.js
+++ b/app/api/blogs/publish/route.js
@@ -15,7 +15,7 @@ export async function POST(request) {
   }
 
   const body = await request.json();
-  const { slugid, title, subtitle, tags, publishAs, editorContent, pageEmoji, coverUrl, coverPos, coverZoom, status, lastKnownUpdatedAt, slug: requestedSlug } = body;
+  const { slugid, title, subtitle, tags, publishAs, editorContent, pageEmoji, coverUrl, coverPos, coverZoom, status, lastKnownUpdatedAt, slug: requestedSlug, collectionId } = body;
   const posX = Number.isFinite(coverPos?.x) ? coverPos.x : 50;
   const posY = Number.isFinite(coverPos?.y) ? coverPos.y : 50;
   const zoom = Number.isFinite(coverZoom) ? coverZoom : 1;
@@ -80,6 +80,19 @@ export async function POST(request) {
       }
     }
 
+    // A collection belongs to exactly one org, so it's only valid when the blog
+    // is published under that org. Publishing personally — or naming a collection
+    // from a different org — clears it. (Co-author access stays blog-scoped either
+    // way; filing under a collection never grants org/collection-level rights.)
+    let finalCollectionId = null;
+    const effectivePublishAs = publishAs || existing?.published_as || 'personal';
+    if (collectionId && effectivePublishAs.startsWith('org:')) {
+      const orgId = effectivePublishAs.slice(4);
+      const col = await db.prepare('SELECT id FROM collections WHERE id = ? AND org_id = ?')
+        .bind(collectionId, orgId).first();
+      if (col) finalCollectionId = collectionId;
+    }
+
     // Slugs are unique per owner (the URL is /owner/slug), not globally.
     const slugScope = {
       authorId: session.userId,
@@ -125,11 +138,11 @@ export async function POST(request) {
 
       let query = `
         UPDATE blogs SET title = ?, subtitle = ?, slug = ?, content = ?, excerpt = ?, published_as = ?,
-          status = ?, page_emoji = ?, cover_image_r2_key = ?, cover_pos_x = ?, cover_pos_y = ?, cover_zoom = ?,
+          collection_id = ?, status = ?, page_emoji = ?, cover_image_r2_key = ?, cover_pos_x = ?, cover_pos_y = ?, cover_zoom = ?,
           read_time_minutes = ?, updated_at = ?
       `;
       const params = [title, subtitle || '', slug, compressedContent, excerpt, publishAs || 'personal',
-        targetStatus, pageEmoji || '', coverUrl || '', posX, posY, zoom, readTime, now];
+        finalCollectionId, targetStatus, pageEmoji || '', coverUrl || '', posX, posY, zoom, readTime, now];
 
       if (publishedAt) {
         query += ', published_at = ?';
@@ -142,12 +155,12 @@ export async function POST(request) {
     } else {
       // Create and publish in one step
       await db.prepare(`
-        INSERT INTO blogs (id, slug, title, subtitle, content, excerpt, author_id, published_as, status,
+        INSERT INTO blogs (id, slug, title, subtitle, content, excerpt, author_id, published_as, collection_id, status,
           page_emoji, cover_image_r2_key, cover_pos_x, cover_pos_y, cover_zoom, read_time_minutes, created_at, updated_at, published_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `).bind(
         slugid, slug, title, subtitle || '', compressedContent, excerpt,
-        session.userId, publishAs || 'personal', targetStatus,
+        session.userId, publishAs || 'personal', finalCollectionId, targetStatus,
         pageEmoji || '', coverUrl || '', posX, posY, zoom, readTime, now, now,
         (targetStatus === 'published' || targetStatus === 'unlisted') ? now : null
       ).run();

--- a/app/api/orgs/collections/route.js
+++ b/app/api/orgs/collections/route.js
@@ -78,14 +78,23 @@ export async function PUT(request) {
   const session = await getSession();
   if (!session?.userId) return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
 
-  const { collectionId, name, description } = await request.json();
+  const { collectionId, name, description, slug } = await request.json();
   if (!collectionId) return NextResponse.json({ error: 'Missing collectionId' }, { status: 400 });
+
+  // Validate the new handle up-front (alphanumeric, single hyphens, 6–48 chars).
+  let cleanSlug = null;
+  if (typeof slug === 'string' && slug.trim()) {
+    const { validateSlug } = await import('../../../../lib/slugify');
+    const slugCheck = validateSlug(slug, { label: 'Collection handle' });
+    if (!slugCheck.ok) return NextResponse.json({ error: slugCheck.error }, { status: 400 });
+    cleanSlug = slugCheck.slug;
+  }
 
   try {
     const { getDB } = await import('../../../../lib/cloudflare');
     const db = getDB();
 
-    const col = await db.prepare('SELECT org_id FROM collections WHERE id = ?').bind(collectionId).first();
+    const col = await db.prepare('SELECT org_id, slug FROM collections WHERE id = ?').bind(collectionId).first();
     if (!col) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
     const myRole = await db.prepare('SELECT role FROM org_members WHERE org_id = ? AND user_id = ?')
@@ -96,11 +105,26 @@ export async function PUT(request) {
       return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
     }
 
-    const now = Math.floor(Date.now() / 1000);
-    await db.prepare('UPDATE collections SET name = COALESCE(?, name), description = COALESCE(?, description), updated_at = ? WHERE id = ?')
-      .bind(name || null, description || null, now, collectionId).run();
+    // Handle rename: collections are unique per (org_id, slug). Reject a clash
+    // before writing so the user gets a clear message, not a 500.
+    if (cleanSlug && cleanSlug !== col.slug) {
+      const clash = await db.prepare('SELECT 1 FROM collections WHERE org_id = ? AND slug = ? AND id != ?')
+        .bind(col.org_id, cleanSlug, collectionId).first();
+      if (clash) return NextResponse.json({ error: 'That handle is already used by another collection in this org' }, { status: 409 });
+    }
 
-    return NextResponse.json({ ok: true });
+    const now = Math.floor(Date.now() / 1000);
+    try {
+      await db.prepare('UPDATE collections SET name = COALESCE(?, name), description = COALESCE(?, description), slug = COALESCE(?, slug), updated_at = ? WHERE id = ?')
+        .bind(name || null, description || null, cleanSlug, now, collectionId).run();
+    } catch (e) {
+      if (e.message?.includes('UNIQUE')) {
+        return NextResponse.json({ error: 'That handle is already used by another collection in this org' }, { status: 409 });
+      }
+      throw e;
+    }
+
+    return NextResponse.json({ ok: true, slug: cleanSlug || col.slug });
   } catch {
     return NextResponse.json({ error: 'Failed to update' }, { status: 500 });
   }

--- a/src/views/WritePage.jsx
+++ b/src/views/WritePage.jsx
@@ -435,6 +435,8 @@ export default function WritePage({ slugid }) {
   const [blogVersion, setBlogVersion] = useState(null);
   const [lastKnownUpdatedAt, setLastKnownUpdatedAt] = useState(null);
   const [userOrgs, setUserOrgs] = useState([]);
+  const [collectionId, setCollectionId] = useState(null); // org collection to file under (null = org root)
+  const [orgCollections, setOrgCollections] = useState([]); // collections of the selected org
   const [hasUnsavedEdits, setHasUnsavedEdits] = useState(false);
   const settingsSnapshotRef = useRef(''); // publish-settings as of load / last publish — for the no-change Update shortcut
   const titleTextareaRef = useRef(null);
@@ -559,10 +561,10 @@ export default function WritePage({ slugid }) {
   }, []);
 
   // Refs to always hold latest draft data (avoids stale closures in intervals/beforeunload)
-  const draftDataRef = useRef({ title, subtitle, tags, publishAs, coverPreview, editorContent, pageEmoji, coverPos, coverZoom });
+  const draftDataRef = useRef({ title, subtitle, tags, publishAs, collectionId, coverPreview, editorContent, pageEmoji, coverPos, coverZoom });
   useEffect(() => {
-    draftDataRef.current = { title, subtitle, tags, publishAs, coverPreview, editorContent, pageEmoji, coverPos, coverZoom };
-  }, [title, subtitle, tags, publishAs, coverPreview, editorContent, pageEmoji, coverPos, coverZoom]);
+    draftDataRef.current = { title, subtitle, tags, publishAs, collectionId, coverPreview, editorContent, pageEmoji, coverPos, coverZoom };
+  }, [title, subtitle, tags, publishAs, collectionId, coverPreview, editorContent, pageEmoji, coverPos, coverZoom]);
 
   // Sync any buffered subpage drafts from localStorage to cloud
   const syncSubpageDrafts = useCallback(async () => {
@@ -779,6 +781,7 @@ export default function WritePage({ slugid }) {
         if (cloud.subtitle) setSubtitle(cloud.subtitle);
         if (cloud.tags?.length) setTags(cloud.tags);
         if (cloud.published_as) setPublishAs(cloud.published_as);
+        setCollectionId(cloud.collection_id || null);
         if (cloud.cover_image_r2_key) setCoverPreview(cloud.cover_image_r2_key);
         if (Number.isFinite(cloud.cover_pos_x) && Number.isFinite(cloud.cover_pos_y)) setCoverPos({ x: cloud.cover_pos_x, y: cloud.cover_pos_y });
         if (Number.isFinite(cloud.cover_zoom)) setCoverZoom(cloud.cover_zoom);
@@ -812,6 +815,7 @@ export default function WritePage({ slugid }) {
         if (local.subtitle) setSubtitle(local.subtitle);
         if (local.tags?.length) setTags(local.tags);
         if (local.publishAs) setPublishAs(local.publishAs);
+        if (local.collectionId) setCollectionId(local.collectionId);
         if (local.coverPreview) setCoverPreview(local.coverPreview);
         if (local.coverPos) setCoverPos(local.coverPos);
         if (Number.isFinite(local.coverZoom)) setCoverZoom(local.coverZoom);
@@ -834,12 +838,12 @@ export default function WritePage({ slugid }) {
     dirtyRef.current = true;
     autoSaveTimer.current = setTimeout(() => {
       if (title || editorContent) {
-        saveDraft(blogId, { title, subtitle, tags, publishAs, coverPreview, editorContent, pageEmoji, coverPos, coverZoom });
+        saveDraft(blogId, { title, subtitle, tags, publishAs, collectionId, coverPreview, editorContent, pageEmoji, coverPos, coverZoom });
         setLastSaved(Date.now());
       }
     }, 2000);
     return () => clearTimeout(autoSaveTimer.current);
-  }, [title, subtitle, tags, publishAs, coverPreview, editorContent, pageEmoji, coverPos, coverZoom, blogId]);
+  }, [title, subtitle, tags, publishAs, collectionId, coverPreview, editorContent, pageEmoji, coverPos, coverZoom, blogId]);
 
   // Background cloud flush — localStorage is the instant buffer, but beforeunload/
   // sendBeacon is unreliable, so flush unsynced edits to the cloud every 20s.
@@ -976,6 +980,19 @@ export default function WritePage({ slugid }) {
       .catch(() => {});
   }, []);
 
+  // Load collections for the selected org (publish-destination dropdown). Cleared
+  // when publishing personally so a stale org's collections can't be selected.
+  useEffect(() => {
+    if (!publishAs.startsWith('org:')) { setOrgCollections([]); return; }
+    const orgId = publishAs.slice(4);
+    let active = true;
+    fetch(`/api/orgs/collections?orgId=${encodeURIComponent(orgId)}`)
+      .then(r => r.ok ? r.json() : null)
+      .then(d => { if (active && d?.collections) setOrgCollections(d.collections); })
+      .catch(() => {});
+    return () => { active = false; };
+  }, [publishAs]);
+
   // Close owner dropdown on outside click
   useEffect(() => {
     if (!showOwnerDropdown) return;
@@ -1008,7 +1025,7 @@ export default function WritePage({ slugid }) {
   }, [blogId]);
 
   const handleSaveDraft = async () => {
-    saveDraft(blogId, { title, subtitle, tags, publishAs, coverPreview, editorContent, pageEmoji, coverPos, coverZoom });
+    saveDraft(blogId, { title, subtitle, tags, publishAs, collectionId, coverPreview, editorContent, pageEmoji, coverPos, coverZoom });
     setLastSaved(Date.now());
     setShowPublishMenu(false);
     syncToCloud({ showToast: true });

--- a/src/views/WritePage.jsx
+++ b/src/views/WritePage.jsx
@@ -1160,7 +1160,7 @@ export default function WritePage({ slugid }) {
   }, [title, draftLoading, editorReady]);
 
   // Serialized publish-settings, used to detect "nothing changed" on Update.
-  const settingsKey = () => JSON.stringify({ title, subtitle, tags, publishAs, pageEmoji, coverPreview, coverPos, coverZoom, slug });
+  const settingsKey = () => JSON.stringify({ title, subtitle, tags, publishAs, collectionId, pageEmoji, coverPreview, coverPos, coverZoom, slug });
   // Capture a baseline once the blog has finished loading.
   useEffect(() => {
     if (!draftLoading && settingsSnapshotRef.current === '') settingsSnapshotRef.current = settingsKey();
@@ -1181,7 +1181,7 @@ export default function WritePage({ slugid }) {
       const res = await fetch('/api/blogs/publish', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ slugid: blogId, title, subtitle, tags, publishAs, editorContent, pageEmoji, coverUrl: coverPreview, coverPos, coverZoom, slug, status: targetStatus, lastKnownUpdatedAt }),
+        body: JSON.stringify({ slugid: blogId, title, subtitle, tags, publishAs, collectionId, editorContent, pageEmoji, coverUrl: coverPreview, coverPos, coverZoom, slug, status: targetStatus, lastKnownUpdatedAt }),
       });
 
       if (res.status === 409) {
@@ -1232,7 +1232,7 @@ export default function WritePage({ slugid }) {
       await fetch('/api/blogs/publish', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ slugid: blogId, title, subtitle, tags, publishAs, editorContent, pageEmoji, slug, status: 'unlisted', lastKnownUpdatedAt }),
+        body: JSON.stringify({ slugid: blogId, title, subtitle, tags, publishAs, collectionId, editorContent, pageEmoji, slug, status: 'unlisted', lastKnownUpdatedAt }),
       });
       setShowPublishPanel(false);
     } catch { /* silent */ }
@@ -2226,7 +2226,7 @@ export default function WritePage({ slugid }) {
                   <div className="absolute top-full mt-1 left-0 right-0 rounded-lg shadow-xl z-10 overflow-hidden" style={{ backgroundColor: 'var(--dropdown-bg)', border: '1px solid var(--dropdown-border)' }}>
                     <div className="px-3 py-2 text-[11px] font-medium uppercase tracking-wider" style={{ color: 'var(--text-faint)', borderBottom: '1px solid var(--divider)' }}>Choose an owner</div>
                     <button
-                      onClick={() => { setPublishAs('personal'); setShowOwnerDropdown(false); }}
+                      onClick={() => { setPublishAs('personal'); setCollectionId(null); setShowOwnerDropdown(false); }}
                       className="w-full flex items-center gap-2.5 px-3 py-2.5 text-[13px] transition-colors"
                       style={{ backgroundColor: publishAs === 'personal' ? 'var(--bg-hover)' : 'transparent' }}
                     >
@@ -2243,7 +2243,7 @@ export default function WritePage({ slugid }) {
                     {userOrgs.map(org => (
                       <button
                         key={org.id}
-                        onClick={() => { setPublishAs(`org:${org.id}`); setShowOwnerDropdown(false); }}
+                        onClick={() => { setPublishAs(`org:${org.id}`); setCollectionId(null); setShowOwnerDropdown(false); }}
                         className="w-full flex items-center gap-2.5 px-3 py-2.5 text-[13px] transition-colors"
                         style={{ backgroundColor: publishAs === `org:${org.id}` ? 'var(--bg-hover)' : 'transparent' }}
                       >
@@ -2257,6 +2257,33 @@ export default function WritePage({ slugid }) {
               </div>
             )}
           </div>
+
+          {/* Collection — only when publishing under an org. Files the post under
+              an org collection (URL becomes /org/collection/slug). Optional. */}
+          {publishAs.startsWith('org:') && (
+            <div>
+              <label className="text-[12px] font-medium mb-2 block" style={{ color: 'var(--text-muted)' }}>
+                Collection <span className="font-normal" style={{ color: 'var(--text-faint)' }}>— optional, files this post under a collection</span>
+              </label>
+              <select
+                value={collectionId || ''}
+                onChange={(e) => setCollectionId(e.target.value || null)}
+                disabled={isPublished && !isOwner}
+                className="w-full rounded-lg px-3 py-2.5 text-[13px] outline-none disabled:opacity-70 disabled:cursor-not-allowed"
+                style={{ backgroundColor: 'var(--bg-app)', border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
+              >
+                <option value="">No collection (org root)</option>
+                {orgCollections.map((c) => (
+                  <option key={c.id} value={c.id}>{c.name}</option>
+                ))}
+              </select>
+              <p className="text-[11px] mt-1" style={{ color: 'var(--text-faint)' }}>
+                {orgCollections.length === 0
+                  ? 'This org has no collections yet — create one in the org settings.'
+                  : 'Collaborators stay scoped to this post regardless of collection.'}
+              </p>
+            </div>
+          )}
 
           {/* URL slug — editable before publish; after publish only the owner can
               change it (destructive — old links break). Non-owners see it locked. */}

--- a/src/views/settings/OrgManagePage.jsx
+++ b/src/views/settings/OrgManagePage.jsx
@@ -95,6 +95,9 @@ export default function OrgManagePage({ slug }) {
   const [newColName, setNewColName] = useState('');
   const [newColSlug, setNewColSlug] = useState('');
   const [newColDesc, setNewColDesc] = useState('');
+  const [editingCol, setEditingCol] = useState(null); // { id, name, slug, description }
+  const [editColError, setEditColError] = useState('');
+  const [savingCol, setSavingCol] = useState(false);
 
   const fetchOrg = useCallback(async () => {
     try {
@@ -338,6 +341,22 @@ export default function OrgManagePage({ slug }) {
       body: JSON.stringify({ collectionId: colId }),
     });
     fetchOrg();
+  };
+
+  const handleSaveCollection = async () => {
+    if (!editingCol || !editingCol.name.trim() || savingCol) return;
+    setSavingCol(true); setEditColError('');
+    try {
+      const res = await fetch('/api/orgs/collections', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ collectionId: editingCol.id, name: editingCol.name.trim(), slug: editingCol.slug, description: editingCol.description }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (res.ok) { setEditingCol(null); fetchOrg(); }
+      else setEditColError(data.error || 'Failed to save');
+    } catch { setEditColError('Failed to save'); }
+    setSavingCol(false);
   };
 
   const handleDeleteInvite = async (inviteId) => {
@@ -650,6 +669,16 @@ export default function OrgManagePage({ slug }) {
         {/* ═══════════ Members Tab ═══════════ */}
         {activeTab === 'members' && (
           <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <p className="text-[13px] text-[var(--text-muted)]">{members.length} member{members.length === 1 ? '' : 's'}</p>
+              <button
+                onClick={() => setActiveTab('invites')}
+                className="flex items-center gap-1.5 px-3.5 py-2 bg-[#9b7bf7] text-white font-medium rounded-lg text-[12px] hover:bg-[#b69aff] transition-colors"
+              >
+                <ion-icon name="person-add-outline" style={{ fontSize: '15px' }} />
+                Invite member
+              </button>
+            </div>
             {members.map(m => (
               <div key={m.id} className="flex items-center gap-3 p-3.5 bg-[var(--card-bg)] border border-[var(--border-default)] rounded-xl">
                 {m.avatar_url ? (
@@ -686,18 +715,56 @@ export default function OrgManagePage({ slug }) {
         {activeTab === 'collections' && (
           <div className="space-y-4">
             {collections.map(c => (
-              <div key={c.id} className="flex items-center gap-3 p-4 bg-[var(--card-bg)] border border-[var(--border-default)] rounded-xl">
-                <div className="h-9 w-9 rounded-lg bg-[var(--bg-base)] flex items-center justify-center shrink-0">
-                  <ion-icon name="folder" style={{ fontSize: '18px', color: '#60a5fa' }} />
+              editingCol?.id === c.id ? (
+                <div key={c.id} className="border border-[#9b7bf7]/40 rounded-xl p-4 space-y-3 bg-[var(--card-bg)]">
+                  <div>
+                    <label className="text-[11px] text-[var(--text-muted)] block mb-1">Name</label>
+                    <input value={editingCol.name} onChange={e => setEditingCol(s => ({ ...s, name: e.target.value }))} placeholder="Collection name"
+                      className="w-full bg-[var(--bg-base)] text-[var(--text-primary)] rounded-lg px-3.5 py-2.5 outline-none text-[13px] border border-[var(--border-default)] focus:border-[#9b7bf7]/50 transition-colors" />
+                  </div>
+                  <div>
+                    <label className="text-[11px] text-[var(--text-muted)] block mb-1">Handle</label>
+                    <div className="flex items-center bg-[var(--bg-base)] rounded-lg px-3 border border-[var(--border-default)] focus-within:border-[#9b7bf7]/50 transition-colors">
+                      <span className="text-[13px] text-[var(--text-faint)]">/</span>
+                      <input value={editingCol.slug} onChange={e => setEditingCol(s => ({ ...s, slug: e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, '') }))} placeholder="handle"
+                        className="flex-1 bg-transparent text-[var(--text-primary)] py-2.5 px-1 outline-none text-[13px]" />
+                    </div>
+                    <p className="text-[11px] text-[var(--text-faint)] mt-1">Must be unique within this org. Changing it updates the collection&apos;s URL.</p>
+                  </div>
+                  <div>
+                    <label className="text-[11px] text-[var(--text-muted)] block mb-1">Description</label>
+                    <input value={editingCol.description || ''} onChange={e => setEditingCol(s => ({ ...s, description: e.target.value }))} placeholder="Description (optional)"
+                      className="w-full bg-[var(--bg-base)] text-[var(--text-primary)] rounded-lg px-3.5 py-2.5 outline-none text-[13px] border border-[var(--border-default)] focus:border-[#9b7bf7]/50 transition-colors" />
+                  </div>
+                  {editColError && <p className="text-[12px] text-[#f87171]">{editColError}</p>}
+                  <div className="flex items-center gap-2">
+                    <button onClick={handleSaveCollection} disabled={!editingCol.name.trim() || savingCol}
+                      className="px-4 py-2 bg-[#9b7bf7] text-white font-medium rounded-lg text-[12px] hover:bg-[#b69aff] disabled:opacity-40 transition-colors">
+                      {savingCol ? 'Saving…' : 'Save'}
+                    </button>
+                    <button onClick={() => { setEditingCol(null); setEditColError(''); }}
+                      className="px-4 py-2 text-[var(--text-muted)] hover:text-[var(--text-primary)] font-medium rounded-lg text-[12px] transition-colors">
+                      Cancel
+                    </button>
+                  </div>
                 </div>
-                <div className="flex-1 min-w-0">
-                  <p className="text-[14px] text-[var(--text-primary)] font-medium">{c.name}</p>
-                  <p className="text-[11px] text-[var(--text-faint)]">/{c.slug} &middot; {c.blog_count || 0} blog{(c.blog_count || 0) !== 1 ? 's' : ''}</p>
+              ) : (
+                <div key={c.id} className="flex items-center gap-3 p-4 bg-[var(--card-bg)] border border-[var(--border-default)] rounded-xl">
+                  <div className="h-9 w-9 rounded-lg bg-[var(--bg-base)] flex items-center justify-center shrink-0">
+                    <ion-icon name="folder" style={{ fontSize: '18px', color: '#60a5fa' }} />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-[14px] text-[var(--text-primary)] font-medium">{c.name}</p>
+                    <p className="text-[11px] text-[var(--text-faint)]">/{c.slug} &middot; {c.blog_count || 0} blog{(c.blog_count || 0) !== 1 ? 's' : ''}</p>
+                  </div>
+                  <button onClick={() => { setEditingCol({ id: c.id, name: c.name, slug: c.slug, description: c.description || '' }); setEditColError(''); }} className="text-[var(--text-muted)] hover:text-[#9b7bf7] transition-colors p-1">
+                    <ion-icon name="create-outline" style={{ fontSize: '16px' }} />
+                  </button>
+                  <button onClick={() => handleDeleteCollection(c.id)} className="text-[var(--text-muted)] hover:text-[#f87171] transition-colors p-1">
+                    <ion-icon name="trash-outline" style={{ fontSize: '16px' }} />
+                  </button>
                 </div>
-                <button onClick={() => handleDeleteCollection(c.id)} className="text-[var(--text-muted)] hover:text-[#f87171] transition-colors p-1">
-                  <ion-icon name="trash-outline" style={{ fontSize: '16px' }} />
-                </button>
-              </div>
+              )
             ))}
 
             <div className="border border-[var(--border-default)] rounded-xl p-5 space-y-4 bg-[var(--card-bg)]">


### PR DESCRIPTION
## Changes Made
- `app/api/blogs/publish/route.js` — Accept `collectionId` in the publish payload; validate that the collection belongs to the org being published under (clears it otherwise); persist `collection_id` in both INSERT and UPDATE queries for blogs.
- `app/api/orgs/collections/route.js` — Accept `slug` in PUT handler for collection handle renames; validate slug via `validateSlug`; check for `(org_id, slug)` uniqueness clashes before writing, returning 409 on conflict; catch DB-level UNIQUE constraint as a fallback.
- `src/views/WritePage.jsx` — Add `collectionId` and `orgCollections` state; fetch collections when `publishAs` targets an org; include `collectionId` in drafts, autosave, and publish payloads; clear collection when switching owner; render a collection `<select>` dropdown in the publish panel (visible only when publishing under an org).
- `src/views/settings/OrgManagePage.jsx` — Add slug/handle field to the collection creation and editing UI so orgs can assign and rename collection handles.

## Checklist
- [ ] No Node built-ins imported (crypto, fs, path, stream, Buffer)
- [ ] New DB columns/tables have a migration in `src/workers/migrations/`
- [ ] `./biome.sh ci` clean
- [ ] Tested locally: <how>