### PR TITLE
[FIX]: Corrected the GitHub cards

### DIFF
--- a/app/[...path]/page.jsx
+++ b/app/[...path]/page.jsx
@@ -44,15 +44,15 @@ export async function generateMetadata({ params, searchParams }) {
         const dn = data.user.display_name || data.user.username || name;
         const handle = `@${data.user.username || name}`;
         const description = (data.user.bio || `${handle} on LixBlogs`).slice(0, 200);
-        const og = ogUrl({ type: 'profile', kind: 'Profile', title: dn, sub: handle, avatar: httpImg(data.user.avatar_url) });
-        return cardMeta({ title: dn, description, url, og, ogType: 'profile' });
+        const og = ogUrl({ type: 'profile', kind: 'Author Profile', title: dn, sub: handle, subtitle: data.user.bio || '', avatar: httpImg(data.user.avatar_url) });
+        return cardMeta({ title: `${dn} — LixBlogs Author Profile`, description, url, og, ogType: 'profile' });
       }
       if (data.type === 'org' && data.org) {
         const dn = data.org.name || name;
         const ownerName = data.owner?.display_name || data.owner?.username || '';
         const description = (data.org.description || data.org.bio || `${dn} on LixBlogs`).slice(0, 200);
-        const og = ogUrl({ type: 'profile', kind: 'Organization', title: dn, sub: ownerName ? `by ${ownerName}` : `@${data.org.slug || name}`, avatar: httpImg(data.org.logo_url || data.org.logo_r2_key) });
-        return cardMeta({ title: dn, description, url, og, ogType: 'profile' });
+        const og = ogUrl({ type: 'profile', kind: 'Organisation', title: dn, sub: ownerName ? `by ${ownerName}` : `@${data.org.slug || name}`, subtitle: data.org.description || data.org.bio || '', avatar: httpImg(data.org.logo_url || data.org.logo_r2_key) });
+        return cardMeta({ title: `${dn} — LixBlogs Organisation`, description, url, og, ogType: 'profile' });
       }
       return {};
     }
@@ -70,8 +70,8 @@ export async function generateMetadata({ params, searchParams }) {
       const orgName = data.owner?.name || name;
       const title = data.collection.name || 'Collection';
       const description = (data.collection.description || `A collection by ${orgName} on LixBlogs`).slice(0, 200);
-      const og = ogUrl({ type: 'profile', kind: 'Collection', title, sub: orgName, avatar: httpImg(data.owner?.logo_url || data.owner?.logo_r2_key) });
-      return cardMeta({ title, description, url, og, ogType: 'website' });
+      const og = ogUrl({ type: 'profile', kind: 'Collection', title, sub: orgName, subtitle: data.collection.description || '', avatar: httpImg(data.owner?.logo_url || data.owner?.logo_r2_key) });
+      return cardMeta({ title: `${title} — ${orgName} on LixBlogs`, description, url, og, ogType: 'website' });
     }
 
     if (data.type !== 'blog' || !data.blog) return {};
