### PR TITLE
[FIX] Hide follow/mute self in blog dots menu

### DIFF
--- a/src/components/BlogDotsMenu.jsx
+++ b/src/components/BlogDotsMenu.jsx
@@ -6,6 +6,7 @@ export default function BlogDotsMenu({ blogId, authorId, author = {}, org = null
   const { user } = useAuth();
   const [open, setOpen] = useState(false);
   const [fAuthor, setFAuthor] = useState(false);
+  const [isSelf, setIsSelf] = useState(false);
   const [fOrg, setFOrg] = useState(false);
   const [done, setDone] = useState('');
   const ref = useRef(null);
@@ -27,7 +28,7 @@ export default function BlogDotsMenu({ blogId, authorId, author = {}, org = null
   // Resolve follow state on open.
   useEffect(() => {
     if (!open || !user) return;
-    if (author?.username) fetch(`/api/users/${author.username}/follow`).then(r => r.ok ? r.json() : null).then(d => d && setFAuthor(!!d.following)).catch(() => {});
+    if (author?.username) fetch(`/api/users/${author.username}/follow`).then(r => r.ok ? r.json() : null).then(d => { if (d) { setFAuthor(!!d.following); setIsSelf(!!d.self); } }).catch(() => {});
     if (org?.slug) fetch(`/api/orgs/${org.slug}/follow`).then(r => r.ok ? r.json() : null).then(d => d && setFOrg(!!d.following)).catch(() => {});
   }, [open, user]);
 
@@ -74,10 +75,10 @@ export default function BlogDotsMenu({ blogId, authorId, author = {}, org = null
               <Row icon="thumbs-down-outline" label="Show less like this" onClick={showLess} />
               <Row icon={hideHighlights ? 'eye-outline' : 'color-wand-outline'} label={hideHighlights ? 'Show highlights' : 'Hide highlights'} onClick={toggleHi} kbd="Ctrl /" />
               <Divider />
-              <Row label={fAuthor ? `Following ${author.display_name || author.username}` : `Follow ${author.display_name || author.username}`} onClick={followAuthor} disabled={fAuthor} />
+              {!isSelf && <Row label={fAuthor ? `Following ${author.display_name || author.username}` : `Follow ${author.display_name || author.username}`} onClick={followAuthor} disabled={fAuthor} />}
               {org && <Row label={fOrg ? `Following ${org.name}` : `Follow ${org.name}`} onClick={followOrg} disabled={fOrg} />}
               <Divider />
-              <Row label="Mute author" onClick={muteAuthor} />
+              {!isSelf && <Row label="Mute author" onClick={muteAuthor} />}
               {org && <Row label="Mute publication" onClick={muteOrg} />}
               {tags.length > 0 && <Row label="Mute topics" onClick={muteTopics} badge />}
               <Divider />

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -202,6 +202,7 @@ function FeedCardMenu({ post, onHide }) {
   const { user } = useAuth();
   const [open, setOpen] = useState(false);
   const [fAuthor, setFAuthor] = useState(false);
+  const [isSelf, setIsSelf] = useState(false);
   const [fOrg, setFOrg] = useState(false);
   const ref = useRef(null);
   const author = post.author || {};
@@ -217,7 +218,7 @@ function FeedCardMenu({ post, onHide }) {
   // Resolve current follow state when the menu opens, to grey out what's already followed.
   useEffect(() => {
     if (!open || !user) return;
-    if (author.username) fetch(`/api/users/${author.username}/follow`).then(r => r.ok ? r.json() : null).then(d => d && setFAuthor(!!d.following)).catch(() => {});
+    if (author.username) fetch(`/api/users/${author.username}/follow`).then(r => r.ok ? r.json() : null).then(d => { if (d) { setFAuthor(!!d.following); setIsSelf(!!d.self); } }).catch(() => {});
     if (org?.slug) fetch(`/api/orgs/${org.slug}/follow`).then(r => r.ok ? r.json() : null).then(d => d && setFOrg(!!d.following)).catch(() => {});
   }, [open, user]);
 
@@ -252,10 +253,10 @@ function FeedCardMenu({ post, onHide }) {
       </button>
       {open && (
         <div className="absolute right-0 top-9 z-50 w-56 rounded-xl py-1.5 overflow-hidden" style={{ backgroundColor: 'var(--dropdown-bg, var(--bg-surface))', border: '1px solid var(--border-default)', boxShadow: '0 12px 40px rgba(0,0,0,0.35)' }}>
-          {item(fAuthor ? `Following ${author.display_name || author.username}` : `Follow ${author.display_name || author.username}`, followAuthor, false, false, fAuthor)}
+          {!isSelf && item(fAuthor ? `Following ${author.display_name || author.username}` : `Follow ${author.display_name || author.username}`, followAuthor, false, false, fAuthor)}
           {org && item(fOrg ? `Following ${org.name}` : `Follow ${org.name}`, followOrg, false, false, fOrg)}
           <div className="my-1.5" style={{ borderTop: '1px solid var(--divider)' }} />
-          {item('Mute author', muteAuthor)}
+          {!isSelf && item('Mute author', muteAuthor)}
           {org && item('Mute publication', muteOrg)}
           {(post.tags || []).length > 0 && item('Mute topics', muteTopics, false, true)}
           <div className="my-1.5" style={{ borderTop: '1px solid var(--divider)' }} />


### PR DESCRIPTION
## Problem

When a logged-in user views their own blog post and opens the three-dot menu, they see "Follow" and "Mute author" options targeting themselves. Same issue on feed cards.

## Root cause

The follow API already returns a `self: true` flag when the target user matches the logged-in user. Components like `FollowToggle` and `FollowButton` already read this flag and hide themselves. However, the two dots menu components never checked it.

## Fix

- **src/components/BlogDotsMenu.jsx** — added `isSelf` state, read the `self` flag from the follow API response, wrapped "Follow author" and "Mute author" rows in `{!isSelf && ...}` so they don't render when viewing your own blog.
- **src/index.jsx** (`FeedCardMenu`) — same fix applied to the dots menu on home feed cards.

No backend or API changes required.