### PR TITLE
[FEAT]: Corrected the cropper style modal

### DIFF
--- a/app/api/media/upload/route.js
+++ b/app/api/media/upload/route.js
@@ -179,8 +179,9 @@ export async function POST(request) {
       if (db) {
         try {
           if (mediaType === 'avatar') {
-            await db.prepare('UPDATE users SET avatar_r2_key = ? WHERE id = ?')
-              .bind(result.public_id, session.userId).run();
+            // Display reads avatar_url, so set both (else the new avatar won't show).
+            await db.prepare('UPDATE users SET avatar_r2_key = ?, avatar_url = ? WHERE id = ?')
+              .bind(result.public_id, result.secure_url, session.userId).run();
           } else if (mediaType === 'banner') {
             await db.prepare('UPDATE users SET banner_r2_key = ? WHERE id = ?')
               .bind(result.public_id, session.userId).run();
@@ -245,5 +246,51 @@ export async function POST(request) {
   } catch (e) {
     console.error('[media/upload] Unhandled error:', e);
     return NextResponse.json({ error: e.message || 'Internal server error' }, { status: 500 });
+  }
+}
+
+// Remove a profile image → clears the DB pointer so it falls back to the default
+// (avatar → initials, banner → blank, org logo → pixel avatar). Body: { type, orgId }.
+export async function DELETE(request) {
+  const session = await getSession();
+  if (!session?.userId) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  }
+
+  const { type, orgId } = await request.json().catch(() => ({}));
+  if (!PROFILE_TYPES.includes(type)) {
+    return NextResponse.json({ error: 'Invalid type' }, { status: 400 });
+  }
+
+  try {
+    const { getDB } = await import('../../../../lib/cloudflare');
+    const db = getDB();
+
+    if (type === 'org_avatar' || type === 'org_banner') {
+      if (!orgId) return NextResponse.json({ error: 'Missing orgId' }, { status: 400 });
+      // Only org admins/maintainers (or the owner) may clear org media.
+      const membership = await db.prepare('SELECT role FROM org_members WHERE org_id = ? AND user_id = ?')
+        .bind(orgId, session.userId).first();
+      const org = await db.prepare('SELECT owner_id FROM orgs WHERE id = ?').bind(orgId).first();
+      if (org?.owner_id !== session.userId && membership?.role !== 'admin' && membership?.role !== 'maintain') {
+        return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
+      }
+      if (type === 'org_avatar') {
+        await db.prepare('UPDATE orgs SET logo_r2_key = NULL, logo_url = NULL WHERE id = ?').bind(orgId).run();
+      } else {
+        await db.prepare('UPDATE orgs SET banner_r2_key = NULL, banner_url = NULL WHERE id = ?').bind(orgId).run();
+      }
+    } else if (type === 'avatar') {
+      await db.prepare('UPDATE users SET avatar_r2_key = NULL, avatar_url = NULL WHERE id = ?').bind(session.userId).run();
+      try { const { kvInvalidate } = await import('../../../../lib/cache'); await kvInvalidate(`v1:user:${session.userId}`); } catch {}
+    } else if (type === 'banner') {
+      await db.prepare('UPDATE users SET banner_r2_key = NULL WHERE id = ?').bind(session.userId).run();
+      try { const { kvInvalidate } = await import('../../../../lib/cache'); await kvInvalidate(`v1:user:${session.userId}`); } catch {}
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    console.error('[media/upload] DELETE failed:', e);
+    return NextResponse.json({ error: 'Failed to remove image' }, { status: 500 });
   }
 }

--- a/src/components/ImageCropModal.jsx
+++ b/src/components/ImageCropModal.jsx
@@ -13,7 +13,8 @@ export default function ImageCropModal({
   title = 'Edit Image',
   aspectRatio = 16 / 5,
   outputWidth = 1200,
-  quality = 0.6,
+  quality = 0.55,         // starting WebP quality; lowered further to hit maxSizeKB
+  maxSizeKB = 120,        // hard target — output is re-encoded down until it fits
   round = false,          // circular crop guide (avatars)
   currentImage = null,    // shows a "Remove" action when set
   initialSrc = null,      // open straight into crop with this image (skips the source tabs)
@@ -172,20 +173,41 @@ export default function ImageCropModal({
     };
   }, [dragging, handleMouseMove, handleMouseUp, handleTouchMove]);
 
-  const handleWheel = (e) => {
-    e.preventDefault();
-    setCrop((prev) => ({ ...prev, scale: Math.max(0.3, Math.min(4, prev.scale + (e.deltaY > 0 ? -0.05 : 0.05))) }));
-  };
+  // Lock background page scroll while the modal is open.
+  useEffect(() => {
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => { document.body.style.overflow = prev; };
+  }, []);
 
-  const handleSave = () => {
+  // Wheel-to-zoom: attach a NON-passive listener so preventDefault actually stops
+  // the page (and the modal) from scrolling. React's onWheel is passive, so it can't.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el || !imageSrc) return;
+    const onWheel = (e) => {
+      e.preventDefault();
+      setCrop((prev) => ({ ...prev, scale: Math.max(0.3, Math.min(4, prev.scale + (e.deltaY > 0 ? -0.05 : 0.05))) }));
+    };
+    el.addEventListener('wheel', onWheel, { passive: false });
+    return () => el.removeEventListener('wheel', onWheel);
+  }, [imageSrc]);
+
+  const handleSave = async () => {
     const canvas = canvasRef.current;
     if (!canvas) return;
     setSaving(true);
-    canvas.toBlob(
-      (blob) => { if (blob) onSave(blob); setSaving(false); },
-      'image/webp',
-      quality,
-    );
+    // Always lossy WebP; step quality down until the blob fits maxSizeKB so every
+    // image hitting the site is heavily compressed regardless of source size.
+    const toBlob = (q) => new Promise((res) => canvas.toBlob(res, 'image/webp', q));
+    const maxBytes = maxSizeKB * 1024;
+    let blob = null;
+    for (let q = quality; q >= 0.3; q -= 0.1) {
+      blob = await toBlob(q);
+      if (blob && blob.size <= maxBytes) break;
+    }
+    if (blob) onSave(blob);
+    setSaving(false);
   };
 
   const handleRemove = () => { onSave(null); onClose(); };
@@ -287,7 +309,6 @@ export default function ImageCropModal({
                     : { width: '100%', aspectRatio: `${aspectRatio}` }}
                   onMouseDown={handleMouseDown}
                   onTouchStart={handleTouchStart}
-                  onWheel={handleWheel}
                 >
                   <canvas ref={canvasRef} className="w-full h-full block" />
                   <div className="absolute bottom-2 right-2 bg-black/50 rounded-md px-2 py-1 text-[10px] text-[#ccc] pointer-events-none">

--- a/src/views/ProfilePage.jsx
+++ b/src/views/ProfilePage.jsx
@@ -29,7 +29,7 @@ function UsageBar({ label, used, limit, unit, color = '#9b7bf7' }) {
 }
 
 export default function ProfilePage() {
-  const { user, loading } = useAuth();
+  const { user, loading, refetchUser } = useAuth();
   const [showBannerModal, setShowBannerModal] = useState(false);
   const [localBanner, setLocalBanner] = useState(null);
   const [bannerError, setBannerError] = useState(null);
@@ -104,8 +104,21 @@ export default function ProfilePage() {
 
   async function handleBannerSave(blob) {
     if (!blob) {
-      setLocalBanner(null);
+      // Remove → clear server-side so it stays blank after reload.
       setShowBannerModal(false);
+      setBannerError(null);
+      try {
+        const res = await fetch('/api/media/upload', {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ type: 'banner' }),
+        });
+        if (!res.ok) throw new Error('Failed to remove banner');
+        setLocalBanner(null);
+        await refetchUser?.();
+      } catch (e) {
+        setBannerError(e?.message || 'Failed to remove banner');
+      }
       return;
     }
 
@@ -135,7 +148,24 @@ export default function ProfilePage() {
   const avatarSrc = localAvatar || user.avatar_url || null;
 
   async function handleAvatarSave(blob) {
-    if (!blob) { setLocalAvatar(null); setShowAvatarModal(false); return; }
+    if (!blob) {
+      // Remove → revert to the default initials avatar.
+      setShowAvatarModal(false);
+      setAvatarError(null);
+      try {
+        const res = await fetch('/api/media/upload', {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ type: 'avatar' }),
+        });
+        if (!res.ok) throw new Error('Failed to remove photo');
+        setLocalAvatar(null);
+        await refetchUser?.();
+      } catch (e) {
+        setAvatarError(e?.message || 'Failed to remove photo');
+      }
+      return;
+    }
     const previewUrl = URL.createObjectURL(blob);
     setLocalAvatar(previewUrl);
     setShowAvatarModal(false);
@@ -398,7 +428,8 @@ export default function ProfilePage() {
           title="Edit banner"
           aspectRatio={16 / 5}
           outputWidth={1200}
-          quality={0.6}
+          quality={0.55}
+          maxSizeKB={90}
           currentImage={bannerSrc}
           onSave={handleBannerSave}
           onClose={() => setShowBannerModal(false)}
@@ -411,7 +442,8 @@ export default function ProfilePage() {
           title="Edit photo"
           aspectRatio={1}
           outputWidth={512}
-          quality={0.85}
+          quality={0.7}
+          maxSizeKB={40}
           round
           currentImage={avatarSrc}
           onSave={handleAvatarSave}

--- a/src/views/WritePage.jsx
+++ b/src/views/WritePage.jsx
@@ -1913,7 +1913,8 @@ export default function WritePage({ slugid }) {
                         title="Crop cover"
                         aspectRatio={16 / 5}
                         outputWidth={1600}
-                        quality={0.7}
+                        quality={0.55}
+                        maxSizeKB={120}
                         initialSrc={coverCropSrc}
                         onSave={handleCoverCropSave}
                         onClose={() => setCoverCropSrc(null)}

--- a/src/views/settings/OrgManagePage.jsx
+++ b/src/views/settings/OrgManagePage.jsx
@@ -76,9 +76,6 @@ export default function OrgManagePage({ slug }) {
   const [logoUploading, setLogoUploading] = useState(false);
   const [logoError, setLogoError] = useState('');
   const [showLogoModal, setShowLogoModal] = useState(false);
-  const [showOrgBannerModal, setShowOrgBannerModal] = useState(false);
-  const [bannerUploading, setBannerUploading] = useState(false);
-  const [bannerError, setBannerError] = useState('');
 
   // Invite state
   const [inviteRole, setInviteRole] = useState('write');
@@ -215,29 +212,26 @@ export default function OrgManagePage({ slug }) {
 
   const handleLogoSave = async (blob) => {
     setShowLogoModal(false);
-    if (!blob || !org) return;
+    if (!org) return;
     setLogoError(''); setLogoUploading(true);
     try {
-      const url = await uploadOrgImage(blob, 'org_avatar', 'logo.webp');
-      if (url) setOrg(prev => ({ ...prev, logo_url: url }));
+      if (blob === null) {
+        // Remove → revert to the default pixel avatar.
+        const res = await fetch('/api/media/upload', {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ type: 'org_avatar', orgId: org.id }),
+        });
+        if (!res.ok) throw new Error('Failed to remove logo');
+        setOrg(prev => ({ ...prev, logo_url: null, logo_r2_key: null }));
+      } else {
+        const url = await uploadOrgImage(blob, 'org_avatar', 'logo.webp');
+        if (url) setOrg(prev => ({ ...prev, logo_url: url }));
+      }
     } catch (err) {
       setLogoError(err?.message || 'Failed to update logo');
     } finally {
       setLogoUploading(false);
-    }
-  };
-
-  const handleOrgBannerSave = async (blob) => {
-    setShowOrgBannerModal(false);
-    if (!blob || !org) return;
-    setBannerError(''); setBannerUploading(true);
-    try {
-      const url = await uploadOrgImage(blob, 'org_banner', 'banner.webp');
-      if (url) setOrg(prev => ({ ...prev, banner_url: url }));
-    } catch (err) {
-      setBannerError(err?.message || 'Failed to update banner');
-    } finally {
-      setBannerUploading(false);
     }
   };
 
@@ -444,19 +438,11 @@ export default function OrgManagePage({ slug }) {
             title="Edit organization logo"
             aspectRatio={1}
             outputWidth={512}
-            quality={0.85}
+            quality={0.7}
+            maxSizeKB={40}
+            currentImage={org.logo_url || null}
             onSave={handleLogoSave}
             onClose={() => setShowLogoModal(false)}
-          />
-        )}
-        {showOrgBannerModal && (
-          <ImageCropModal
-            title="Edit organization banner"
-            aspectRatio={16 / 5}
-            outputWidth={1200}
-            quality={0.6}
-            onSave={handleOrgBannerSave}
-            onClose={() => setShowOrgBannerModal(false)}
           />
         )}
 
@@ -469,34 +455,6 @@ export default function OrgManagePage({ slug }) {
             <section>
               <h3 className="text-[11px] font-semibold text-[var(--text-faint)] uppercase tracking-widest mb-4">Identity</h3>
               <div className="space-y-4">
-                {/* Banner */}
-                <div>
-                  <label className="text-[13px] text-[var(--text-primary)] mb-2 block font-medium">Banner</label>
-                  {(() => {
-                    const orgBannerSrc = org.banner_url || (org.banner_r2_key ? `/api/media/${org.banner_r2_key}` : null);
-                    return (
-                      <button
-                        type="button"
-                        onClick={() => setShowOrgBannerModal(true)}
-                        disabled={bannerUploading}
-                        className="group relative w-full rounded-xl overflow-hidden border border-[var(--border-default)] block"
-                        style={{ aspectRatio: `${16 / 5}` }}
-                        title="Change banner"
-                      >
-                        {orgBannerSrc
-                          ? <img src={orgBannerSrc} alt="" className="w-full h-full object-cover" />
-                          : <div className="w-full h-full bg-[var(--bg-elevated)]" />}
-                        <span className="absolute inset-0 flex items-center justify-center bg-black/0 group-hover:bg-black/40 transition-colors">
-                          <span className="flex items-center gap-2 px-3 py-1.5 bg-black/60 rounded-lg text-[12px] text-white font-medium opacity-0 group-hover:opacity-100 transition-opacity">
-                            <ion-icon name={bannerUploading ? 'hourglass-outline' : 'image-outline'} style={{ fontSize: '14px' }} />
-                            {orgBannerSrc ? 'Change banner' : 'Add banner'}
-                          </span>
-                        </span>
-                      </button>
-                    );
-                  })()}
-                  {bannerError && <p className="text-[12px] text-red-400 mt-2">{bannerError}</p>}
-                </div>
                 <Input label="Organization name" value={name} onChange={e => setName(e.target.value)} placeholder="My Organization" />
                 <div>
                   <label className="text-[13px] text-[var(--text-primary)] mb-1 block font-medium">Handle</label>


### PR DESCRIPTION
## Changes Made

- `app/api/media/upload/route.js` — Avatar upload now writes both `avatar_r2_key` **and** `avatar_url` so the UI picks up the new image immediately. Added `DELETE` handler that clears the DB pointer for avatars, banners, and org images so they fall back to defaults, with org-admin permission checks and KV cache invalidation.
- `src/components/ImageCropModal.jsx` — Added `maxSizeKB` prop (default 120); `handleSave` iteratively lowers WebP quality until the output fits under that limit. Body scroll is locked while the modal is open. Wheel-to-zoom moved from React's passive `onWheel` to a non-passive `addEventListener` so `preventDefault` actually stops page scroll.
- `src/views/ProfilePage.jsx` — Banner/avatar "Remove" now calls `DELETE /api/media/upload` and `refetchUser()` instead of only clearing local state, so the removal persists across reloads. Updated crop modal props: banner `quality=0.55, maxSizeKB=90`, avatar `quality=0.7, maxSizeKB=40`.
- `src/views/WritePage.jsx` — Cover crop modal updated to `quality=0.55, maxSizeKB=120`.
- `src/views/settings/OrgManagePage.jsx` — Removed org banner crop modal and all related state/handlers. Org logo removal now calls the `DELETE` endpoint instead of being a no-op. Updated logo modal to `quality=0.7, maxSizeKB=40` and added `currentImage` for the "Remove" button.

## Checklist

- [ ] `export const runtime = 'edge'` on any new API route
- [ ] No Node built-ins imported (crypto, fs, path, stream, Buffer)
- [ ] New DB columns/tables have a migration in `src/workers/migrations/`
- [ ] Rate-limit middleware on new public auth endpoints
- [ ] `./biome.sh ci` clean
- [ ] Tested locally: <how>