@@ -95,7 +95,8 @@ export async function generateMetadata({ params, searchParams }) {
     const authorList = [primary, ...coAuthors].filter(Boolean);
     const sub = authorList.length ? `by ${authorList.slice(0, 4).join(', ')}${authorList.length > 4 ? ` +${authorList.length - 4}` : ''}` : '';
     const description = (b.subtitle || '').slice(0, 200) || (primary ? `By ${primary} on LixBlogs` : 'On LixBlogs');
-    const og = ogUrl({ type: 'blog', title, subtitle: b.subtitle || '', sub, avatar: httpImg(b.author_avatar) });
+    const readTime = b.read_time_minutes ? `${b.read_time_minutes} min read` : '';
+    const og = ogUrl({ type: 'blog', title, subtitle: b.subtitle || '', sub, readTime, cover: httpImg(b.cover_image_r2_key), avatar: httpImg(b.author_avatar) });
 
     return {
       title,

--- a/app/api/og/route.js
+++ b/app/api/og/route.js
@@ -3,23 +3,23 @@ import { ImageResponse } from 'next/og';
 export const runtime = 'edge';
 
 // GitHub-style social cards on a clean white background.
-//   type=blog    → LixBlogs mark + blog title + author list (small)
-//   type=profile → avatar + name + owner/handle (orgs, users, collections, invites)
+//   type=profile → real logo + avatar + name + @handle + bio (users & orgs)
+//   type=blog    → real logo + blog banner + title + tagline + read time · authors
 //
-// Params: type, title, sub, subtitle, avatar, kind
-//   sub      — authors line (blog) or owner/handle (profile)
-//   subtitle — short description (optional)
-//   kind     — small badge label (e.g. "Organization", "Collection", "Invitation")
+// Params: type, title, subtitle, sub, kind, avatar, cover, readTime
+//   subtitle — bio (profile) or tagline (blog)
+//   sub      — @handle (profile) or author list (blog)
+//   kind     — small badge ("Author Profile", "Organisation", "Collection", …)
 export async function GET(request) {
-  const { searchParams } = new URL(request.url);
+  const { searchParams, origin } = new URL(request.url);
   const type = searchParams.get('type') || 'blog';
   const title = (searchParams.get('title') || 'Untitled').slice(0, 120);
-  const sub = (searchParams.get('sub') || '').slice(0, 120);
-  const subtitle = (searchParams.get('subtitle') || '').slice(0, 200);
+  const subtitle = (searchParams.get('subtitle') || '').slice(0, 220);
+  const sub = (searchParams.get('sub') || '').slice(0, 140);
   const kind = (searchParams.get('kind') || '').slice(0, 40);
+  const readTime = (searchParams.get('readTime') || '').slice(0, 20);
 
-  // satori (next/og) can't decode WebP — our Cloudinary URLs default to f_webp.
-  // Force JPEG delivery so avatars actually render.
+  // satori can't decode WebP — force Cloudinary to deliver JPEG.
   const ogSafeImage = (url) => {
     if (!url || !/^https?:\/\//.test(url)) return '';
     if (url.includes('res.cloudinary.com')) {
@@ -30,44 +30,57 @@ export async function GET(request) {
     return url;
   };
   const avatar = ogSafeImage(searchParams.get('avatar') || '');
+  const cover = ogSafeImage(searchParams.get('cover') || '');
   const hasAvatar = !!avatar;
+  const hasCover = !!cover;
 
-  const WHITE = '#ffffff';
-  const INK = '#0d1117';      // GitHub near-black
-  const MUTED = '#57606a';    // GitHub muted text
-  const BORDER = '#d0d7de';   // GitHub border
-  const ACCENT = '#9b7bf7';   // LixBlogs purple
+  // Embed the real LixBlogs logo (public/logo-dark.png — dark mark on white) as a
+  // data URI so it renders reliably inside the edge OG runtime.
+  let logoSrc = '';
+  try {
+    const r = await fetch(`${origin}/logo-dark.png`);
+    if (r.ok) {
+      const bytes = new Uint8Array(await r.arrayBuffer());
+      let binary = '';
+      for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+      logoSrc = `data:image/png;base64,${btoa(binary)}`;
+    }
+  } catch { /* fall back to the drawn mark */ }
 
-  // Brand mark — drawn inline (static assets don't render reliably in edge OG).
-  const Brand = ({ size = 34, font = 24 }) => (
+  const INK = '#0d1117';
+  const MUTED = '#57606a';
+  const BORDER = '#d0d7de';
+  const ACCENT = '#9b7bf7';
+
+  const Brand = () => (
     <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
-      <div style={{ display: 'flex', width: `${size}px`, height: `${size}px`, borderRadius: '9px', background: `linear-gradient(135deg, ${ACCENT}, #6d4fd1)`, alignItems: 'center', justifyContent: 'center', color: '#fff', fontSize: `${font}px`, fontWeight: 800 }}>L</div>
-      <span style={{ color: MUTED, fontSize: '26px', fontWeight: 700 }}>LixBlogs</span>
+      {logoSrc
+        ? <img src={logoSrc} width={36} height={36} style={{ width: '36px', height: '36px', borderRadius: '50%' }} />
+        : <div style={{ display: 'flex', width: '36px', height: '36px', borderRadius: '50%', background: `linear-gradient(135deg, ${ACCENT}, #6d4fd1)`, alignItems: 'center', justifyContent: 'center', color: '#fff', fontSize: '22px', fontWeight: 800 }}>L</div>}
+      <span style={{ color: INK, fontSize: '28px', fontWeight: 700 }}>LixBlogs</span>
     </div>
   );
 
   const initial = (title || 'L').replace('@', '').charAt(0).toUpperCase();
 
-  // ── Profile / org / collection / invite — avatar + name + owner ──
+  // ── Profile / org / collection — logo + avatar + name + handle + bio ──
   if (type === 'profile') {
     return new ImageResponse(
       (
-        <div style={{ width: '100%', height: '100%', display: 'flex', background: WHITE, fontFamily: 'sans-serif', padding: '64px' }}>
-          <div style={{ display: 'flex', flexDirection: 'column', width: '100%', height: '100%', border: `1px solid ${BORDER}`, borderRadius: '24px', padding: '56px 64px', justifyContent: 'space-between' }}>
+        <div style={{ width: '100%', height: '100%', display: 'flex', background: '#ffffff', fontFamily: 'sans-serif', padding: '72px' }}>
+          <div style={{ display: 'flex', flexDirection: 'column', width: '100%', height: '100%', border: `1px solid ${BORDER}`, borderRadius: '28px', padding: '60px 68px', justifyContent: 'space-between' }}>
             <Brand />
-            <div style={{ display: 'flex', alignItems: 'center', gap: '40px' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '44px' }}>
               {hasAvatar ? (
-                <img src={avatar} width={200} height={200} style={{ width: '200px', height: '200px', borderRadius: '50%', objectFit: 'cover', border: `1px solid ${BORDER}` }} />
+                <img src={avatar} width={210} height={210} style={{ width: '210px', height: '210px', borderRadius: '50%', objectFit: 'cover', border: `1px solid ${BORDER}` }} />
               ) : (
-                <div style={{ display: 'flex', width: '200px', height: '200px', borderRadius: '50%', alignItems: 'center', justifyContent: 'center', background: `linear-gradient(135deg, ${ACCENT}, #6d4fd1)`, color: '#fff', fontSize: '96px', fontWeight: 800 }}>
-                  {initial}
-                </div>
+                <div style={{ display: 'flex', width: '210px', height: '210px', borderRadius: '50%', alignItems: 'center', justifyContent: 'center', background: `linear-gradient(135deg, ${ACCENT}, #6d4fd1)`, color: '#fff', fontSize: '100px', fontWeight: 800 }}>{initial}</div>
               )}
               <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minWidth: 0 }}>
-                {kind ? <div style={{ display: 'flex', color: ACCENT, fontSize: '24px', fontWeight: 700, letterSpacing: '1px', textTransform: 'uppercase', marginBottom: '10px' }}>{kind}</div> : null}
-                <div style={{ display: 'flex', color: INK, fontSize: title.length > 22 ? '56px' : '68px', fontWeight: 800, lineHeight: 1.05 }}>{title}</div>
-                {sub ? <div style={{ display: 'flex', color: MUTED, fontSize: '30px', fontWeight: 600, marginTop: '14px' }}>{sub}</div> : null}
-                {subtitle ? <div style={{ display: 'flex', color: MUTED, fontSize: '24px', marginTop: '14px', lineHeight: 1.35, maxWidth: '720px' }}>{subtitle}</div> : null}
+                {kind ? <div style={{ display: 'flex', color: ACCENT, fontSize: '22px', fontWeight: 700, letterSpacing: '1.5px', textTransform: 'uppercase', marginBottom: '12px' }}>{kind}</div> : null}
+                <div style={{ display: 'flex', color: INK, fontSize: title.length > 22 ? '54px' : '66px', fontWeight: 800, lineHeight: 1.05 }}>{title}</div>
+                {sub ? <div style={{ display: 'flex', color: MUTED, fontSize: '28px', fontWeight: 600, marginTop: '12px' }}>{sub}</div> : null}
+                {subtitle ? <div style={{ display: 'flex', color: MUTED, fontSize: '24px', marginTop: '16px', lineHeight: 1.4, maxWidth: '700px' }}>{subtitle}</div> : null}
               </div>
             </div>
             <div style={{ display: 'flex' }} />
@@ -78,21 +91,29 @@ export async function GET(request) {
     );
   }
 
-  // ── Blog — mark + title + author list (small) ──
+  // ── Blog — logo + banner + title + tagline + read time · authors ──
   return new ImageResponse(
     (
-      <div style={{ width: '100%', height: '100%', display: 'flex', background: WHITE, fontFamily: 'sans-serif', padding: '64px' }}>
-        <div style={{ display: 'flex', flexDirection: 'column', width: '100%', height: '100%', border: `1px solid ${BORDER}`, borderRadius: '24px', padding: '56px 64px', justifyContent: 'space-between' }}>
-          <Brand />
-          <div style={{ display: 'flex', flexDirection: 'column' }}>
-            <div style={{ display: 'flex', color: INK, fontSize: title.length > 60 ? '60px' : '76px', fontWeight: 800, lineHeight: 1.08 }}>{title}</div>
-            {subtitle ? <div style={{ display: 'flex', color: MUTED, fontSize: '30px', marginTop: '20px', lineHeight: 1.3, maxWidth: '960px' }}>{subtitle}</div> : null}
+      <div style={{ width: '100%', height: '100%', display: 'flex', background: '#ffffff', fontFamily: 'sans-serif', padding: '64px' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', width: '100%', height: '100%', border: `1px solid ${BORDER}`, borderRadius: '28px', overflow: 'hidden' }}>
+          {/* Banner — cover if present, else a branded default */}
+          <div style={{ display: 'flex', width: '100%', height: '230px' }}>
+            {hasCover
+              ? <img src={cover} width={1072} height={230} style={{ width: '100%', height: '230px', objectFit: 'cover' }} />
+              : <div style={{ display: 'flex', width: '100%', height: '230px', background: `linear-gradient(135deg, ${ACCENT} 0%, #6d4fd1 100%)` }} />}
           </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '14px' }}>
-            {hasAvatar ? (
-              <img src={avatar} width={52} height={52} style={{ width: '52px', height: '52px', borderRadius: '50%', objectFit: 'cover', border: `1px solid ${BORDER}` }} />
-            ) : null}
-            {sub ? <span style={{ display: 'flex', color: MUTED, fontSize: '28px', fontWeight: 600 }}>{sub}</span> : null}
+          <div style={{ display: 'flex', flexDirection: 'column', flex: 1, padding: '40px 56px', justifyContent: 'space-between' }}>
+            <div style={{ display: 'flex', flexDirection: 'column' }}>
+              <div style={{ display: 'flex', color: INK, fontSize: title.length > 52 ? '52px' : '64px', fontWeight: 800, lineHeight: 1.08 }}>{title}</div>
+              {subtitle ? <div style={{ display: 'flex', color: MUTED, fontSize: '28px', marginTop: '16px', lineHeight: 1.3, maxWidth: '960px' }}>{subtitle}</div> : null}
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '14px', color: MUTED, fontSize: '24px', fontWeight: 600 }}>
+                {hasAvatar ? <img src={avatar} width={44} height={44} style={{ width: '44px', height: '44px', borderRadius: '50%', objectFit: 'cover', border: `1px solid ${BORDER}` }} /> : null}
+                <span style={{ display: 'flex' }}>{[readTime, sub].filter(Boolean).join('  ·  ')}</span>
+              </div>
+              <Brand />
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Changes Made
- `app/[...path]/page.jsx` — Added `subtitle` and `readTime` params to OG URL calls for profiles, orgs, and collections; updated card titles to include platform branding (e.g. `${dn} — LixBlogs Author Profile`).
- `app/[...path]/page.jsx` — Blog metadata now passes `readTime` (from `read_time_minutes`) and `cover` (from `cover_image_r2_key`) to the OG image endpoint.
- `app/api/og/route.js` — Replaced the drawn-inline brand mark with a fetched data-URI of the real `logo-dark.png`, with fallback to the drawn "L" circle.
- `app/api/og/route.js` — Added `cover` and `readTime` query params; blog cards now render a cover image banner at the top (or a purple gradient fallback).
- `app/api/og/route.js` — Restructured blog card layout: banner → title/tagline → footer with author avatar + read time · authors + brand mark.
- `app/api/og/route.js` — Profile cards now include `subtitle` (bio/description), larger avatar, slightly wider padding, and refined typography.
- `app/api/og/route.js` — Changed "Organization" → "Organisation", "Profile" → "Author Profile" in kind labels; adjusted character limits on `sub` and `subtitle`.

## Checklist
- [ ] `export const runtime = 'edge'` on any new API route
- [ ] No Node built-ins imported (crypto, fs, path, stream, Buffer)
- [ ] `./biome.sh ci` clean
- [ ] Tested locally: <how>