### PR TITLE
[PATCH]: Fix the direct editor based blogs on the WYSIWYG for the authors and the update settings

### DIFF
--- a/app/api/blogs/draft/route.js
+++ b/app/api/blogs/draft/route.js
@@ -98,12 +98,20 @@ export async function GET(request) {
       isOwner = !!ownerRow;
     }
 
+    // The real author — so collaborators see the actual owner in publish settings,
+    // not themselves.
+    const author = await db.prepare('SELECT username, display_name, avatar_url FROM users WHERE id = ?')
+      .bind(blog.author_id).first();
+
     return NextResponse.json({
       blog: {
         ...blog,
         content,
         tags: (tags?.results || []).map(t => t.tag),
         is_owner: isOwner,
+        owner_username: author?.username || null,
+        owner_display_name: author?.display_name || null,
+        owner_avatar: author?.avatar_url || null,
       },
       version,
     }, { headers: NO_STORE });

--- a/src/components/AppShell.jsx
+++ b/src/components/AppShell.jsx
@@ -34,6 +34,7 @@ function NotificationDropdown() {
   const [unread, setUnread] = useState(0);
   const [loading, setLoading] = useState(false);
   const ref = useRef(null);
+  const seenIdsRef = useRef(new Set()); // notif ids already surfaced — opening the panel marks all seen
 
   useEffect(() => {
     function handleClickOutside(e) {
@@ -43,13 +44,22 @@ function NotificationDropdown() {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [open]);
 
-  const fetchNotifications = useCallback(async () => {
+  // markSeen=true (panel opened) clears the badge and remembers every current
+  // notification, so the count stays hidden until genuinely NEW ones arrive —
+  // even if the user never marks them read.
+  const fetchNotifications = useCallback(async (markSeen = false) => {
     try {
       const res = await fetch('/api/notifications?limit=20');
       if (res.ok) {
         const data = await res.json();
-        setNotifications(data.notifications || []);
-        setUnread(data.unread || 0);
+        const list = data.notifications || [];
+        setNotifications(list);
+        if (markSeen) {
+          list.forEach(n => seenIdsRef.current.add(n.id));
+          setUnread(0);
+        } else {
+          setUnread(list.filter(n => !n.read && !seenIdsRef.current.has(n.id)).length);
+        }
       }
     } catch {}
   }, []);
@@ -57,13 +67,13 @@ function NotificationDropdown() {
   // Poll every 30s for new notifications
   useEffect(() => {
     fetchNotifications();
-    const interval = setInterval(fetchNotifications, 30000);
+    const interval = setInterval(() => fetchNotifications(), 30000);
     return () => clearInterval(interval);
   }, [fetchNotifications]);
 
-  // Fetch fresh data when opening
+  // Opening the panel clears the badge immediately, then fetches + marks seen.
   useEffect(() => {
-    if (open) fetchNotifications();
+    if (open) { setUnread(0); fetchNotifications(true); }
   }, [open, fetchNotifications]);
 
   const markAllRead = async () => {

--- a/src/components/Editor/BlogEditor.jsx
+++ b/src/components/Editor/BlogEditor.jsx
@@ -682,6 +682,7 @@ const BlogEditor = forwardRef(function BlogEditor({ onChange, initialContent, on
   const [mentionQuery, setMentionQuery] = useState('');
   const [mentionPos, setMentionPos] = useState({ top: 0, left: 0 });
   const mentionStartRef = useRef(null);
+  const mentionDismissedRef = useRef(null); // @-position the user ESC-dismissed, so we don't reopen it
   const [showAIMenu, setShowAIMenu] = useState(false);
   const [aiMenuPos, setAiMenuPos] = useState({ top: 0, left: 0, anchorBlockId: null });
   const [aiGenerating, setAiGenerating] = useState(false);
@@ -1850,10 +1851,15 @@ const BlogEditor = forwardRef(function BlogEditor({ onChange, initialContent, on
 
         const textUpToCursor = anchorNode.textContent.slice(0, domSel.anchorOffset);
         const atIdx = textUpToCursor.lastIndexOf('@');
-        if (atIdx === -1) { setShowMentionMenu(false); return; }
+        if (atIdx === -1) { setShowMentionMenu(false); mentionDismissedRef.current = null; return; }
 
         const afterAt = textUpToCursor.slice(atIdx + 1);
         if (afterAt.includes(' ') || afterAt.length > 30) { setShowMentionMenu(false); return; }
+
+        // The user pressed ESC on this @token — keep it closed until they move to
+        // a different @ (so typing more text doesn't pop the menu back open).
+        if (mentionDismissedRef.current === atIdx) { setShowMentionMenu(false); return; }
+        mentionDismissedRef.current = null;
 
         const range = domSel.getRangeAt(0);
         const rect = range.getBoundingClientRect();
@@ -1882,6 +1888,15 @@ const BlogEditor = forwardRef(function BlogEditor({ onChange, initialContent, on
     setShowMentionMenu(false);
     setMentionQuery('');
     mentionStartRef.current = null;
+    mentionDismissedRef.current = null;
+  }, []);
+
+  // ESC: dismiss the menu but keep the typed @text, and remember this @-position
+  // so it doesn't pop back open as the user keeps typing.
+  const handleMentionDismiss = useCallback(() => {
+    mentionDismissedRef.current = mentionStartRef.current;
+    setShowMentionMenu(false);
+    setMentionQuery('');
   }, []);
 
   const handleAIStop = useCallback(() => {
@@ -2688,6 +2703,7 @@ const BlogEditor = forwardRef(function BlogEditor({ onChange, initialContent, on
             editor={editor}
             query={mentionQuery}
             onClose={handleMentionClose}
+            onDismiss={handleMentionDismiss}
           />
         </div>
       )}

--- a/src/components/Editor/BlogPreview.jsx
+++ b/src/components/Editor/BlogPreview.jsx
@@ -742,7 +742,13 @@ export default function BlogPreview({ title, subtitle, coverPreview, coverZoom, 
       {user && (() => {
         const authors = [
           { name: user.display_name || user.username || 'Author', avatar_url: user.avatar_url, username: user.username },
-          ...coAuthors,
+          // Co-authors come from /api/resolve with display_name/username — normalize
+          // to `name` so their names actually render (not just the primary author).
+          ...coAuthors.map((c) => ({
+            name: c.name || c.display_name || c.username || 'Author',
+            avatar_url: c.avatar_url,
+            username: c.username,
+          })),
         ];
         const shownAvatars = authors.slice(0, 3);
         const moreAuthors = authors.length - shownAvatars.length;

--- a/src/components/Editor/LinkPreviewTooltip.jsx
+++ b/src/components/Editor/LinkPreviewTooltip.jsx
@@ -90,6 +90,32 @@ export default function LinkPreviewTooltip({ anchorEl, url, onClose }) {
     return () => clearTimeout(hideTimerRef.current);
   }, []);
 
+  // Safety net: dismiss on Escape, and hide if the pointer wanders away from
+  // both the link and the tooltip — covers cases where the anchor's mouseleave
+  // never fires (e.g. the link is re-rendered out from under the cursor), which
+  // is what left the preview stuck on screen.
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') onClose(); };
+    const within = (el, e, pad = 28) => {
+      if (!el) return false;
+      const r = el.getBoundingClientRect();
+      return e.clientX >= r.left - pad && e.clientX <= r.right + pad
+        && e.clientY >= r.top - pad && e.clientY <= r.bottom + pad;
+    };
+    const onMove = (e) => {
+      if (!within(anchorEl, e) && !within(tooltipRef.current, e)) {
+        hoverRef.current = false;
+        scheduleHide();
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('pointermove', onMove, { passive: true });
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('pointermove', onMove);
+    };
+  }, [anchorEl, onClose, scheduleHide]);
+
   if (!url || !posRef.current) return null;
 
   const style = posRef.current.useBottom

--- a/src/components/Editor/MentionMenu.jsx
+++ b/src/components/Editor/MentionMenu.jsx
@@ -6,7 +6,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
  * Custom @ mention suggestion menu.
  * Searches users, orgs, and blogs and renders grouped results.
  */
-export default function MentionMenu({ editor, query, onClose }) {
+export default function MentionMenu({ editor, query, onClose, onDismiss }) {
   const [results, setResults] = useState({ users: [], orgs: [], blogs: [] });
   const [activeIndex, setActiveIndex] = useState(0);
   const [loading, setLoading] = useState(false);
@@ -137,26 +137,33 @@ export default function MentionMenu({ editor, query, onClose }) {
   // Keyboard navigation
   useEffect(() => {
     function handleKeyDown(e) {
+      // Escape must work even with no results — the user wants plain text, not a tag.
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
+        (onDismiss || onClose)?.();
+        return;
+      }
       if (allItems.length === 0) return;
 
+      // stopPropagation (capture phase) is essential: otherwise the keydown also
+      // reaches ProseMirror, so Enter splits the block and the mention chip ends
+      // up on a new line / overwrites the line below.
       if (e.key === 'ArrowDown') {
-        e.preventDefault();
+        e.preventDefault(); e.stopPropagation();
         setActiveIndex((i) => (i + 1) % allItems.length);
       } else if (e.key === 'ArrowUp') {
-        e.preventDefault();
+        e.preventDefault(); e.stopPropagation();
         setActiveIndex((i) => (i - 1 + allItems.length) % allItems.length);
       } else if (e.key === 'Enter' || e.key === 'Tab') {
-        e.preventDefault();
+        e.preventDefault(); e.stopPropagation();
         if (allItems[activeIndex]) insertMention(allItems[activeIndex]);
-      } else if (e.key === 'Escape') {
-        e.preventDefault();
-        onClose?.();
       }
     }
 
     document.addEventListener('keydown', handleKeyDown, true);
     return () => document.removeEventListener('keydown', handleKeyDown, true);
-  }, [allItems, activeIndex, insertMention, onClose]);
+  }, [allItems, activeIndex, insertMention, onClose, onDismiss]);
 
   // Scroll active item into view
   useEffect(() => {

--- a/src/styles/editor/menus.css
+++ b/src/styles/editor/menus.css
@@ -419,7 +419,8 @@
 .link-editor-popup {
   position: fixed;
   z-index: 99;
-  width: 320px;
+  width: min(520px, 92vw);
+  max-width: 92vw;
   background: var(--bg-surface);
   border: 1px solid var(--border-default);
   border-radius: 12px;

--- a/src/views/WritePage.jsx
+++ b/src/views/WritePage.jsx
@@ -2408,20 +2408,20 @@ export default function WritePage({ slugid }) {
         <div className="p-5 space-y-2" style={{ borderTop: '1px solid var(--border-default)' }}>
           <button
             onClick={() => { if (isPublished) setShowPublishConfirm(true); else handlePublish(); }}
-            disabled={!title.trim() || publishing || !hasUnsavedEdits}
+            disabled={!title.trim() || publishing || hasNoChanges()}
             className="w-full py-2.5 bg-[#9b7bf7] text-white font-bold rounded-xl text-[13px] hover:bg-[#b69aff] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
           >
             {publishing ? (isPublished ? 'Updating...' : 'Publishing...') : (isPublished ? 'Update now' : 'Publish now')}
           </button>
           <button
             onClick={handleSaveDraft}
-            disabled={publishing || !hasUnsavedEdits}
+            disabled={publishing || hasNoChanges()}
             className="w-full py-2 font-medium rounded-xl text-[12px] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
             style={{ backgroundColor: 'var(--bg-elevated)', color: 'var(--text-muted)' }}
           >
             Save Draft
           </button>
-          {!hasUnsavedEdits && (
+          {hasNoChanges() && (
             <p className="text-center text-[11px]" style={{ color: 'var(--text-faint)' }}>No changes to save</p>
           )}
         </div>

--- a/src/views/WritePage.jsx
+++ b/src/views/WritePage.jsx
@@ -460,6 +460,7 @@ export default function WritePage({ slugid }) {
   const [slugManual, setSlugManual] = useState(false); // user typed a custom slug → stop auto-deriving from title
   const [slugAvail, setSlugAvail] = useState({ state: 'idle' }); // idle | checking | available | taken
   const [isOwner, setIsOwner] = useState(true); // owner (author / org admin) — only owners may change a published slug
+  const [ownerInfo, setOwnerInfo] = useState(null); // real author {username, display_name, avatar_url} — shown to collaborators
   const [publishing, setPublishing] = useState(false);
   const [showOwnerDropdown, setShowOwnerDropdown] = useState(false);
   const [inviteUsername, setInviteUsername] = useState('');
@@ -778,6 +779,7 @@ export default function WritePage({ slugid }) {
         if (cloud.title) setTitle(cloud.title);
         if (cloud.slug) { setSlug(cloud.slug); setSlugManual(true); }
         setIsOwner(cloud.is_owner !== false);
+        if (cloud.owner_username) setOwnerInfo({ username: cloud.owner_username, display_name: cloud.owner_display_name, avatar_url: cloud.owner_avatar });
         if (cloud.subtitle) setSubtitle(cloud.subtitle);
         if (cloud.tags?.length) setTags(cloud.tags);
         if (cloud.published_as) setPublishAs(cloud.published_as);
@@ -1185,7 +1187,16 @@ export default function WritePage({ slugid }) {
     if (!draftLoading && settingsSnapshotRef.current === '') settingsSnapshotRef.current = settingsKey();
   }, [draftLoading]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const ownerSlug = publishAs === 'personal' ? username : (userOrgs.find(o => `org:${o.id}` === publishAs)?.slug || username);
+  const ownerSlug = publishAs === 'personal' ? (ownerInfo?.username || username) : (userOrgs.find(o => `org:${o.id}` === publishAs)?.slug || username);
+  // Owner shown in publish settings = the REAL author (not the current collaborator) for personal blogs, or the org for org blogs.
+  const ownerOrg = publishAs !== 'personal' ? userOrgs.find(o => `org:${o.id}` === publishAs) : null;
+  const ownerName = publishAs === 'personal'
+    ? (ownerInfo?.display_name || ownerInfo?.username || username)
+    : (ownerOrg?.name || publishAs.replace('org:', ''));
+  const ownerAvatar = publishAs === 'personal'
+    ? (ownerInfo?.avatar_url || (isOwner ? user?.avatar_url : ''))
+    : (ownerOrg?.logo_url || '');
+  const ownerInitial = (ownerName || '?').charAt(0).toUpperCase();
   const publishedUrl = `/${ownerSlug}/${slug || blogId}`;
   // Nothing edited (content or settings) since load / last publish.
   const hasNoChanges = () => !hasUnsavedEdits && settingsSnapshotRef.current === settingsKey();
@@ -2199,16 +2210,14 @@ export default function WritePage({ slugid }) {
             {isPublished ? (
               /* Locked — show current owner, no dropdown */
               <div className="flex items-center gap-2.5 rounded-lg px-3 py-2.5 text-[13px]" style={{ backgroundColor: 'var(--bg-app)', border: '1px solid var(--border-default)', opacity: 0.7 }}>
-                {user?.avatar_url ? (
-                  <img src={user.avatar_url} alt="" className="w-5 h-5 rounded-full object-cover" />
+                {ownerAvatar ? (
+                  <img src={ownerAvatar} alt="" className="w-5 h-5 rounded-full object-cover" />
                 ) : (
                   <div className="w-5 h-5 rounded-full flex items-center justify-center text-[10px] font-bold" style={{ backgroundColor: 'var(--bg-elevated)', color: 'var(--text-body)' }}>
-                    {(user?.display_name || username || '?')[0].toUpperCase()}
+                    {ownerInitial}
                   </div>
                 )}
-                <span className="font-medium" style={{ color: 'var(--text-primary)' }}>
-                  {publishAs === 'personal' ? username : (userOrgs.find(o => `org:${o.id}` === publishAs)?.name || publishAs.replace('org:', ''))}
-                </span>
+                <span className="font-medium" style={{ color: 'var(--text-primary)' }}>{ownerName}</span>
                 <ion-icon name="lock-closed" style={{ fontSize: '12px', color: 'var(--text-faint)', marginLeft: 'auto' }} />
               </div>
             ) : (
@@ -2219,16 +2228,14 @@ export default function WritePage({ slugid }) {
                   className="w-full flex items-center gap-2.5 rounded-lg px-3 py-2.5 text-[13px] transition-colors"
                   style={{ backgroundColor: 'var(--bg-app)', border: '1px solid var(--border-default)' }}
                 >
-                  {user?.avatar_url ? (
-                    <img src={user.avatar_url} alt="" className="w-5 h-5 rounded-full object-cover" />
+                  {ownerAvatar ? (
+                    <img src={ownerAvatar} alt="" className="w-5 h-5 rounded-full object-cover" />
                   ) : (
                     <div className="w-5 h-5 rounded-full flex items-center justify-center text-[10px] font-bold" style={{ backgroundColor: 'var(--bg-elevated)', color: 'var(--text-body)' }}>
-                      {(user?.display_name || username || '?')[0].toUpperCase()}
+                      {ownerInitial}
                     </div>
                   )}
-                  <span className="font-medium flex-1 text-left" style={{ color: 'var(--text-primary)' }}>
-                    {publishAs === 'personal' ? username : (userOrgs.find(o => `org:${o.id}` === publishAs)?.name || publishAs.replace('org:', ''))}
-                  </span>
+                  <span className="font-medium flex-1 text-left" style={{ color: 'var(--text-primary)' }}>{ownerName}</span>
                   <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" style={{ color: 'var(--text-faint)' }}>
                     <polyline points="6 9 12 15 18 9" />
                   </svg>
@@ -2309,7 +2316,7 @@ export default function WritePage({ slugid }) {
             </label>
             <div className="flex items-center gap-1 rounded-lg px-3 py-2.5 text-[13px]" style={{ backgroundColor: 'var(--bg-app)', border: '1px solid var(--border-default)', opacity: slugLocked ? 0.7 : 1 }}>
               <span className="shrink-0" style={{ color: 'var(--text-faint)' }}>
-                /{publishAs === 'personal' ? username : (userOrgs.find(o => `org:${o.id}` === publishAs)?.slug || '')}/
+                /{ownerSlug}/
               </span>
               <input
                 type="text"


### PR DESCRIPTION
## Changes Made

- `app/api/blogs/draft/route.js` — Added `owner_username`, `owner_display_name`, and `owner_avatar` to the draft GET response so collaborators see the actual blog owner in publish settings, not themselves.
- `src/components/AppShell.jsx` — Fixed notification badge: opening the dropdown now marks current notifications as "seen" via a ref-tracked ID set, so the badge stays hidden until genuinely new notifications arrive instead of reappearing on every 30s poll.
- `src/components/Editor/BlogEditor.jsx` — Added `mentionDismissedRef` so pressing ESC on the @-mention menu remembers the dismissed @-position, preventing the menu from reopening as the user keeps typing at that same @.
- `src/components/Editor/MentionMenu.jsx` — Added `onDismiss` prop for ESC handling (keeps typed @text intact); added `stopPropagation` on Arrow/Enter/Tab keys to stop ProseMirror from also processing them, which caused mention chips to land on a new line.
- `src/components/Editor/BlogPreview.jsx` — Normalized co-author objects to include a `name` field (from `display_name`/`username`), so co-author names actually render in the preview instead of appearing blank.
- `src/components/Editor/LinkPreviewTooltip.jsx` — Added Escape-key dismiss and `pointermove` tracking that hides the tooltip when the cursor leaves both the anchor and tooltip area, fixing stuck tooltips when anchor elements are re-rendered out from under the cursor.
- `src/styles/editor/menus.css` — Widened `.link-editor-popup` from 320px to `min(520px, 92vw)` for better link-form usability on wider screens.
- `src/views/WritePage.jsx` — Publish settings panel now displays the real blog owner's name/avatar/slug (from `ownerInfo` returned by the draft API) instead of the current collaborator's info; uses computed `ownerSlug`, `ownerName`, `ownerAvatar`, `ownerInitial` throughout.

## Checklist
- [ ] No Node built-ins imported (crypto, fs, path, stream, Buffer)
- [ ] `./biome.sh ci` clean
- [ ] Tested locally: <how>