### PR TITLE
[FEAT]: Add cropper modal for the utils and the functionality of image uploads 

### DIFF
--- a/src/components/ImageCropModal.jsx
+++ b/src/components/ImageCropModal.jsx
@@ -16,10 +16,12 @@ export default function ImageCropModal({
   quality = 0.6,
   round = false,          // circular crop guide (avatars)
   currentImage = null,    // shows a "Remove" action when set
+  initialSrc = null,      // open straight into crop with this image (skips the source tabs)
   onSave,
   onClose,
 }) {
   const outputHeight = Math.round(outputWidth / aspectRatio);
+  const isSquare = Math.abs(aspectRatio - 1) < 0.01;
 
   const [tab, setTab] = useState('upload');
   const [imageSrc, setImageSrc] = useState(null);
@@ -54,6 +56,11 @@ export default function ImageCropModal({
     img.onerror = () => setUrlError('Failed to load image');
     img.src = src;
   }, []);
+
+  // Caller pre-selected an image (e.g. a device file) — load it straight away.
+  useEffect(() => {
+    if (initialSrc) loadImage(initialSrc);
+  }, [initialSrc, loadImage]);
 
   const handleFileUpload = (e) => {
     const file = e.target.files?.[0];
@@ -271,12 +278,12 @@ export default function ImageCropModal({
           {/* Crop + stylise */}
           {imageSrc && (
             <div className="space-y-5">
-              <div className={round ? 'flex justify-center' : ''}>
+              <div className={isSquare ? 'flex justify-center' : ''}>
                 <div
                   ref={containerRef}
-                  className={`relative overflow-hidden border border-[var(--border-default)] cursor-grab active:cursor-grabbing select-none ${round ? 'rounded-full' : 'rounded-xl w-full'}`}
-                  style={round
-                    ? { width: 'min(260px, 70vw)', aspectRatio: '1 / 1' }
+                  className={`relative overflow-hidden border border-[var(--border-default)] cursor-grab active:cursor-grabbing select-none ${round ? 'rounded-full' : 'rounded-xl'} ${isSquare ? '' : 'w-full'}`}
+                  style={isSquare
+                    ? { width: 'min(280px, 75vw)', aspectRatio: '1 / 1' }
                     : { width: '100%', aspectRatio: `${aspectRatio}` }}
                   onMouseDown={handleMouseDown}
                   onTouchStart={handleTouchStart}

--- a/src/components/ImageCropModal.jsx
+++ b/src/components/ImageCropModal.jsx
@@ -1,0 +1,349 @@
+'use client';
+
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { IMAGE_ACCEPT_ATTR, isAllowedImage } from '../utils/allowedImageTypes';
+
+const DEFAULT_FILTERS = { brightness: 100, contrast: 100, saturation: 100, vignette: 0 };
+
+// One crop + stylise modal for every fixed-ratio image: avatars, banners, covers
+// (NOT in-blog images). The caller fixes the aspect ratio and output size; the
+// user pans/zooms within that ratio and tunes brightness / contrast / saturation
+// / vignette. Outputs a WebP Blob to onSave (or null when the image is removed).
+export default function ImageCropModal({
+  title = 'Edit Image',
+  aspectRatio = 16 / 5,
+  outputWidth = 1200,
+  quality = 0.6,
+  round = false,          // circular crop guide (avatars)
+  currentImage = null,    // shows a "Remove" action when set
+  onSave,
+  onClose,
+}) {
+  const outputHeight = Math.round(outputWidth / aspectRatio);
+
+  const [tab, setTab] = useState('upload');
+  const [imageSrc, setImageSrc] = useState(null);
+  const [urlInput, setUrlInput] = useState('');
+  const [urlError, setUrlError] = useState('');
+  const [crop, setCrop] = useState({ x: 0, y: 0, scale: 1 });
+  const [filters, setFilters] = useState(DEFAULT_FILTERS);
+  const [dragging, setDragging] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const dragStart = useRef({ x: 0, y: 0, cropX: 0, cropY: 0 });
+  const canvasRef = useRef(null);
+  const imgRef = useRef(null);
+  const fileInputRef = useRef(null);
+  const containerRef = useRef(null);
+
+  const resetState = () => {
+    setImageSrc(null);
+    setCrop({ x: 0, y: 0, scale: 1 });
+    setFilters(DEFAULT_FILTERS);
+    setUrlError('');
+  };
+
+  const loadImage = useCallback((src) => {
+    const img = new Image();
+    img.crossOrigin = 'anonymous';
+    img.onload = () => {
+      imgRef.current = img;
+      setCrop({ x: 0, y: 0, scale: 1 });
+      setFilters(DEFAULT_FILTERS);
+      setImageSrc(src);
+    };
+    img.onerror = () => setUrlError('Failed to load image');
+    img.src = src;
+  }, []);
+
+  const handleFileUpload = (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (!isAllowedImage(file)) {
+      setUrlError('Unsupported file type. Allowed: AVIF, JPEG, PNG, BMP, SVG, WebP.');
+      e.target.value = '';
+      return;
+    }
+    if (file.size > 20 * 1024 * 1024) {
+      setUrlError('File too large (max 20MB)');
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = (ev) => loadImage(ev.target.result);
+    reader.readAsDataURL(file);
+  };
+
+  const handleDrop = (e) => {
+    e.preventDefault();
+    const file = e.dataTransfer.files?.[0];
+    if (!file || !isAllowedImage(file)) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => loadImage(ev.target.result);
+    reader.readAsDataURL(file);
+  };
+
+  const handleUrlSubmit = () => {
+    setUrlError('');
+    if (!urlInput.trim()) return;
+    loadImage(urlInput.trim());
+  };
+
+  // Render the crop + filters to the output-resolution canvas.
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const img = imgRef.current;
+    if (!canvas || !img || !imageSrc) return;
+
+    const ctx = canvas.getContext('2d');
+    canvas.width = outputWidth;
+    canvas.height = outputHeight;
+
+    ctx.fillStyle = '#141a26';
+    ctx.fillRect(0, 0, outputWidth, outputHeight);
+
+    // Colour adjustments apply to the photo only (vignette is drawn after).
+    ctx.filter = `brightness(${filters.brightness}%) contrast(${filters.contrast}%) saturate(${filters.saturation}%)`;
+
+    const fitScale = Math.max(outputWidth / img.naturalWidth, outputHeight / img.naturalHeight);
+    const drawScale = fitScale * crop.scale;
+    const drawW = img.naturalWidth * drawScale;
+    const drawH = img.naturalHeight * drawScale;
+    const drawX = (outputWidth - drawW) / 2 + crop.x;
+    const drawY = (outputHeight - drawH) / 2 + crop.y;
+    ctx.drawImage(img, drawX, drawY, drawW, drawH);
+    ctx.filter = 'none';
+
+    // Vignette — radial darkening from the edges inward.
+    if (filters.vignette > 0) {
+      const cx = outputWidth / 2;
+      const cy = outputHeight / 2;
+      const outerR = Math.hypot(outputWidth, outputHeight) / 2;
+      const g = ctx.createRadialGradient(cx, cy, outerR * 0.5, cx, cy, outerR);
+      g.addColorStop(0, 'rgba(0,0,0,0)');
+      g.addColorStop(1, `rgba(0,0,0,${(filters.vignette / 100) * 0.9})`);
+      ctx.fillStyle = g;
+      ctx.fillRect(0, 0, outputWidth, outputHeight);
+    }
+  }, [imageSrc, crop, filters, outputWidth, outputHeight]);
+
+  // Pointer drag → pan (mouse + touch), scaled from preview px to canvas px.
+  const panFrom = (clientX, clientY) => {
+    const container = containerRef.current;
+    if (!container) return;
+    const rect = container.getBoundingClientRect();
+    const scaleX = outputWidth / rect.width;
+    const scaleY = outputHeight / rect.height;
+    const dx = (clientX - dragStart.current.x) * scaleX;
+    const dy = (clientY - dragStart.current.y) * scaleY;
+    setCrop((prev) => ({ ...prev, x: dragStart.current.cropX + dx, y: dragStart.current.cropY + dy }));
+  };
+
+  const handleMouseDown = (e) => {
+    setDragging(true);
+    dragStart.current = { x: e.clientX, y: e.clientY, cropX: crop.x, cropY: crop.y };
+  };
+  const handleMouseMove = useCallback((e) => { if (dragging) panFrom(e.clientX, e.clientY); }, [dragging]); // eslint-disable-line react-hooks/exhaustive-deps
+  const handleMouseUp = useCallback(() => setDragging(false), []);
+
+  const handleTouchStart = (e) => {
+    const t = e.touches[0];
+    setDragging(true);
+    dragStart.current = { x: t.clientX, y: t.clientY, cropX: crop.x, cropY: crop.y };
+  };
+  const handleTouchMove = useCallback((e) => { if (dragging) panFrom(e.touches[0].clientX, e.touches[0].clientY); }, [dragging]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (!dragging) return;
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mouseup', handleMouseUp);
+    window.addEventListener('touchmove', handleTouchMove, { passive: true });
+    window.addEventListener('touchend', handleMouseUp);
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseup', handleMouseUp);
+      window.removeEventListener('touchmove', handleTouchMove);
+      window.removeEventListener('touchend', handleMouseUp);
+    };
+  }, [dragging, handleMouseMove, handleMouseUp, handleTouchMove]);
+
+  const handleWheel = (e) => {
+    e.preventDefault();
+    setCrop((prev) => ({ ...prev, scale: Math.max(0.3, Math.min(4, prev.scale + (e.deltaY > 0 ? -0.05 : 0.05))) }));
+  };
+
+  const handleSave = () => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    setSaving(true);
+    canvas.toBlob(
+      (blob) => { if (blob) onSave(blob); setSaving(false); },
+      'image/webp',
+      quality,
+    );
+  };
+
+  const handleRemove = () => { onSave(null); onClose(); };
+
+  const SLIDERS = [
+    { key: 'brightness', label: 'Brightness', min: 50, max: 150, suffix: '%' },
+    { key: 'contrast', label: 'Contrast', min: 50, max: 150, suffix: '%' },
+    { key: 'saturation', label: 'Saturation', min: 0, max: 200, suffix: '%' },
+    { key: 'vignette', label: 'Vignette', min: 0, max: 100, suffix: '' },
+  ];
+
+  return (
+    <div className="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center z-[100] p-4" onClick={onClose}>
+      <div
+        className="bg-[var(--bg-surface)] border border-[var(--border-default)] rounded-2xl w-full max-w-[720px] shadow-2xl max-h-[92vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-[var(--border-default)]">
+          <h3 className="text-[15px] font-semibold text-[var(--text-primary)]">{title}</h3>
+          <button onClick={onClose} className="text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors p-1">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Source tabs — only before an image is chosen */}
+        {!imageSrc && (
+          <div className="flex border-b border-[var(--border-default)]">
+            {[
+              { key: 'upload', label: 'Upload', icon: 'cloud-upload-outline' },
+              { key: 'url', label: 'From URL', icon: 'link-outline' },
+            ].map((t) => (
+              <button
+                key={t.key}
+                onClick={() => { setTab(t.key); resetState(); }}
+                className={`flex-1 flex items-center justify-center gap-2 py-3 text-[13px] font-medium transition-colors ${
+                  tab === t.key
+                    ? 'text-[var(--text-primary)] border-b-2 border-[#9b7bf7]'
+                    : 'text-[var(--text-muted)] hover:text-[var(--text-body)] border-b-2 border-transparent'
+                }`}
+              >
+                <ion-icon name={t.icon} style={{ fontSize: '15px' }} />
+                {t.label}
+              </button>
+            ))}
+          </div>
+        )}
+
+        <div className="p-6">
+          {/* Upload */}
+          {tab === 'upload' && !imageSrc && (
+            <div
+              onClick={() => fileInputRef.current?.click()}
+              onDragOver={(e) => e.preventDefault()}
+              onDrop={handleDrop}
+              className="border-2 border-dashed border-[var(--border-default)] rounded-xl h-[180px] flex flex-col items-center justify-center cursor-pointer hover:border-[var(--border-hover)] transition-colors group"
+            >
+              <ion-icon name="image-outline" style={{ fontSize: '30px', color: 'var(--text-faint)' }} />
+              <p className="text-[var(--text-muted)] text-[13px] mt-2">Drop an image or click to browse</p>
+              <p className="text-[var(--text-faint)] text-[11px] mt-1">
+                {round ? 'Square crop' : `${aspectRatio.toFixed(2)}:1 crop`} · output {outputWidth}×{outputHeight}. Max 20MB.
+              </p>
+              <input ref={fileInputRef} type="file" accept={IMAGE_ACCEPT_ATTR} className="hidden" onChange={handleFileUpload} />
+            </div>
+          )}
+
+          {/* URL */}
+          {tab === 'url' && !imageSrc && (
+            <div className="space-y-3">
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={urlInput}
+                  onChange={(e) => { setUrlInput(e.target.value); setUrlError(''); }}
+                  onKeyDown={(e) => e.key === 'Enter' && handleUrlSubmit()}
+                  placeholder="https://example.com/image.jpg"
+                  className="flex-1 bg-[var(--bg-app)] text-[var(--text-primary)] rounded-lg px-4 py-2.5 outline-none text-[13px] border border-[var(--border-default)] focus:border-[var(--border-hover)] transition-colors placeholder-[var(--text-faint)]"
+                />
+                <button onClick={handleUrlSubmit} className="px-5 py-2.5 bg-[#9b7bf7] text-white font-semibold rounded-lg text-[13px] hover:bg-[#b69aff] transition-colors">
+                  Load
+                </button>
+              </div>
+              {urlError && <p className="text-red-400 text-[11px]">{urlError}</p>}
+            </div>
+          )}
+          {urlError && imageSrc === null && tab === 'upload' && <p className="text-red-400 text-[11px] mt-2">{urlError}</p>}
+
+          {/* Crop + stylise */}
+          {imageSrc && (
+            <div className="space-y-5">
+              <div className={round ? 'flex justify-center' : ''}>
+                <div
+                  ref={containerRef}
+                  className={`relative overflow-hidden border border-[var(--border-default)] cursor-grab active:cursor-grabbing select-none ${round ? 'rounded-full' : 'rounded-xl w-full'}`}
+                  style={round
+                    ? { width: 'min(260px, 70vw)', aspectRatio: '1 / 1' }
+                    : { width: '100%', aspectRatio: `${aspectRatio}` }}
+                  onMouseDown={handleMouseDown}
+                  onTouchStart={handleTouchStart}
+                  onWheel={handleWheel}
+                >
+                  <canvas ref={canvasRef} className="w-full h-full block" />
+                  <div className="absolute bottom-2 right-2 bg-black/50 rounded-md px-2 py-1 text-[10px] text-[#ccc] pointer-events-none">
+                    Drag · scroll to zoom
+                  </div>
+                </div>
+              </div>
+
+              {/* Zoom */}
+              <div>
+                <label className="text-[11px] text-[var(--text-muted)] mb-1.5 flex justify-between">
+                  <span>Zoom</span><span>{Math.round(crop.scale * 100)}%</span>
+                </label>
+                <input
+                  type="range" min="0.3" max="4" step="0.05" value={crop.scale}
+                  onChange={(e) => setCrop((prev) => ({ ...prev, scale: parseFloat(e.target.value) }))}
+                  className="w-full accent-[#9b7bf7] h-1 bg-[var(--bg-elevated)] rounded-full appearance-none cursor-pointer"
+                />
+              </div>
+
+              {/* Stylise */}
+              <div className="grid grid-cols-2 gap-x-5 gap-y-4">
+                {SLIDERS.map((s) => (
+                  <div key={s.key}>
+                    <label className="text-[11px] text-[var(--text-muted)] mb-1.5 flex justify-between">
+                      <span>{s.label}</span><span>{filters[s.key]}{s.suffix}</span>
+                    </label>
+                    <input
+                      type="range" min={s.min} max={s.max} step="1" value={filters[s.key]}
+                      onChange={(e) => setFilters((prev) => ({ ...prev, [s.key]: parseInt(e.target.value) }))}
+                      className="w-full accent-[#9b7bf7] h-1 bg-[var(--bg-elevated)] rounded-full appearance-none cursor-pointer"
+                    />
+                  </div>
+                ))}
+              </div>
+
+              {/* Actions */}
+              <div className="flex items-center justify-between pt-1">
+                <div className="flex gap-2">
+                  <button onClick={resetState} className="px-4 py-2 text-[13px] text-[var(--text-muted)] hover:text-[var(--text-primary)] bg-[var(--bg-elevated)] rounded-lg transition-colors">
+                    Change image
+                  </button>
+                  <button onClick={() => setFilters(DEFAULT_FILTERS)} className="px-4 py-2 text-[13px] text-[var(--text-muted)] hover:text-[var(--text-primary)] bg-[var(--bg-elevated)] rounded-lg transition-colors">
+                    Reset style
+                  </button>
+                  {currentImage && (
+                    <button onClick={handleRemove} className="px-4 py-2 text-[13px] text-red-400 hover:text-red-300 bg-[var(--bg-elevated)] rounded-lg transition-colors">
+                      Remove
+                    </button>
+                  )}
+                </div>
+                <button
+                  onClick={handleSave}
+                  disabled={saving}
+                  className="px-6 py-2 bg-[#9b7bf7] text-white font-semibold rounded-lg text-[13px] hover:bg-[#b69aff] transition-colors disabled:opacity-50 flex items-center gap-2"
+                >
+                  {saving ? <span className="h-4 w-4 border-2 border-white/40 border-t-transparent rounded-full animate-spin" /> : 'Save'}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/views/ProfilePage.jsx
+++ b/src/views/ProfilePage.jsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 import { useAuth } from '../context/AuthContext';
 import AppShell from '../components/AppShell';
 import TabBar from '../components/TabBar';
-import BannerUploadModal from '../components/BannerUploadModal';
+import ImageCropModal from '../components/ImageCropModal';
 import FollowListModal from '../components/FollowListModal';
 import Link from 'next/link';
 
@@ -33,6 +33,9 @@ export default function ProfilePage() {
   const [showBannerModal, setShowBannerModal] = useState(false);
   const [localBanner, setLocalBanner] = useState(null);
   const [bannerError, setBannerError] = useState(null);
+  const [showAvatarModal, setShowAvatarModal] = useState(false);
+  const [localAvatar, setLocalAvatar] = useState(null);
+  const [avatarError, setAvatarError] = useState(null);
   const [usage, setUsage] = useState(null);
   const [usageLoading, setUsageLoading] = useState(true);
   const [activeTab, setActiveTab] = useState(0);
@@ -129,6 +132,30 @@ export default function ProfilePage() {
     }
   }
 
+  const avatarSrc = localAvatar || user.avatar_url || null;
+
+  async function handleAvatarSave(blob) {
+    if (!blob) { setLocalAvatar(null); setShowAvatarModal(false); return; }
+    const previewUrl = URL.createObjectURL(blob);
+    setLocalAvatar(previewUrl);
+    setShowAvatarModal(false);
+    setAvatarError(null);
+    try {
+      const form = new FormData();
+      form.append('file', blob, 'avatar.webp');
+      form.append('type', 'avatar');
+      const res = await fetch('/api/media/upload', { method: 'POST', body: form });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data?.error || 'Upload failed');
+      if (data.url) setLocalAvatar(data.url);
+    } catch (e) {
+      setAvatarError(e?.message || 'Failed to update avatar');
+      setLocalAvatar(null);
+    } finally {
+      URL.revokeObjectURL(previewUrl);
+    }
+  }
+
   const tierLabel = usage?.tier === 'member' ? 'Member' : 'Free';
   const tierColor = usage?.tier === 'member' ? '#a78bfa' : '#9ca3af';
 
@@ -160,11 +187,25 @@ export default function ProfilePage() {
             </div>
           )}
           <div className="absolute -bottom-12 left-6">
-            {user.avatar_url ? (
-              <img src={user.avatar_url} alt="" className="h-24 w-24 rounded-full border-4 border-[var(--bg-app)] object-cover" />
-            ) : (
-              <div className="h-24 w-24 rounded-full border-4 border-[var(--bg-app)] bg-[var(--bg-elevated)] flex items-center justify-center text-3xl text-[var(--text-muted)] font-bold">
-                {(user.display_name || user.username || '?')[0].toUpperCase()}
+            <button
+              onClick={() => setShowAvatarModal(true)}
+              className="group/av relative h-24 w-24 rounded-full border-4 border-[var(--bg-app)] overflow-hidden block"
+              title={avatarSrc ? 'Change photo' : 'Add photo'}
+            >
+              {avatarSrc ? (
+                <img src={avatarSrc} alt="" className="h-full w-full rounded-full object-cover" />
+              ) : (
+                <div className="h-full w-full rounded-full bg-[var(--bg-elevated)] flex items-center justify-center text-3xl text-[var(--text-muted)] font-bold">
+                  {(user.display_name || user.username || '?')[0].toUpperCase()}
+                </div>
+              )}
+              <span className="absolute inset-0 flex items-center justify-center bg-black/0 group-hover/av:bg-black/45 transition-colors">
+                <ion-icon name="camera-outline" style={{ fontSize: '22px', color: '#fff' }} className="opacity-0 group-hover/av:opacity-100 transition-opacity" />
+              </span>
+            </button>
+            {avatarError && (
+              <div className="absolute left-28 bottom-2 whitespace-nowrap px-3 py-1.5 rounded-lg text-[12px] font-medium bg-red-500/15 text-red-400 border border-red-500/25">
+                {avatarError}
               </div>
             )}
           </div>
@@ -351,12 +392,30 @@ export default function ProfilePage() {
         })()}
       </div>
 
-      {/* Banner Upload Modal */}
+      {/* Banner crop + stylise */}
       {showBannerModal && (
-        <BannerUploadModal
+        <ImageCropModal
+          title="Edit banner"
+          aspectRatio={16 / 5}
+          outputWidth={1200}
+          quality={0.6}
+          currentImage={bannerSrc}
           onSave={handleBannerSave}
           onClose={() => setShowBannerModal(false)}
-          currentBanner={bannerSrc}
+        />
+      )}
+
+      {/* Avatar crop + stylise (square, circular guide) */}
+      {showAvatarModal && (
+        <ImageCropModal
+          title="Edit photo"
+          aspectRatio={1}
+          outputWidth={512}
+          quality={0.85}
+          round
+          currentImage={avatarSrc}
+          onSave={handleAvatarSave}
+          onClose={() => setShowAvatarModal(false)}
         />
       )}
     </AppShell>

--- a/src/views/WritePage.jsx
+++ b/src/views/WritePage.jsx
@@ -10,7 +10,6 @@ import '@blocknote/core/fonts/inter.css';
 import '@blocknote/mantine/style.css';
 import '../styles/editor/editor.css';
 import '../styles/katex-fonts.css';
-import { compressCoverImage } from '../utils/compressImage';
 import { readTimeFromWords } from '../../lib/readTime';
 import { IMAGE_ACCEPT_ATTR, isAllowedImage } from '../utils/allowedImageTypes';
 import { generatePixelAvatar } from '../utils/pixelAvatar';
@@ -45,8 +44,8 @@ const BlogCodeView = dynamic(
   { ssr: false }
 );
 
-const CoverUploadModal = dynamic(
-  () => import('../components/Editor/CoverUploadModal'),
+const ImageCropModal = dynamic(
+  () => import('../components/ImageCropModal'),
   { ssr: false }
 );
 
@@ -416,6 +415,7 @@ export default function WritePage({ slugid }) {
   });
   const [showPublishMenu, setShowPublishMenu] = useState(false);
   const [showCoverModal, setShowCoverModal] = useState(false);
+  const [coverCropSrc, setCoverCropSrc] = useState(null); // device image awaiting crop+stylise
   const [coverUrlMode, setCoverUrlMode] = useState(false);
   const [coverUrlInput, setCoverUrlInput] = useState('');
   const [showEmojiPicker, setShowEmojiPicker] = useState(false);
@@ -1006,6 +1006,25 @@ export default function WritePage({ slugid }) {
     }
     return null;
   }, [blogId]);
+
+  // Read a chosen device file into a data URL and open the crop+stylise modal.
+  const openCoverCropper = useCallback((file) => {
+    if (!file || !isAllowedImage(file)) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => setCoverCropSrc(ev.target.result);
+    reader.readAsDataURL(file);
+  }, []);
+
+  // Cropped + stylised cover → optimistic preview, then upload.
+  const handleCoverCropSave = useCallback((blob) => {
+    setCoverCropSrc(null);
+    setShowCoverModal(false);
+    if (!blob) return;
+    setCoverPreview(URL.createObjectURL(blob));
+    setCoverZoom(1);
+    setCoverPos({ x: 50, y: 50 });
+    uploadCover(blob);
+  }, [uploadCover]);
 
   const handleSaveDraft = async () => {
     saveDraft(blogId, { title, subtitle, tags, publishAs, coverPreview, editorContent, pageEmoji, coverPos, coverZoom });
@@ -1742,17 +1761,7 @@ export default function WritePage({ slugid }) {
                               type="file"
                               accept={IMAGE_ACCEPT_ATTR}
                               className="hidden"
-                              onChange={(e) => {
-                                const file = e.target.files?.[0];
-                                if (file && isAllowedImage(file)) {
-                                  compressCoverImage(file).then(({ blob, url }) => {
-                                    setCoverPreview(url);
-                                    setCoverZoom(1);
-                                    setCoverPos({ x: 50, y: 50 });
-                                    uploadCover(blob);
-                                  });
-                                }
-                              }}
+                              onChange={(e) => { openCoverCropper(e.target.files?.[0]); e.target.value = ''; }}
                             />
                           </label>
                           {/* Remove */}
@@ -1788,16 +1797,7 @@ export default function WritePage({ slugid }) {
                               type="file"
                               accept={IMAGE_ACCEPT_ATTR}
                               className="hidden"
-                              onChange={(e) => {
-                                const file = e.target.files?.[0];
-                                if (file && isAllowedImage(file)) {
-                                  compressCoverImage(file).then(({ blob, url }) => {
-                                    setCoverPreview(url);
-                                    setShowCoverModal(false);
-                                    uploadCover(blob);
-                                  });
-                                }
-                              }}
+                              onChange={(e) => { openCoverCropper(e.target.files?.[0]); e.target.value = ''; }}
                             />
                           </label>
                           <button
@@ -1906,6 +1906,19 @@ export default function WritePage({ slugid }) {
                         </button>
                       </div>
                     ) : null}
+
+                    {/* Cover crop + stylise (opens when a device image is chosen) */}
+                    {coverCropSrc && (
+                      <ImageCropModal
+                        title="Crop cover"
+                        aspectRatio={16 / 5}
+                        outputWidth={1600}
+                        quality={0.7}
+                        initialSrc={coverCropSrc}
+                        onSave={handleCoverCropSave}
+                        onClose={() => setCoverCropSrc(null)}
+                      />
+                    )}
 
                     {/* Emoji overlapping banner bottom-left */}
                     {pageEmoji && (

--- a/src/views/settings/OrgManagePage.jsx
+++ b/src/views/settings/OrgManagePage.jsx
@@ -7,7 +7,7 @@ import AppShell from '../../components/AppShell';
 import TabBar from '../../components/TabBar';
 import Link from 'next/link';
 import { generatePixelAvatar } from '../../utils/pixelAvatar';
-import { compressImage } from '../../utils/compressImage';
+import ImageCropModal from '../../components/ImageCropModal';
 import { isHttpsUrl } from '../../../lib/validate';
 
 const ROLE_LABELS = { admin: 'Admin', maintain: 'Maintain', write: 'Write', read: 'Read' };
@@ -73,9 +73,12 @@ export default function OrgManagePage({ slug }) {
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [saveError, setSaveError] = useState('');
-  const logoInputRef = useRef(null);
   const [logoUploading, setLogoUploading] = useState(false);
   const [logoError, setLogoError] = useState('');
+  const [showLogoModal, setShowLogoModal] = useState(false);
+  const [showOrgBannerModal, setShowOrgBannerModal] = useState(false);
+  const [bannerUploading, setBannerUploading] = useState(false);
+  const [bannerError, setBannerError] = useState('');
 
   // Invite state
   const [inviteRole, setInviteRole] = useState('write');
@@ -199,26 +202,42 @@ export default function OrgManagePage({ slug }) {
     setDeleteConfirm(false);
   };
 
-  const handleLogoFile = async (e) => {
-    const file = e.target.files?.[0];
-    e.target.value = ''; // allow re-selecting the same file
-    if (!file || !org) return;
-    setLogoError('');
-    setLogoUploading(true);
+  const uploadOrgImage = async (blob, type, filename) => {
+    const form = new FormData();
+    form.append('file', blob, filename);
+    form.append('type', type);
+    form.append('orgId', org.id);
+    const res = await fetch('/api/media/upload', { method: 'POST', body: form });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(data?.error || 'Upload failed');
+    return data.url;
+  };
+
+  const handleLogoSave = async (blob) => {
+    setShowLogoModal(false);
+    if (!blob || !org) return;
+    setLogoError(''); setLogoUploading(true);
     try {
-      const { blob } = await compressImage(file, { maxWidth: 400, maxHeight: 400 });
-      const form = new FormData();
-      form.append('file', blob, 'logo.webp');
-      form.append('type', 'org_avatar');
-      form.append('orgId', org.id);
-      const res = await fetch('/api/media/upload', { method: 'POST', body: form });
-      const data = await res.json().catch(() => ({}));
-      if (!res.ok) throw new Error(data?.error || 'Upload failed');
-      if (data.url) setOrg(prev => ({ ...prev, logo_url: data.url }));
+      const url = await uploadOrgImage(blob, 'org_avatar', 'logo.webp');
+      if (url) setOrg(prev => ({ ...prev, logo_url: url }));
     } catch (err) {
       setLogoError(err?.message || 'Failed to update logo');
     } finally {
       setLogoUploading(false);
+    }
+  };
+
+  const handleOrgBannerSave = async (blob) => {
+    setShowOrgBannerModal(false);
+    if (!blob || !org) return;
+    setBannerError(''); setBannerUploading(true);
+    try {
+      const url = await uploadOrgImage(blob, 'org_banner', 'banner.webp');
+      if (url) setOrg(prev => ({ ...prev, banner_url: url }));
+    } catch (err) {
+      setBannerError(err?.message || 'Failed to update banner');
+    } finally {
+      setBannerUploading(false);
     }
   };
 
@@ -390,10 +409,9 @@ export default function OrgManagePage({ slug }) {
           <Link href="/settings" className="text-[var(--text-faint)] hover:text-[var(--text-primary)] transition-colors p-1">
             <ion-icon name="arrow-back" style={{ fontSize: '18px' }} />
           </Link>
-          <input ref={logoInputRef} type="file" accept="image/*" className="hidden" onChange={handleLogoFile} />
           <button
             type="button"
-            onClick={() => logoInputRef.current?.click()}
+            onClick={() => setShowLogoModal(true)}
             disabled={logoUploading}
             className="relative group h-10 w-10 rounded-xl overflow-hidden flex-shrink-0"
             title="Change organization logo"
@@ -421,6 +439,27 @@ export default function OrgManagePage({ slug }) {
           <p className="text-[12px] text-red-400 mb-3 -mt-3">{logoError}</p>
         )}
 
+        {showLogoModal && (
+          <ImageCropModal
+            title="Edit organization logo"
+            aspectRatio={1}
+            outputWidth={512}
+            quality={0.85}
+            onSave={handleLogoSave}
+            onClose={() => setShowLogoModal(false)}
+          />
+        )}
+        {showOrgBannerModal && (
+          <ImageCropModal
+            title="Edit organization banner"
+            aspectRatio={16 / 5}
+            outputWidth={1200}
+            quality={0.6}
+            onSave={handleOrgBannerSave}
+            onClose={() => setShowOrgBannerModal(false)}
+          />
+        )}
+
         <TabBar tabs={TABS} active={activeTab} onChange={setActiveTab} keyField="key" />
 
         {/* ═══════════ Profile Tab ═══════════ */}
@@ -430,6 +469,34 @@ export default function OrgManagePage({ slug }) {
             <section>
               <h3 className="text-[11px] font-semibold text-[var(--text-faint)] uppercase tracking-widest mb-4">Identity</h3>
               <div className="space-y-4">
+                {/* Banner */}
+                <div>
+                  <label className="text-[13px] text-[var(--text-primary)] mb-2 block font-medium">Banner</label>
+                  {(() => {
+                    const orgBannerSrc = org.banner_url || (org.banner_r2_key ? `/api/media/${org.banner_r2_key}` : null);
+                    return (
+                      <button
+                        type="button"
+                        onClick={() => setShowOrgBannerModal(true)}
+                        disabled={bannerUploading}
+                        className="group relative w-full rounded-xl overflow-hidden border border-[var(--border-default)] block"
+                        style={{ aspectRatio: `${16 / 5}` }}
+                        title="Change banner"
+                      >
+                        {orgBannerSrc
+                          ? <img src={orgBannerSrc} alt="" className="w-full h-full object-cover" />
+                          : <div className="w-full h-full bg-[var(--bg-elevated)]" />}
+                        <span className="absolute inset-0 flex items-center justify-center bg-black/0 group-hover:bg-black/40 transition-colors">
+                          <span className="flex items-center gap-2 px-3 py-1.5 bg-black/60 rounded-lg text-[12px] text-white font-medium opacity-0 group-hover:opacity-100 transition-opacity">
+                            <ion-icon name={bannerUploading ? 'hourglass-outline' : 'image-outline'} style={{ fontSize: '14px' }} />
+                            {orgBannerSrc ? 'Change banner' : 'Add banner'}
+                          </span>
+                        </span>
+                      </button>
+                    );
+                  })()}
+                  {bannerError && <p className="text-[12px] text-red-400 mt-2">{bannerError}</p>}
+                </div>
                 <Input label="Organization name" value={name} onChange={e => setName(e.target.value)} placeholder="My Organization" />
                 <div>
                   <label className="text-[13px] text-[var(--text-primary)] mb-1 block font-medium">Handle</label>


### PR DESCRIPTION
## Changes Made

- Added `src/components/ImageCropModal.jsx` — reusable modal for cropping and stylising fixed-ratio images (avatars, banners, covers). Supports file upload, URL input, drag-to-pan, scroll-to-zoom, and brightness/contrast/saturation/vignette sliders. Outputs a WebP Blob via `onSave`.
- Added `src/utils/allowedImageTypes.js` — shared constants and validation for accepted image MIME types (`IMAGE_ACCEPT_ATTR` for file inputs, `isAllowedImage()` for runtime checks).
- Modified `src/views/ProfilePage.jsx` — replaced `BannerUploadModal` with `ImageCropModal` for banner editing, added separate avatar crop flow (`showAvatarModal`, `localAvatar`, `avatarError`, `handleAvatarSave`), wired both banner and avatar modals to the new component with appropriate aspect ratios and output sizes.
- Removed `src/components/BannerUploadModal.jsx` — superseded by the generic `ImageCropModal`.

## Checklist

- [ ] No Node built-ins imported (crypto, fs, path, stream, Buffer)
- [ ] `./biome.sh ci` clean
- [ ] Tested locally: <how>