### PR TITLE
[PATCH]: Fix the co author visibility for the blogs

### DIFF
--- a/app/api/blogs/invite/route.js
+++ b/app/api/blogs/invite/route.js
@@ -41,7 +41,7 @@ export async function GET(request) {
     `).bind(slugid).first();
 
     const collabs = await db.prepare(`
-      SELECT u.id, u.username, u.display_name, u.avatar_url, bc.role, bc.status, bc.added_at
+      SELECT u.id, u.username, u.display_name, u.avatar_url, bc.role, bc.status, bc.added_at, bc.show_on_profile
       FROM blog_co_authors bc JOIN users u ON u.id = bc.user_id
       WHERE bc.blog_id = ? ORDER BY bc.added_at
     `).bind(slugid).all();

--- a/app/api/blogs/invite/route.js
+++ b/app/api/blogs/invite/route.js
@@ -126,25 +126,37 @@ export async function PUT(request) {
   const session = await getSession();
   if (!session?.userId) return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
 
-  const { slugid, userId, role, accept } = await request.json();
+  const { slugid, userId, role, accept, showOnProfile } = await request.json();
   if (!slugid) return NextResponse.json({ error: 'Missing slugid' }, { status: 400 });
 
   try {
     const { getDB } = await import('../../../../lib/cloudflare');
     const db = getDB();
 
-    // Accept invite — the invitee accepts their own invite
+    // Accept invite — the invitee accepts their own invite, choosing whether the
+    // post cross-posts to their profile.
     if (accept) {
       const existing = await db.prepare(
         'SELECT status FROM blog_co_authors WHERE blog_id = ? AND user_id = ?'
       ).bind(slugid, session.userId).first();
       if (!existing) return NextResponse.json({ error: 'No invite found' }, { status: 404 });
 
+      const sop = showOnProfile === false ? 0 : 1;
       await db.prepare(
-        "UPDATE blog_co_authors SET status = 'accepted' WHERE blog_id = ? AND user_id = ?"
-      ).bind(slugid, session.userId).run();
+        "UPDATE blog_co_authors SET status = 'accepted', show_on_profile = ? WHERE blog_id = ? AND user_id = ?"
+      ).bind(sop, slugid, session.userId).run();
 
-      return NextResponse.json({ ok: true, status: 'accepted' });
+      return NextResponse.json({ ok: true, status: 'accepted', show_on_profile: sop });
+    }
+
+    // Self visibility toggle — a co-author changes whether THIS post shows on their profile.
+    if (showOnProfile !== undefined && !role) {
+      const mine = await db.prepare('SELECT 1 FROM blog_co_authors WHERE blog_id = ? AND user_id = ?')
+        .bind(slugid, session.userId).first();
+      if (!mine) return NextResponse.json({ error: 'Not a co-author' }, { status: 403 });
+      await db.prepare('UPDATE blog_co_authors SET show_on_profile = ? WHERE blog_id = ? AND user_id = ?')
+        .bind(showOnProfile ? 1 : 0, slugid, session.userId).run();
+      return NextResponse.json({ ok: true, show_on_profile: showOnProfile ? 1 : 0 });
     }
 
     // Change role — requires manage permission

--- a/app/api/blogs/list/route.js
+++ b/app/api/blogs/list/route.js
@@ -43,6 +43,24 @@ export async function GET(request) {
       return NextResponse.json({ blogs: rows?.results || [] });
     }
 
+    // Co-authored = published blogs where THIS user is an accepted co-author
+    // (authored by someone else). Shown on the user's own profile/stories tabs.
+    if (filter === 'coauthored') {
+      const rows = await db.prepare(`
+        SELECT b.id, b.id as slugid, b.slug, b.title, b.subtitle, b.status,
+          b.page_emoji, b.cover_image_r2_key, b.read_time_minutes,
+          b.published_as, b.created_at, b.updated_at, b.published_at,
+          u.username as author_username, u.display_name as author_name, u.avatar_url as author_avatar,
+          bc.role as co_author_role, bc.show_on_profile, ${COUNTS}
+        FROM blog_co_authors bc
+        JOIN blogs b ON b.id = bc.blog_id AND b.status IN ('published', 'unlisted')
+        JOIN users u ON u.id = b.author_id
+        WHERE bc.user_id = ? AND bc.status = 'accepted' AND b.author_id != ?
+        ORDER BY b.published_at DESC LIMIT 50
+      `).bind(session.userId, session.userId).all();
+      return NextResponse.json({ blogs: rows?.results || [] });
+    }
+
     let query = `
       SELECT b.id, b.id as slugid, b.slug, b.title, b.subtitle, b.status,
         b.page_emoji, b.cover_image_r2_key, b.read_time_minutes,

--- a/app/api/resolve/route.js
+++ b/app/api/resolve/route.js
@@ -126,7 +126,7 @@ export async function GET(request) {
         FROM blogs b
         JOIN users au ON au.id = b.author_id
         WHERE (b.author_id = ? OR b.id IN (
-                 SELECT blog_id FROM blog_co_authors WHERE user_id = ? AND status = 'accepted'
+                 SELECT blog_id FROM blog_co_authors WHERE user_id = ? AND status = 'accepted' AND show_on_profile = 1
                ))
           AND b.status IN ('published', 'unlisted')
         ORDER BY b.published_at DESC LIMIT 20

--- a/migrations/0034_coauthor_visibility.sql
+++ b/migrations/0034_coauthor_visibility.sql
@@ -1,0 +1,3 @@
+-- Co-authors choose whether an accepted co-authored post shows on their profile
+-- (cross-post). Default 1 = visible, matching prior behavior.
+ALTER TABLE blog_co_authors ADD COLUMN show_on_profile INTEGER NOT NULL DEFAULT 1;

--- a/src/components/BlogDotsMenu.jsx
+++ b/src/components/BlogDotsMenu.jsx
@@ -8,6 +8,7 @@ export default function BlogDotsMenu({ blogId, authorId, author = {}, org = null
   const [fAuthor, setFAuthor] = useState(false);
   const [fOrg, setFOrg] = useState(false);
   const [done, setDone] = useState('');
+  const [coAuthorVisible, setCoAuthorVisible] = useState(null); // null = not a co-author; true/false = show_on_profile
   const ref = useRef(null);
 
   useEffect(() => {
@@ -29,7 +30,28 @@ export default function BlogDotsMenu({ blogId, authorId, author = {}, org = null
     if (!open || !user) return;
     if (author?.username) fetch(`/api/users/${author.username}/follow`).then(r => r.ok ? r.json() : null).then(d => d && setFAuthor(!!d.following)).catch(() => {});
     if (org?.slug) fetch(`/api/orgs/${org.slug}/follow`).then(r => r.ok ? r.json() : null).then(d => d && setFOrg(!!d.following)).catch(() => {});
-  }, [open, user]);
+    // Am I an accepted co-author here (not the primary author)? If so, surface
+    // a "show on my profile" toggle.
+    if (blogId && user.id !== authorId) {
+      fetch(`/api/blogs/invite?slugid=${encodeURIComponent(blogId)}`)
+        .then(r => r.ok ? r.json() : null)
+        .then(d => {
+          const mine = (d?.collaborators || []).find(c => c.id === user.id && c.status === 'accepted');
+          setCoAuthorVisible(mine ? mine.show_on_profile !== 0 : null);
+        }).catch(() => {});
+    }
+  }, [open, user, blogId, authorId]);
+
+  const toggleProfileVisibility = () => {
+    if (needAuth() || coAuthorVisible === null) return;
+    const next = !coAuthorVisible;
+    setCoAuthorVisible(next);
+    fetch('/api/blogs/invite', {
+      method: 'PUT', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ slugid: blogId, showOnProfile: next }),
+    }).catch(() => {});
+    flash(next ? 'Showing on your profile' : 'Hidden from your profile');
+  };
 
   const needAuth = () => { if (!user) { window.location.href = `/sign-in?next=${typeof window !== 'undefined' ? window.location.pathname : '/'}`; return true; } return false; };
   const post_ = (url, body) => fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }).catch(() => {});
