### PR TITLE
[FEAT]: Addition of the pricing modal  and terms

### DIFF
--- a/app/api/pricing/route.js
+++ b/app/api/pricing/route.js
@@ -1,0 +1,12 @@
+export const runtime = 'edge';
+import { NextResponse } from 'next/server';
+import { pricingForCountry } from '../../../lib/pricing';
+
+// Returns PPP-adjusted prices for the visitor's country (Cloudflare geo header).
+export async function GET(request) {
+  let cc = request.headers.get('cf-ipcountry') || '';
+  if (!cc) { try { cc = request.cf?.country || ''; } catch {} }
+  return NextResponse.json(pricingForCountry(cc), {
+    headers: { 'cache-control': 'public, max-age=300' },
+  });
+}

--- a/app/api/subpages/route.js
+++ b/app/api/subpages/route.js
@@ -29,6 +29,13 @@ export async function POST(request) {
     if (blog.author_id !== session.userId) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     const canonicalBlogId = blog.id;
 
+    // Sub-pages are a Member feature — gate creation by tier.
+    const { getLimits } = await import('../../../lib/tiers');
+    const me = await db.prepare('SELECT tier FROM users WHERE id = ?').bind(session.userId).first();
+    if (!getLimits(me?.tier).canUseSubpages) {
+      return NextResponse.json({ error: 'Sub-pages are a Member feature.', upgrade: true }, { status: 402 });
+    }
+
     // Cap sub-pages per kind: max 2 doc sub-pages and max 2 canvas sub-pages per blog.
     // (Nesting is structurally impossible — a sub-page's id is never a blogs row,
     //  so creating a sub-page "under" a sub-page 404s on the ownership check above.)

--- a/lib/pricing.js
+++ b/lib/pricing.js
@@ -1,0 +1,103 @@
+// Plans + purchasing-power-adjusted (PPP) regional pricing.
+// Checkout itself is handled by the central payments service (payouts.elixpo.com),
+// like Elixpo Accounts — this app only presents prices and hands the user off.
+
+export const PAYOUTS_BASE = 'https://payouts.elixpo.com';
+
+// Feature copy per plan. Prices come from the regional band (below).
+export const PLANS = [
+  {
+    id: 'free',
+    name: 'Free',
+    tagline: 'For readers and casual writers',
+    features: [
+      'Read everything public',
+      'Unlimited public posts',
+      'Block editor + 15 AI requests/day',
+      '1 organization · 50 MB storage',
+      'Comments, follows, bookmarks',
+    ],
+  },
+  {
+    id: 'member',
+    name: 'Member',
+    tagline: 'For people who publish seriously',
+    highlighted: true,
+    features: [
+      'Everything in Free',
+      'Sub-pages & canvas boards',
+      '50 AI requests/day + AI image generation',
+      'Member-only posts — earn from reads',
+      '2 GB storage · 5 co-authors · 5 orgs',
+      'No LixBlogs branding on share cards',
+    ],
+  },
+  {
+    id: 'team',
+    name: 'Team',
+    tagline: 'For organizations',
+    perSeat: true,
+    features: [
+      'Everything in Member, for the whole org',
+      'Unlimited seats & collections',
+      'Private organizations',
+      'Team analytics & rollups',
+      'Priority AI',
+    ],
+  },
+];
+
+// PPP bands — monthly. `member` = individual plan, `team` = per-seat.
+export const PRICE_BANDS = {
+  T1: { currency: 'USD', symbol: '$', member: 6, team: 5 },     // high income
+  T2: { currency: 'USD', symbol: '$', member: 4, team: 3 },     // upper-middle
+  T3: { currency: 'USD', symbol: '$', member: 2.5, team: 2 },   // lower income
+  IN: { currency: 'INR', symbol: '₹', member: 199, team: 149 }, // India
+};
+
+// Country → band. Anything unlisted falls back to T1 (full price).
+const COUNTRY_BAND = {
+  // T1 — high income
+  US: 'T1', CA: 'T1', GB: 'T1', IE: 'T1', AU: 'T1', NZ: 'T1', CH: 'T1', NO: 'T1', SE: 'T1',
+  DK: 'T1', FI: 'T1', DE: 'T1', NL: 'T1', FR: 'T1', BE: 'T1', AT: 'T1', LU: 'T1', IS: 'T1',
+  JP: 'T1', KR: 'T1', SG: 'T1', HK: 'T1', AE: 'T1', QA: 'T1', IL: 'T1',
+  // IN — India
+  IN: 'IN',
+  // T2 — upper-middle income
+  BR: 'T2', MX: 'T2', AR: 'T2', CL: 'T2', CO: 'T2', ZA: 'T2', TR: 'T2', PL: 'T2', RO: 'T2',
+  TH: 'T2', MY: 'T2', CN: 'T2', RU: 'T2', SA: 'T2', PT: 'T2', GR: 'T2', ES: 'T2', IT: 'T2',
+  // T3 — lower income
+  ID: 'T3', PH: 'T3', VN: 'T3', PK: 'T3', BD: 'T3', NG: 'T3', KE: 'T3', EG: 'T3', LK: 'T3',
+  NP: 'T3', GH: 'T3', UA: 'T3', MA: 'T3', DZ: 'T3',
+};
+
+export function bandForCountry(cc) {
+  return COUNTRY_BAND[(cc || '').toUpperCase()] || 'T1';
+}
+
+// Build the localized pricing payload sent to the client.
+export function pricingForCountry(cc) {
+  const band = bandForCountry(cc);
+  const b = PRICE_BANDS[band];
+  return {
+    country: (cc || '').toUpperCase() || null,
+    band,
+    currency: b.currency,
+    symbol: b.symbol,
+    prices: { free: 0, member: b.member, team: b.team },
+  };
+}
+
+// Hand-off URL to the central payments service. The secret/expiry-coded checkout
+// lives there; we only pass the plan, localized amount, the buyer, and a return URL.
+export function checkoutUrl({ plan, currency, amount, uid, returnUrl }) {
+  const qs = new URLSearchParams({
+    app: 'lixblogs',
+    plan,
+    currency: currency || 'USD',
+    amount: String(amount ?? ''),
+  });
+  if (uid) qs.set('uid', uid);
+  if (returnUrl) qs.set('return', returnUrl);
+  return `${PAYOUTS_BASE}/checkout?${qs}`;
+}

--- a/lib/tiers.js
+++ b/lib/tiers.js
@@ -9,6 +9,7 @@ export const TIER_LIMITS = {
     ownedOrgs: 1,
     canReadMemberOnly: false,
     canMarkMemberOnly: false,
+    canUseSubpages: false,
   },
   member: {
     totalStorageBytes: 2 * 1024 * 1024 * 1024,  // 2 GB
@@ -18,6 +19,7 @@ export const TIER_LIMITS = {
     ownedOrgs: 5,
     canReadMemberOnly: true,
     canMarkMemberOnly: true,
+    canUseSubpages: true,
   },
 };
 

--- a/src/components/Editor/blocks/TabsBlock.jsx
+++ b/src/components/Editor/blocks/TabsBlock.jsx
@@ -20,6 +20,7 @@ export const TabsBlock = createReactBlockSpec(
       const [adding, setAdding] = useState(tabs.length === 0);
       const [newPageName, setNewPageName] = useState('');
       const [creating, setCreating] = useState(false);
+      const [gateError, setGateError] = useState('');
       const inputRef = useRef(null);
       const wrapperRef = useRef(null);
 
@@ -60,6 +61,7 @@ export const TabsBlock = createReactBlockSpec(
       const addPage = useCallback(async () => {
         const name = newPageName.trim() || 'Untitled Page';
         setCreating(true);
+        setGateError('');
         try {
           const blogId = getBlogId();
           const res = await fetch('/api/subpages', {
@@ -73,6 +75,8 @@ export const TabsBlock = createReactBlockSpec(
             editor.updateBlock(block, { props: { tabs: JSON.stringify(updated) } });
             setNewPageName('');
             setAdding(false);
+          } else if (res.status === 402) {
+            setGateError('Sub-pages are a Member feature.');
           }
         } catch {}
         setCreating(false);
@@ -140,6 +144,11 @@ export const TabsBlock = createReactBlockSpec(
                 <button onClick={addPage} disabled={!newPageName.trim()} className="subpage-create-btn">Create</button>
               )}
             </div>
+            {gateError && (
+              <div style={{ fontSize: '12px', color: 'var(--text-muted)', marginTop: '8px', paddingLeft: '4px' }}>
+                {gateError} <a href="/pricing" style={{ color: '#9b7bf7', fontWeight: 600 }}>Upgrade →</a>
+              </div>
+            )}
           </div>
         );
       }

--- a/src/views/PricingPage.jsx
+++ b/src/views/PricingPage.jsx
@@ -1,27 +1,114 @@
 'use client';
 
+import { useState, useEffect } from 'react';
+import { useAuth } from '../context/AuthContext';
 import AppShell from '../components/AppShell';
-import Link from 'next/link';
-import '../styles/pricing/pricing.css';
+import { PLANS, checkoutUrl } from '../../lib/pricing';
+
+function fmtPrice(symbol, amount) {
+  if (!amount) return 'Free';
+  const n = Number.isInteger(amount) ? amount : amount.toFixed(1);
+  return `${symbol}${n}`;
+}
 
 export default function PricingPage() {
+  const { user } = useAuth();
+  const [pricing, setPricing] = useState(null); // { currency, symbol, prices, country, band }
+
+  useEffect(() => {
+    fetch('/api/pricing')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => { if (d) setPricing(d); })
+      .catch(() => {});
+  }, []);
+
+  const symbol = pricing?.symbol || '$';
+  const prices = pricing?.prices || { free: 0, member: 6, team: 5 };
+  const currentTier = user?.tier || (user ? 'free' : null);
+
+  const startCheckout = (planId) => {
+    if (planId === 'free') { window.location.href = user ? '/' : '/sign-in'; return; }
+    window.location.href = checkoutUrl({
+      plan: planId,
+      currency: pricing?.currency || 'USD',
+      amount: prices[planId],
+      uid: user?.id,
+      returnUrl: `${window.location.origin}/settings`,
+    });
+  };
+
   return (
     <AppShell>
-      <div className="pricing-page">
-        <div className="pricing-coming-soon">
-          <div className="pricing-coming-soon-icon">
-            <ion-icon name="sparkles-outline" />
-          </div>
-          <h1 className="pricing-title">Pricing is coming soon</h1>
-          <p className="pricing-subtitle">
-            We're still figuring out the right plans. For now, everything is free while we build.
+      <div className="max-w-5xl mx-auto px-6 py-14">
+        <div className="text-center mb-3">
+          <h1 className="text-3xl font-extrabold" style={{ color: 'var(--text-primary)' }}>Plans that grow with you</h1>
+          <p className="text-[15px] mt-2" style={{ color: 'var(--text-muted)' }}>
+            Publish for free. Upgrade to unlock sub-pages, more AI, and member-only earnings.
           </p>
-          <div className="pricing-coming-soon-cta">
-            <Link href="/" className="cta-button cta-primary">
-              Back to feed
-            </Link>
-          </div>
         </div>
+
+        <div className="grid gap-5 md:grid-cols-3 mt-10">
+          {PLANS.map((plan) => {
+            const isCurrent = currentTier === plan.id;
+            const amount = prices[plan.id] ?? 0;
+            const highlighted = plan.highlighted;
+            return (
+              <div
+                key={plan.id}
+                className="rounded-2xl p-6 flex flex-col"
+                style={{
+                  backgroundColor: 'var(--bg-surface)',
+                  border: highlighted ? '1.5px solid #9b7bf7' : '1px solid var(--border-default)',
+                  boxShadow: highlighted ? '0 12px 40px rgba(155,123,247,0.12)' : 'none',
+                }}
+              >
+                <div className="flex items-center justify-between mb-1">
+                  <h3 className="text-[17px] font-bold" style={{ color: 'var(--text-primary)' }}>{plan.name}</h3>
+                  {highlighted && (
+                    <span className="text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full" style={{ backgroundColor: '#9b7bf71f', color: '#9b7bf7' }}>Popular</span>
+                  )}
+                </div>
+                <p className="text-[12px] mb-4" style={{ color: 'var(--text-muted)' }}>{plan.tagline}</p>
+
+                <div className="mb-5">
+                  <span className="text-3xl font-extrabold" style={{ color: 'var(--text-primary)' }}>{fmtPrice(symbol, amount)}</span>
+                  {amount ? (
+                    <span className="text-[13px]" style={{ color: 'var(--text-muted)' }}> /{plan.perSeat ? 'seat · mo' : 'mo'}</span>
+                  ) : null}
+                </div>
+
+                <ul className="flex-1 space-y-2.5 mb-6">
+                  {plan.features.map((f) => (
+                    <li key={f} className="flex items-start gap-2 text-[13px]" style={{ color: 'var(--text-body)' }}>
+                      <ion-icon name="checkmark-circle" style={{ fontSize: '16px', color: '#9b7bf7', flexShrink: 0, marginTop: '1px' }} />
+                      <span>{f}</span>
+                    </li>
+                  ))}
+                </ul>
+
+                <button
+                  onClick={() => startCheckout(plan.id)}
+                  disabled={isCurrent}
+                  className="w-full py-2.5 rounded-xl text-[14px] font-semibold transition-colors disabled:opacity-50 disabled:cursor-default"
+                  style={
+                    isCurrent
+                      ? { backgroundColor: 'var(--bg-elevated)', color: 'var(--text-muted)' }
+                      : highlighted
+                        ? { backgroundColor: '#9b7bf7', color: '#fff' }
+                        : { backgroundColor: 'var(--bg-elevated)', color: 'var(--text-primary)', border: '1px solid var(--border-default)' }
+                  }
+                >
+                  {isCurrent ? 'Current plan' : plan.id === 'free' ? 'Get started' : `Upgrade to ${plan.name}`}
+                </button>
+              </div>
+            );
+          })}
+        </div>
+
+        <p className="text-center text-[12px] mt-8" style={{ color: 'var(--text-faint)' }}>
+          {pricing?.country ? `Prices adjusted for your region (${pricing.country}). ` : ''}
+          Payments are processed securely by Elixpo Pay. Cancel anytime.
+        </p>
       </div>
     </AppShell>
   );


### PR DESCRIPTION
## Changes Made
- Added `app/api/pricing/route.js` — new edge API route that returns PPP-adjusted prices based on the visitor's country via `cf-ipcountry` header.
- Added `lib/pricing.js` — plan definitions, PPP regional price bands (T1/T2/T3/IN), country-to-band mapping, and `checkoutUrl()` helper that hands off to the central payments service.
- Updated `lib/tiers.js` — added `canUseSubpages` flag (false for free tier, true for member tier).
- Updated `app/api/subpages/route.js` — gates sub-page creation behind the Member tier; returns 402 with `upgrade: true` for free users.
- Updated `src/components/Editor/blocks/TabsBlock.jsx` — captures 402 responses from the sub-pages endpoint and displays an upgrade prompt with a link to `/pricing`.
- Replaced `src/views/PricingPage.jsx` — swaps the "coming soon" placeholder for a live pricing page that fetches localized prices, renders plan cards with feature lists, and redirects to the Elixpo Pay checkout.

## Checklist
- [ ] `export const runtime = 'edge'` on any new API route
- [ ] No Node built-ins imported (crypto, fs, path, stream, Buffer)
- [ ] `./biome.sh ci` clean
- [ ] Tested locally: <how>