### PR TITLE
[FEAT]: Created SEO github like cardsand fixed joining URLs

### DIFF
--- a/app/[...path]/page.jsx
+++ b/app/[...path]/page.jsx
@@ -5,105 +5,109 @@ import CatchAllClient from './client';
 
 // Per-blog SEO: shared links pick up the blog's cover (if set) + title/author,
 // otherwise a dynamic GitHub-style card from /api/og.
-export async function generateMetadata({ params }) {
+const httpImg = (u) => (typeof u === 'string' && /^https?:\/\//.test(u) ? u : '');
+
+function cardMeta({ title, description, url, og, ogType = 'website' }) {
+  return {
+    title,
+    description,
+    alternates: { canonical: url },
+    openGraph: { type: ogType, title, description, url, siteName: 'LixBlogs', images: [{ url: og, secureUrl: og, type: 'image/png', width: 1200, height: 630, alt: title }] },
+    twitter: { card: 'summary_large_image', title, description, images: [og] },
+  };
+}
+
+export async function generateMetadata({ params, searchParams }) {
   const { path } = await params;
+  const sp = searchParams ? await searchParams : {};
   const name = (path?.[0] || '').toLowerCase();
   const len = path?.length || 0;
   const slug = len === 2 ? (path[1] || '').toLowerCase() : len === 3 ? (path[2] || '').toLowerCase() : '';
   const collection = len === 3 ? (path[1] || '').toLowerCase() : '';
+  const isInvite = !!(sp.invite);
 
   if (!name) return {};
 
-  // Profile cards (1-segment paths) — a user or org gets an avatar + name + bio card.
-  if (!slug) {
-    try {
-      const h = await headers();
-      const origin = `${h.get('x-forwarded-proto') || 'https'}://${h.get('host')}`;
-      const httpImg = (u) => (typeof u === 'string' && /^https?:\/\//.test(u) ? u : '');
+  try {
+    const h = await headers();
+    const origin = `${h.get('x-forwarded-proto') || 'https'}://${h.get('host')}`;
+    const ogUrl = (p) => `${origin}/api/og?${new URLSearchParams(p)}`;
+
+    // ── 1-segment: user or org profile ──
+    if (!slug) {
       const res = await fetch(`${origin}/api/resolve?name=${encodeURIComponent(name)}`, { headers: { 'user-agent': 'lixblogs-ssr' } });
       if (!res.ok) return {};
       const data = await res.json();
       const url = `${origin}/${name}`;
-      let dn, description, avatar, handle;
+
       if (data.type === 'user' && data.user) {
-        dn = data.user.display_name || data.user.username || name;
-        description = (data.user.bio || `@${data.user.username || name} on LixBlogs`).slice(0, 200);
-        avatar = httpImg(data.user.avatar_url);
-        handle = `@${data.user.username || name}`;
-      } else if (data.type === 'org' && data.org) {
-        dn = data.org.name || name;
-        description = (data.org.description || data.org.bio || `${dn} on LixBlogs`).slice(0, 200);
-        avatar = httpImg(data.org.logo_url || data.org.logo_r2_key);
-        handle = `@${data.org.slug || name}`;
-      } else {
-        return {};
+        const dn = data.user.display_name || data.user.username || name;
+        const handle = `@${data.user.username || name}`;
+        const description = (data.user.bio || `${handle} on LixBlogs`).slice(0, 200);
+        const og = ogUrl({ type: 'profile', kind: 'Profile', title: dn, sub: handle, avatar: httpImg(data.user.avatar_url) });
+        return cardMeta({ title: dn, description, url, og, ogType: 'profile' });
       }
-      const og = `${origin}/api/og?${new URLSearchParams({ type: 'profile', title: dn, subtitle: description, author: handle, avatar })}`;
-      return {
-        title: dn,
-        description,
-        alternates: { canonical: url },
-        openGraph: { type: 'profile', title: dn, description, url, siteName: 'LixBlogs', images: [{ url: og, secureUrl: og, type: 'image/png', width: 1200, height: 630, alt: dn }] },
-        twitter: { card: 'summary_large_image', title: dn, description, images: [og] },
-      };
-    } catch {
+      if (data.type === 'org' && data.org) {
+        const dn = data.org.name || name;
+        const ownerName = data.owner?.display_name || data.owner?.username || '';
+        const description = (data.org.description || data.org.bio || `${dn} on LixBlogs`).slice(0, 200);
+        const og = ogUrl({ type: 'profile', kind: 'Organization', title: dn, sub: ownerName ? `by ${ownerName}` : `@${data.org.slug || name}`, avatar: httpImg(data.org.logo_url || data.org.logo_r2_key) });
+        return cardMeta({ title: dn, description, url, og, ogType: 'profile' });
+      }
       return {};
     }
-  }
 
-  try {
-    const h = await headers();
-    const host = h.get('host');
-    const proto = h.get('x-forwarded-proto') || 'https';
-    const origin = `${proto}://${host}`;
-
+    // ── 2/3-segment: blog, collection, or a blog invite link ──
     const qs = new URLSearchParams({ name, slug });
     if (collection) qs.set('collection', collection);
-
     const res = await fetch(`${origin}/api/resolve?${qs}`, { headers: { 'user-agent': 'lixblogs-ssr' } });
     if (!res.ok) return {};
     const data = await res.json();
-    if (data.type !== 'blog' || !data.blog) return {};
-
-    const b = data.blog;
-    const title = b.title || 'Untitled';
-    const authorName = b.author_name || b.author_username || '';
-    const description = (b.subtitle || '').slice(0, 200) || `By ${authorName} on LixBlogs`;
     const url = `${origin}/${path.join('/')}`;
 
-    // Always render the composed card (banner + author avatar + title + tagline)
-    // so every platform (WhatsApp, Twitter, Slack) shows the same generic preview.
-    // Only forward http(s) media — a data:/blob: cover would bloat the URL and break crawlers.
-    const httpOnly = (u) => (typeof u === 'string' && /^https?:\/\//.test(u) ? u : '');
-    const ogImage = `${origin}/api/og?${new URLSearchParams({
-      title,
-      subtitle: b.subtitle || '',
-      author: authorName,
-      avatar: httpOnly(b.author_avatar),
-      cover: httpOnly(b.cover_image_r2_key),
-      emoji: b.page_emoji || '',
-    })}`;
+    // Collection → org-branded card (org avatar + collection name + org name).
+    if (data.type === 'collection' && data.collection) {
+      const orgName = data.owner?.name || name;
+      const title = data.collection.name || 'Collection';
+      const description = (data.collection.description || `A collection by ${orgName} on LixBlogs`).slice(0, 200);
+      const og = ogUrl({ type: 'profile', kind: 'Collection', title, sub: orgName, avatar: httpImg(data.owner?.logo_url || data.owner?.logo_r2_key) });
+      return cardMeta({ title, description, url, og, ogType: 'website' });
+    }
+
+    if (data.type !== 'blog' || !data.blog) return {};
+    const b = data.blog;
+
+    // Blog invite link (?invite=) → show who's inviting (org or author).
+    if (isInvite) {
+      const ownerIsOrg = data.owner?.type === 'org';
+      const inviterName = ownerIsOrg ? (data.owner.name || '') : (data.owner?.display_name || data.owner?.username || b.author_name || '');
+      const avatar = httpImg(ownerIsOrg ? (data.owner.logo_url || data.owner.logo_r2_key) : (data.owner?.avatar_url || b.author_avatar));
+      const title = inviterName || 'LixBlogs';
+      const description = `You're invited to collaborate on "${b.title || 'a post'}".`;
+      const og = ogUrl({ type: 'profile', kind: 'Invitation to collaborate', title, sub: `on "${(b.title || 'a post').slice(0, 50)}"`, avatar });
+      return cardMeta({ title: `Invitation · ${title}`, description, url, og, ogType: 'website' });
+    }
+
+    // Normal blog → mark + title + author list (small).
+    const title = b.title || 'Untitled';
+    const primary = b.author_name || b.author_username || '';
+    const coAuthors = (b.co_authors || []).map((c) => c.display_name || c.username).filter(Boolean);
+    const authorList = [primary, ...coAuthors].filter(Boolean);
+    const sub = authorList.length ? `by ${authorList.slice(0, 4).join(', ')}${authorList.length > 4 ? ` +${authorList.length - 4}` : ''}` : '';
+    const description = (b.subtitle || '').slice(0, 200) || (primary ? `By ${primary} on LixBlogs` : 'On LixBlogs');
+    const og = ogUrl({ type: 'blog', title, subtitle: b.subtitle || '', sub, avatar: httpImg(b.author_avatar) });
 
     return {
       title,
       description,
       alternates: { canonical: url },
       openGraph: {
-        type: 'article',
-        title,
-        description,
-        url,
-        siteName: 'LixBlogs',
+        type: 'article', title, description, url, siteName: 'LixBlogs',
         publishedTime: b.published_at ? new Date(b.published_at * 1000).toISOString() : undefined,
-        authors: authorName ? [authorName] : undefined,
-        images: [{ url: ogImage, secureUrl: ogImage, type: 'image/png', width: 1200, height: 630, alt: title }],
+        authors: authorList.length ? authorList : undefined,
+        images: [{ url: og, secureUrl: og, type: 'image/png', width: 1200, height: 630, alt: title }],
       },
-      twitter: {
-        card: 'summary_large_image',
-        title,
-        description,
-        images: [ogImage],
-      },
+      twitter: { card: 'summary_large_image', title, description, images: [og] },
     };
   } catch {
     return {};

--- a/app/api/og/route.js
+++ b/app/api/og/route.js
@@ -2,19 +2,24 @@ import { ImageResponse } from 'next/og';
 
 export const runtime = 'edge';
 
-// Per-blog social card. Composes: blog banner (top), title + tagline, and a
-// footer row with the author avatar + name + brand. Kept generic so WhatsApp /
-// Twitter / Slack all render it the same way.
-// /api/og?title=&subtitle=&author=&avatar=&cover=&emoji=
+// GitHub-style social cards on a clean white background.
+//   type=blog    → LixBlogs mark + blog title + author list (small)
+//   type=profile → avatar + name + owner/handle (orgs, users, collections, invites)
+//
+// Params: type, title, sub, subtitle, avatar, kind
+//   sub      — authors line (blog) or owner/handle (profile)
+//   subtitle — short description (optional)
+//   kind     — small badge label (e.g. "Organization", "Collection", "Invitation")
 export async function GET(request) {
   const { searchParams } = new URL(request.url);
+  const type = searchParams.get('type') || 'blog';
   const title = (searchParams.get('title') || 'Untitled').slice(0, 120);
-  const subtitle = (searchParams.get('subtitle') || '').slice(0, 160);
-  const author = (searchParams.get('author') || '').slice(0, 60);
-  const emoji = (searchParams.get('emoji') || '').slice(0, 8);
+  const sub = (searchParams.get('sub') || '').slice(0, 120);
+  const subtitle = (searchParams.get('subtitle') || '').slice(0, 200);
+  const kind = (searchParams.get('kind') || '').slice(0, 40);
 
-  // satori (next/og) cannot decode WebP — our Cloudinary URLs default to f_webp.
-  // Force a PNG/JPEG delivery so avatars and covers actually render.
+  // satori (next/og) can't decode WebP — our Cloudinary URLs default to f_webp.
+  // Force JPEG delivery so avatars actually render.
   const ogSafeImage = (url) => {
     if (!url || !/^https?:\/\//.test(url)) return '';
     if (url.includes('res.cloudinary.com')) {
@@ -24,93 +29,70 @@ export async function GET(request) {
     }
     return url;
   };
-
   const avatar = ogSafeImage(searchParams.get('avatar') || '');
-  const cover = ogSafeImage(searchParams.get('cover') || '');
-  const hasCover = !!cover;
   const hasAvatar = !!avatar;
-  const type = searchParams.get('type') || 'blog';
 
-  // ── Profile card: real logo + big avatar + a hue derived from the handle ──
+  const WHITE = '#ffffff';
+  const INK = '#0d1117';      // GitHub near-black
+  const MUTED = '#57606a';    // GitHub muted text
+  const BORDER = '#d0d7de';   // GitHub border
+  const ACCENT = '#9b7bf7';   // LixBlogs purple
+
+  // Brand mark — drawn inline (static assets don't render reliably in edge OG).
+  const Brand = ({ size = 34, font = 24 }) => (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+      <div style={{ display: 'flex', width: `${size}px`, height: `${size}px`, borderRadius: '9px', background: `linear-gradient(135deg, ${ACCENT}, #6d4fd1)`, alignItems: 'center', justifyContent: 'center', color: '#fff', fontSize: `${font}px`, fontWeight: 800 }}>L</div>
+      <span style={{ color: MUTED, fontSize: '26px', fontWeight: 700 }}>LixBlogs</span>
+    </div>
+  );
+
+  const initial = (title || 'L').replace('@', '').charAt(0).toUpperCase();
+
+  // ── Profile / org / collection / invite — avatar + name + owner ──
   if (type === 'profile') {
-    // Deterministic hue from the handle so the tint feels matched to the user.
-    let h = 0;
-    for (let i = 0; i < author.length; i++) h = (h * 31 + author.charCodeAt(i)) % 360;
-    const accent = `hsl(${h}, 62%, 58%)`;
-    const accentDeep = `hsl(${h}, 55%, 28%)`;
-    const initial = (title || author || 'L').replace('@', '').charAt(0).toUpperCase();
-
     return new ImageResponse(
       (
-        <div style={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', background: `linear-gradient(135deg, #0f1117 0%, ${accentDeep} 100%)`, fontFamily: 'sans-serif', position: 'relative' }}>
-          {/* Brand row, top-left. Drawn inline — same-origin static assets don't
-              reliably render inside the edge OG runtime, so we don't <img> the logo. */}
-          <div style={{ position: 'absolute', top: 48, left: 56, display: 'flex', alignItems: 'center', gap: '12px' }}>
-            <div style={{ display: 'flex', width: '40px', height: '40px', borderRadius: '11px', background: 'linear-gradient(135deg, #9b7bf7, #6d4fd1)', alignItems: 'center', justifyContent: 'center', color: '#fff', fontSize: '24px', fontWeight: 800 }}>L</div>
-            <span style={{ color: '#e8e8ee', fontSize: '26px', fontWeight: 700 }}>LixBlogs</span>
-          </div>
-
-          {/* Avatar */}
-          {hasAvatar ? (
-            <img src={avatar} width={180} height={180} style={{ width: '180px', height: '180px', borderRadius: '50%', objectFit: 'cover', border: `6px solid ${accent}` }} />
-          ) : (
-            <div style={{ display: 'flex', width: '180px', height: '180px', borderRadius: '50%', alignItems: 'center', justifyContent: 'center', background: accent, color: '#fff', fontSize: '84px', fontWeight: 800, border: '6px solid rgba(255,255,255,0.15)' }}>
-              {initial}
+        <div style={{ width: '100%', height: '100%', display: 'flex', background: WHITE, fontFamily: 'sans-serif', padding: '64px' }}>
+          <div style={{ display: 'flex', flexDirection: 'column', width: '100%', height: '100%', border: `1px solid ${BORDER}`, borderRadius: '24px', padding: '56px 64px', justifyContent: 'space-between' }}>
+            <Brand />
+            <div style={{ display: 'flex', alignItems: 'center', gap: '40px' }}>
+              {hasAvatar ? (
+                <img src={avatar} width={200} height={200} style={{ width: '200px', height: '200px', borderRadius: '50%', objectFit: 'cover', border: `1px solid ${BORDER}` }} />
+              ) : (
+                <div style={{ display: 'flex', width: '200px', height: '200px', borderRadius: '50%', alignItems: 'center', justifyContent: 'center', background: `linear-gradient(135deg, ${ACCENT}, #6d4fd1)`, color: '#fff', fontSize: '96px', fontWeight: 800 }}>
+                  {initial}
+                </div>
+              )}
+              <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minWidth: 0 }}>
+                {kind ? <div style={{ display: 'flex', color: ACCENT, fontSize: '24px', fontWeight: 700, letterSpacing: '1px', textTransform: 'uppercase', marginBottom: '10px' }}>{kind}</div> : null}
+                <div style={{ display: 'flex', color: INK, fontSize: title.length > 22 ? '56px' : '68px', fontWeight: 800, lineHeight: 1.05 }}>{title}</div>
+                {sub ? <div style={{ display: 'flex', color: MUTED, fontSize: '30px', fontWeight: 600, marginTop: '14px' }}>{sub}</div> : null}
+                {subtitle ? <div style={{ display: 'flex', color: MUTED, fontSize: '24px', marginTop: '14px', lineHeight: 1.35, maxWidth: '720px' }}>{subtitle}</div> : null}
+              </div>
             </div>
-          )}
-
-          {/* Name + handle + bio */}
-          <div style={{ display: 'flex', color: '#f4f4f6', fontSize: '54px', fontWeight: 800, marginTop: '28px' }}>{title}</div>
-          {author ? <div style={{ display: 'flex', color: accent, fontSize: '28px', fontWeight: 600, marginTop: '6px' }}>{author}</div> : null}
-          {subtitle ? (
-            <div style={{ display: 'flex', color: '#aab0bd', fontSize: '26px', marginTop: '16px', maxWidth: '820px', textAlign: 'center', lineHeight: 1.3 }}>{subtitle}</div>
-          ) : null}
+            <div style={{ display: 'flex' }} />
+          </div>
         </div>
       ),
       { width: 1200, height: 630 },
     );
   }
 
+  // ── Blog — mark + title + author list (small) ──
   return new ImageResponse(
     (
-      <div style={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column', background: '#0f1117', fontFamily: 'sans-serif' }}>
-        {/* Banner band */}
-        <div style={{ display: 'flex', width: '100%', height: '300px', overflow: 'hidden' }}>
-          {hasCover ? (
-            <img src={cover} width={1200} height={300} style={{ width: '100%', height: '300px', objectFit: 'cover' }} />
-          ) : (
-            <div style={{ display: 'flex', width: '100%', height: '300px', background: 'linear-gradient(135deg, #9b7bf7 0%, #6d4fd1 100%)' }} />
-          )}
-        </div>
-
-        {/* Content */}
-        <div style={{ display: 'flex', flexDirection: 'column', flex: 1, padding: '40px 72px', justifyContent: 'space-between' }}>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '18px' }}>
-            {emoji ? <div style={{ fontSize: '52px' }}>{emoji}</div> : null}
-            <div style={{ display: 'flex', color: '#f4f4f6', fontSize: title.length > 60 ? '50px' : '62px', fontWeight: 800, lineHeight: 1.08 }}>
-              {title}
-            </div>
-            {subtitle ? (
-              <div style={{ display: 'flex', color: '#9aa0ad', fontSize: '28px', lineHeight: 1.3 }}>{subtitle}</div>
-            ) : null}
+      <div style={{ width: '100%', height: '100%', display: 'flex', background: WHITE, fontFamily: 'sans-serif', padding: '64px' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', width: '100%', height: '100%', border: `1px solid ${BORDER}`, borderRadius: '24px', padding: '56px 64px', justifyContent: 'space-between' }}>
+          <Brand />
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <div style={{ display: 'flex', color: INK, fontSize: title.length > 60 ? '60px' : '76px', fontWeight: 800, lineHeight: 1.08 }}>{title}</div>
+            {subtitle ? <div style={{ display: 'flex', color: MUTED, fontSize: '30px', marginTop: '20px', lineHeight: 1.3, maxWidth: '960px' }}>{subtitle}</div> : null}
           </div>
-
-          {/* Footer: author avatar + name, brand on the right */}
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
-              {hasAvatar ? (
-                <img src={avatar} width={56} height={56} style={{ width: '56px', height: '56px', borderRadius: '50%', objectFit: 'cover' }} />
-              ) : (
-                <div style={{ display: 'flex', width: '56px', height: '56px', borderRadius: '50%', background: '#9b7bf7', alignItems: 'center', justifyContent: 'center', color: '#fff', fontSize: '26px', fontWeight: 800 }}>
-                  {(author || 'L').charAt(0).toUpperCase()}
-                </div>
-              )}
-              {author ? <span style={{ color: '#c4c8d2', fontSize: '28px', fontWeight: 600 }}>{author}</span> : null}
-            </div>
-            <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
-              <div style={{ display: 'flex', width: '34px', height: '34px', borderRadius: '9px', background: 'linear-gradient(135deg, #9b7bf7, #6d4fd1)', alignItems: 'center', justifyContent: 'center', color: '#fff', fontSize: '20px', fontWeight: 800 }}>L</div>
-              <span style={{ color: '#9aa0ad', fontSize: '24px', fontWeight: 600 }}>LixBlogs</span>
-            </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '14px' }}>
+            {hasAvatar ? (
+              <img src={avatar} width={52} height={52} style={{ width: '52px', height: '52px', borderRadius: '50%', objectFit: 'cover', border: `1px solid ${BORDER}` }} />
+            ) : null}
+            {sub ? <span style={{ display: 'flex', color: MUTED, fontSize: '28px', fontWeight: 600 }}>{sub}</span> : null}
           </div>
         </div>
       </div>

--- a/app/api/orgs/invite/route.js
+++ b/app/api/orgs/invite/route.js
@@ -92,12 +92,46 @@ export async function PUT(request) {
   }
 }
 
-// List invites for an org
+// GET — single-invite preview (?inviteId, auth-optional for OG + join page) OR
+// the org's invite list (?orgId, requires auth).
 export async function GET(request) {
   const session = await getSession();
-  if (!session?.userId) return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
-
   const { searchParams } = new URL(request.url);
+  const inviteId = searchParams.get('inviteId');
+
+  // Invite preview: org identity + validity (+ membership when signed in).
+  if (inviteId) {
+    try {
+      const { getDB } = await import('../../../../lib/cloudflare');
+      const db = getDB();
+      const invite = await db.prepare('SELECT * FROM org_invites WHERE id = ?').bind(inviteId).first();
+      if (!invite) return NextResponse.json({ error: 'Invite not found' }, { status: 404 });
+
+      const now = Math.floor(Date.now() / 1000);
+      const expired = !!(invite.expires_at && invite.expires_at < now);
+      const maxed = !!(invite.max_uses && invite.uses >= invite.max_uses);
+      const org = await db.prepare('SELECT slug, name, description, logo_url, logo_r2_key, owner_id FROM orgs WHERE id = ?')
+        .bind(invite.org_id).first();
+      const owner = org ? await db.prepare('SELECT display_name, username FROM users WHERE id = ?').bind(org.owner_id).first() : null;
+      let alreadyMember = false;
+      if (session?.userId) {
+        const m = await db.prepare('SELECT user_id FROM org_members WHERE org_id = ? AND user_id = ?')
+          .bind(invite.org_id, session.userId).first();
+        alreadyMember = !!m;
+      }
+      return NextResponse.json({
+        invite: { role: invite.role, expired, maxed, valid: !expired && !maxed },
+        org: org ? { slug: org.slug, name: org.name, description: org.description, logo_url: org.logo_url || null } : null,
+        owner: owner ? { display_name: owner.display_name, username: owner.username } : null,
+        alreadyMember,
+        authed: !!session?.userId,
+      });
+    } catch {
+      return NextResponse.json({ error: 'Failed to load invite' }, { status: 500 });
+    }
+  }
+
+  if (!session?.userId) return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
   const orgId = searchParams.get('orgId');
   if (!orgId) return NextResponse.json({ error: 'Missing orgId' }, { status: 400 });
 

--- a/app/org/join/[id]/client.jsx
+++ b/app/org/join/[id]/client.jsx
@@ -1,0 +1,9 @@
+'use client';
+
+import { use } from 'react';
+import JoinOrgView from '../../../../src/views/JoinOrgPage';
+
+export default function JoinOrgClient({ params }) {
+  const { id } = use(params);
+  return <JoinOrgView inviteId={id} />;
+}

--- a/app/org/join/[id]/page.jsx
+++ b/app/org/join/[id]/page.jsx
@@ -1,0 +1,44 @@
+export const runtime = 'edge';
+
+import { headers } from 'next/headers';
+import JoinOrgClient from './client';
+
+// Invite link SEO — org avatar + org name + owner name (GitHub-style white card).
+export async function generateMetadata({ params }) {
+  const { id } = await params;
+  const fallback = { title: 'Join organization · LixBlogs' };
+  try {
+    const h = await headers();
+    const origin = `${h.get('x-forwarded-proto') || 'https'}://${h.get('host')}`;
+    const res = await fetch(`${origin}/api/orgs/invite?inviteId=${encodeURIComponent(id)}`, { headers: { 'user-agent': 'lixblogs-ssr' } });
+    if (!res.ok) return fallback;
+    const d = await res.json();
+    if (!d.org) return fallback;
+
+    const httpImg = (u) => (typeof u === 'string' && /^https?:\/\//.test(u) ? u : '');
+    const ownerName = d.owner?.display_name || d.owner?.username || '';
+    const title = d.org.name || 'an organization';
+    const url = `${origin}/org/join/${id}`;
+    const description = `You're invited to join ${title}${ownerName ? ` (by ${ownerName})` : ''} on LixBlogs.`;
+    const og = `${origin}/api/og?${new URLSearchParams({
+      type: 'profile',
+      kind: 'Invitation to join',
+      title,
+      sub: ownerName ? `by ${ownerName}` : `@${d.org.slug || ''}`,
+      avatar: httpImg(d.org.logo_url),
+    })}`;
+    return {
+      title: `Join ${title} · LixBlogs`,
+      description,
+      alternates: { canonical: url },
+      openGraph: { type: 'website', title: `Join ${title}`, description, url, siteName: 'LixBlogs', images: [{ url: og, secureUrl: og, type: 'image/png', width: 1200, height: 630, alt: title }] },
+      twitter: { card: 'summary_large_image', title: `Join ${title}`, description, images: [og] },
+    };
+  } catch {
+    return fallback;
+  }
+}
+
+export default function JoinOrgPage({ params }) {
+  return <JoinOrgClient params={params} />;
+}

--- a/src/components/AppShell.jsx
+++ b/src/components/AppShell.jsx
@@ -6,6 +6,7 @@ import { usePathname } from 'next/navigation';
 import { useAuth } from '../context/AuthContext';
 import { useTheme } from '../context/ThemeContext';
 import { generatePixelAvatar } from '../utils/pixelAvatar';
+import JoinedToast from './JoinedToast';
 
 // ─── Notification type config ───
 const NOTIF_CONFIG = {
@@ -414,6 +415,7 @@ export default function AppShell({ children }) {
 
   return (
     <div className="min-h-screen" style={{ backgroundColor: 'var(--bg-app)' }}>
+      <JoinedToast />
       {/* Header */}
       <header className="sticky top-0 z-50 backdrop-blur-md" style={{ backgroundColor: 'color-mix(in srgb, var(--bg-app) 92%, transparent)', borderBottom: '1px solid var(--border-default)' }}>
         <div className="max-w-[1400px] mx-auto px-6 h-14 flex items-center justify-between">

--- a/src/components/JoinedToast.jsx
+++ b/src/components/JoinedToast.jsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+// One-shot toast shown after an org-join redirect (?joined=1 or ?joined=member).
+// Reads the flag once, then strips it from the URL so a refresh won't re-show it.
+export default function JoinedToast() {
+  const [msg, setMsg] = useState(null);
+
+  useEffect(() => {
+    const sp = new URLSearchParams(window.location.search);
+    const j = sp.get('joined');
+    if (!j) return;
+    setMsg(j === 'member' ? "You're already a member of this organization." : 'Welcome — you joined the organization! 🎉');
+    sp.delete('joined');
+    const qs = sp.toString();
+    window.history.replaceState({}, '', window.location.pathname + (qs ? `?${qs}` : '') + window.location.hash);
+    const t = setTimeout(() => setMsg(null), 4000);
+    return () => clearTimeout(t);
+  }, []);
+
+  if (!msg) return null;
+  return (
+    <div
+      style={{ position: 'fixed', top: 70, left: '50%', transform: 'translateX(-50%)', zIndex: 300, backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border-default)' }}
+      className="px-4 py-2.5 rounded-xl text-[13px] font-medium shadow-2xl flex items-center gap-2"
+    >
+      <ion-icon name="checkmark-circle" style={{ fontSize: '17px', color: '#4ade80' }} />
+      <span style={{ color: 'var(--text-primary)' }}>{msg}</span>
+    </div>
+  );
+}

--- a/src/views/JoinOrgPage.jsx
+++ b/src/views/JoinOrgPage.jsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { useAuth } from '../context/AuthContext';
+import AppShell from '../components/AppShell';
+import { generatePixelAvatar } from '../utils/pixelAvatar';
+
+const ROLE_LABELS = { admin: 'Admin', maintain: 'Maintain', write: 'Write', read: 'Read' };
+
+export default function JoinOrgPage({ inviteId }) {
+  const { user, loading: authLoading } = useAuth();
+  const router = useRouter();
+  const [phase, setPhase] = useState('loading'); // loading | preview | joining | error
+  const [data, setData] = useState(null);
+  const [error, setError] = useState('');
+
+  // Send the user to the org page with a one-shot toast flag.
+  const goToOrg = useCallback((slug, kind) => {
+    router.replace(`/${slug}?joined=${kind}`);
+  }, [router]);
+
+  useEffect(() => {
+    if (authLoading) return;
+    // Must be signed in first — bounce through sign-in and come back here.
+    if (!user) {
+      window.location.href = `/sign-in?next=${encodeURIComponent(`/org/join/${inviteId}`)}`;
+      return;
+    }
+    let active = true;
+    (async () => {
+      try {
+        const res = await fetch(`/api/orgs/invite?inviteId=${encodeURIComponent(inviteId)}`);
+        const d = await res.json().catch(() => ({}));
+        if (!active) return;
+        if (!res.ok || !d.org) { setError(d.error || 'This invite is no longer valid.'); setPhase('error'); return; }
+        if (d.alreadyMember) { goToOrg(d.org.slug, 'member'); return; }
+        if (!d.invite?.valid) { setError(d.invite?.expired ? 'This invite has expired.' : 'This invite has reached its limit.'); setPhase('error'); return; }
+        setData(d);
+        setPhase('preview');
+      } catch {
+        if (active) { setError('Failed to load this invite.'); setPhase('error'); }
+      }
+    })();
+    return () => { active = false; };
+  }, [authLoading, user, inviteId, goToOrg]);
+
+  const handleJoin = async () => {
+    if (!data?.org) return;
+    setPhase('joining');
+    try {
+      const res = await fetch('/api/orgs/invite', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ inviteId }),
+      });
+      const d = await res.json().catch(() => ({}));
+      if (res.ok) { goToOrg(d.orgSlug || data.org.slug, '1'); return; }
+      if (res.status === 409) { goToOrg(data.org.slug, 'member'); return; } // already a member
+      setError(d.error || 'Failed to join.');
+      setPhase('error');
+    } catch {
+      setError('Failed to join.');
+      setPhase('error');
+    }
+  };
+
+  const org = data?.org;
+  const ownerName = data?.owner?.display_name || data?.owner?.username || '';
+  const avatar = org?.logo_url || (org ? generatePixelAvatar(org.slug) : '');
+
+  return (
+    <AppShell>
+      <div className="min-h-[70vh] flex items-center justify-center px-6 py-16">
+        <div className="w-full max-w-md text-center">
+          {(phase === 'loading' || phase === 'joining') && (
+            <div className="flex flex-col items-center gap-4 py-10">
+              <span className="h-8 w-8 rounded-full border-2 border-[var(--border-default)] border-t-[#9b7bf7] animate-spin" />
+              <p className="text-[14px]" style={{ color: 'var(--text-muted)' }}>
+                {phase === 'joining' ? 'Joining…' : 'Loading invite…'}
+              </p>
+            </div>
+          )}
+
+          {phase === 'error' && (
+            <div className="flex flex-col items-center gap-4 py-10">
+              <div className="h-12 w-12 rounded-full flex items-center justify-center" style={{ backgroundColor: 'rgba(248,113,113,0.12)' }}>
+                <ion-icon name="alert-circle-outline" style={{ fontSize: '26px', color: '#f87171' }} />
+              </div>
+              <p className="text-[15px] font-medium" style={{ color: 'var(--text-primary)' }}>{error}</p>
+              <Link href="/" className="text-[13px] font-medium" style={{ color: 'var(--accent)' }}>Go home</Link>
+            </div>
+          )}
+
+          {phase === 'preview' && org && (
+            <div className="rounded-2xl p-8" style={{ backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border-default)' }}>
+              <img src={avatar} alt="" className="h-20 w-20 rounded-2xl object-cover mx-auto mb-4" style={{ border: '1px solid var(--border-default)' }} />
+              <p className="text-[12px] font-semibold uppercase tracking-wider mb-1" style={{ color: 'var(--accent)' }}>You're invited to join</p>
+              <h1 className="text-2xl font-bold mb-1" style={{ color: 'var(--text-primary)' }}>{org.name}</h1>
+              {ownerName && <p className="text-[13px] mb-1" style={{ color: 'var(--text-muted)' }}>by {ownerName}</p>}
+              {org.description && <p className="text-[13px] mt-2 mb-1" style={{ color: 'var(--text-muted)' }}>{org.description}</p>}
+              <p className="text-[12px] mt-3 mb-5" style={{ color: 'var(--text-faint)' }}>
+                Role: <span style={{ color: 'var(--text-secondary)' }}>{ROLE_LABELS[data.invite.role] || data.invite.role}</span>
+              </p>
+              <div className="flex items-center gap-3">
+                <button
+                  onClick={handleJoin}
+                  className="flex-1 py-2.5 bg-[#9b7bf7] text-white font-semibold rounded-xl text-[14px] hover:bg-[#b69aff] transition-colors"
+                >
+                  Join {org.name}
+                </button>
+                <Link
+                  href={`/${org.slug}`}
+                  className="px-4 py-2.5 rounded-xl text-[14px] font-medium transition-colors"
+                  style={{ backgroundColor: 'var(--bg-elevated)', color: 'var(--text-muted)' }}
+                >
+                  View first
+                </Link>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </AppShell>
+  );
+}


### PR DESCRIPTION
## Changes Made

- `app/[...path]/page.jsx` — Extracted `cardMeta()` and `httpImg()` helpers to DRY up metadata generation across all route types.
- `app/[...path]/page.jsx` — Added `searchParams` support and `?invite` detection so invite links get a dedicated OG card showing the inviter.
- `app/[...path]/page.jsx` — Added collection OG card branch: org avatar + collection name + org name via `type=profile&kind=Collection`.
- `app/[...path]/page.jsx` — Blog metadata now includes `co_authors` in the author list and passes `sub` (author line) to the OG endpoint instead of separate `author`/`cover`/`emoji` params.
- `app/api/og/route.js` — Redesigned both card types to GitHub-style white cards with consistent `INK`/`MUTED`/`BORDER`/`ACCENT` palette and a reusable `Brand` component.
- `app/api/og/route.js` — Replaced `author`/`cover`/`emoji` query params with `sub`/`kind`/`subtitle`; profile cards now show a `kind` badge (Organization, Collection, Invitation, Profile) and flexible `sub` line.
- `app/api/og/route.js` — Removed cover-image banner from blog cards; blog cards now render mark + title + author list on a clean white background.

## Checklist

- [ ] `export const runtime = 'edge'` on any new API route
- [ ] No Node built-ins imported (crypto, fs, path, stream, Buffer)
- [ ] New DB columns/tables have a migration in `src/workers/migrations/`
- [ ] Rate-limit middleware on new public auth endpoints
- [ ] `./biome.sh ci` clean
- [ ] Tested locally: <how>