@@ -73,6 +95,13 @@ export default function BlogDotsMenu({ blogId, authorId, author = {}, org = null
             <>
               <Row icon="thumbs-down-outline" label="Show less like this" onClick={showLess} />
               <Row icon={hideHighlights ? 'eye-outline' : 'color-wand-outline'} label={hideHighlights ? 'Show highlights' : 'Hide highlights'} onClick={toggleHi} kbd="Ctrl /" />
+              {coAuthorVisible !== null && (
+                <Row
+                  icon={coAuthorVisible ? 'eye-off-outline' : 'person-outline'}
+                  label={coAuthorVisible ? 'Hide from my profile' : 'Show on my profile'}
+                  onClick={toggleProfileVisibility}
+                />
+              )}
               <Divider />
               <Row label={fAuthor ? `Following ${author.display_name || author.username}` : `Follow ${author.display_name || author.username}`} onClick={followAuthor} disabled={fAuthor} />
               {org && <Row label={fOrg ? `Following ${org.name}` : `Follow ${org.name}`} onClick={followOrg} disabled={fOrg} />}

--- a/src/components/BlogInviteOverlay.jsx
+++ b/src/components/BlogInviteOverlay.jsx
@@ -10,6 +10,7 @@ export default function BlogInviteOverlay() {
   const { user } = useAuth();
   const [invite, setInvite] = useState(null);  // { blogId, slug, title, role, status }
   const [busy, setBusy] = useState(false);
+  const [showOnProfile, setShowOnProfile] = useState(true);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -43,7 +44,7 @@ export default function BlogInviteOverlay() {
     try {
       const res = await fetch('/api/blogs/invite', {
         method: 'PUT', headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ slugid: invite.blogId, accept: true }),
+        body: JSON.stringify({ slugid: invite.blogId, accept: true, showOnProfile }),
       });
       if (!res.ok) throw new Error();
       // Editors/admins go to the editor; viewers just read (now cross-posted).
@@ -85,7 +86,16 @@ export default function BlogInviteOverlay() {
             <h1 className="text-xl font-bold mb-2 text-[var(--text-primary)]">Collaboration invite</h1>
             <p className="text-[var(--text-muted)] text-[14px] mb-1">You've been invited to collaborate on</p>
             <p className="text-[var(--text-primary)] font-semibold text-[15px] mb-3">“{invite.title || 'Untitled blog'}”</p>
-            <p className="text-[var(--text-faint)] text-[13px] mb-6">Role: <span className="text-[#9b7bf7] font-medium">{roleLabel}</span></p>
+            <p className="text-[var(--text-faint)] text-[13px] mb-4">Role: <span className="text-[#9b7bf7] font-medium">{roleLabel}</span></p>
+            <label className="flex items-center gap-2.5 justify-center mb-6 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={showOnProfile}
+                onChange={(e) => setShowOnProfile(e.target.checked)}
+                className="w-4 h-4 accent-[#9b7bf7] cursor-pointer"
+              />
+              <span className="text-[13px] text-[var(--text-body)]">Show this post on my profile</span>
+            </label>
             <div className="flex items-center gap-3 justify-center">
               <button onClick={decline} disabled={busy}
                 className="px-5 py-2 rounded-full text-[13px] font-medium border border-[var(--border-default)] text-[var(--text-body)] hover:border-[var(--border-hover)] transition-colors disabled:opacity-50">

--- a/src/views/ProfilePage.jsx
+++ b/src/views/ProfilePage.jsx
@@ -419,10 +419,12 @@ export default function ProfilePage() {
                 </div>
               ) : (
                 <div className="text-center py-16">
-                  <p className="text-[var(--text-muted)] text-sm">{activeTab === 0 ? 'No published blogs yet.' : 'No drafts yet.'}</p>
-                  <Link href="/new-blog" className="inline-block mt-4 px-5 py-2 text-[13px] font-medium text-[var(--text-primary)] bg-[#9b7bf7] hover:bg-[#b69aff] rounded-full transition-colors">
-                    Write your first blog
-                  </Link>
+                  <p className="text-[var(--text-muted)] text-sm">{activeTab === 0 ? 'No published blogs yet.' : activeTab === 2 ? "You haven't co-authored any posts yet." : 'No drafts yet.'}</p>
+                  {activeTab !== 2 && (
+                    <Link href="/new-blog" className="inline-block mt-4 px-5 py-2 text-[13px] font-medium text-[var(--text-primary)] bg-[#9b7bf7] hover:bg-[#b69aff] rounded-full transition-colors">
+                      Write your first blog
+                    </Link>
+                  )}
                 </div>
               )}
             </>

--- a/src/views/ProfilePage.jsx
+++ b/src/views/ProfilePage.jsx
@@ -393,7 +393,9 @@ export default function ProfilePage() {
               ) : list.length > 0 ? (
                 <div>
                   {list.map((b) => {
-                    const href = activeTab === 0 ? `/${user.username}/${b.slug}` : `/edit/${b.slug || b.id}`;
+                    const href = activeTab === 0 ? `/${user.username}/${b.slug}`
+                      : activeTab === 2 ? `/${b.author_username}/${b.slug}`
+                      : `/edit/${b.slug || b.id}`;
                     return (
                       <article key={b.id} className="flex gap-4 py-5 border-b border-[var(--border-default)] last:border-b-0">
                         <div className="flex-1 min-w-0">

--- a/src/views/ProfilePage.jsx
+++ b/src/views/ProfilePage.jsx
@@ -40,6 +40,7 @@ export default function ProfilePage() {
   const [usageLoading, setUsageLoading] = useState(true);
   const [activeTab, setActiveTab] = useState(0);
   const [blogs, setBlogs] = useState([]);
+  const [coAuthored, setCoAuthored] = useState([]);
   const [blogsLoading, setBlogsLoading] = useState(true);
   const [counts, setCounts] = useState({ followers: 0, following: 0 });
   const [followModal, setFollowModal] = useState(null); // 'followers' | 'following'
@@ -71,6 +72,10 @@ export default function ProfilePage() {
       .then(d => setBlogs(d.blogs || []))
       .catch(() => {})
       .finally(() => setBlogsLoading(false));
+    fetch('/api/blogs/list?filter=coauthored')
+      .then(r => r.ok ? r.json() : { blogs: [] })
+      .then(d => setCoAuthored(d.blogs || []))
+      .catch(() => {});
   }, [user]);
 
   if (loading) {
@@ -367,7 +372,7 @@ export default function ProfilePage() {
         {(() => {
           const published = blogs.filter(b => b.status === 'published' || b.status === 'unlisted');
           const drafts = blogs.filter(b => b.status === 'draft');
-          const list = activeTab === 0 ? published : drafts;
+          const list = activeTab === 0 ? published : activeTab === 1 ? drafts : coAuthored;
           const fmt = (ts) => ts ? new Date(ts * 1000).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }) : '';
           return (
             <>
@@ -375,6 +380,7 @@ export default function ProfilePage() {
                 tabs={[
                   { label: 'Published', icon: 'globe-outline', count: published.length },
                   { label: 'Drafts', icon: 'document-outline', count: drafts.length },
+                  { label: 'Co-authored', icon: 'people-outline', count: coAuthored.length },
                 ]}
                 active={activeTab}
                 onChange={setActiveTab}

--- a/src/views/StoriesPage.jsx
+++ b/src/views/StoriesPage.jsx
@@ -10,6 +10,7 @@ const TABS = [
   { label: 'Drafts', icon: 'document-outline' },
   { label: 'Published', icon: 'globe-outline' },
   { label: 'Reshared', icon: 'repeat-outline' },
+  { label: 'Co-authored', icon: 'people-outline' },
 ];
 
 const SORTS = [
@@ -112,7 +113,8 @@ export default function StoriesPage() {
     setBlogsLoading(true);
     const url = activeTab === 0 ? '/api/blogs/list?status=draft'
       : activeTab === 1 ? `/api/blogs/list?status=published${sort ? `&sort=${sort}` : ''}`
-      : '/api/blogs/list?filter=reshared';
+      : activeTab === 2 ? '/api/blogs/list?filter=reshared'
+      : '/api/blogs/list?filter=coauthored';
     fetch(url)
       .then(r => r.ok ? r.json() : { blogs: [] })
       .then(d => setStories(d.blogs || []))
@@ -198,7 +200,7 @@ export default function StoriesPage() {
         ) : stories.length > 0 ? (
           <div>
             {stories.map((story) => (
-              <StoryCard key={story.id} story={story} onDelete={setConfirmTarget} reshared={activeTab === 2} />
+              <StoryCard key={story.id} story={story} onDelete={setConfirmTarget} reshared={activeTab === 2 || activeTab === 3} />
             ))}
           </div>
         ) : (
@@ -211,14 +213,15 @@ export default function StoriesPage() {
               )}
             </svg>
             <p className="text-[var(--text-muted)] text-[15px] font-medium mb-1.5">
-              {activeTab === 0 ? 'No drafts yet' : activeTab === 1 ? 'No published stories yet' : 'No reshared posts yet'}
+              {activeTab === 0 ? 'No drafts yet' : activeTab === 1 ? 'No published stories yet' : activeTab === 2 ? 'No reshared posts yet' : 'No co-authored posts yet'}
             </p>
             <p className="text-[var(--text-muted)] text-[13px] mb-6">
               {activeTab === 0 ? 'Start writing and your drafts will show up here.'
                 : activeTab === 1 ? 'Once you publish a story, it will appear here.'
-                : 'Posts you repost from others will appear here.'}
+                : activeTab === 2 ? 'Posts you repost from others will appear here.'
+                : 'Posts where you are an accepted co-author will appear here.'}
             </p>
-            {activeTab !== 2 && (
+            {activeTab < 2 && (
               <Link href="/new-blog" className="px-5 py-2 text-[13px] font-medium text-white bg-[#9b7bf7] hover:bg-[#b69aff] rounded-full transition-colors">
                 Write a story
               </Link>


### PR DESCRIPTION
## Changes Made

- `migrations/0034_coauthor_visibility.sql` — Adds `show_on_profile` integer column (default 1) to `blog_co_authors`, letting co-authors control whether a post appears on their profile.
- `app/api/blogs/invite/route.js` — GET now returns `show_on_profile` in collaborator rows. PUT accepts `showOnProfile` on invite acceptance and adds a self-visibility toggle path (no `role`, just `showOnProfile`).
- `app/api/blogs/list/route.js` — New `coauthored` filter returns published blogs where the session user is an accepted co-author (and not the primary author), for profile/stories tabs.
- `app/api/resolve/route.js` — Profile blog resolution now scopes co-authored posts to `show_on_profile = 1`, preventing hidden posts from appearing on public profiles.
- `src/components/BlogDotsMenu.jsx` — Detects if the viewer is an accepted co-author and surfaces a "Hide from my profile" / "Show on my profile" toggle in the dots menu.
- `src/components/BlogInviteOverlay.jsx` — Adds a "Show this post on my profile" checkbox (default checked) to the collaboration invite acceptance dialog, passing `showOnProfile` to the PUT endpoint.

## Checklist

- [ ] `./biome.sh ci` clean
- [ ] New DB columns/tables have a migration in `src/workers/migrations/`
- [ ] Tested locally: <how>