### PR TITLE
[FEAT]: Attached some new elements to the WYSIWYG editor package

### DIFF
--- a/feature-req,md
+++ b/feature-req,md
@@ -1,0 +1,238 @@
+# @elixpo/lixeditor — feature requests (from mail.elixpo)
+
+Spec for changes to implement in the **lixeditor package repo** (dogfooded by
+mail.elixpo). Current consumed version: **2.6.9**. Suggested target: **2.7.0**.
+
+mail.elixpo embeds LixEditor as its email-template WYSIWYG. Two things block us
+today, plus a few that would make the editor a clean embed for any host app.
+The contracts below are what mail.elixpo will code against — please keep the
+prop names / signatures exact so integration is drop-in.
+
+---
+
+## P0 — must have
+
+### 1. `uploadFile` hook (host-controlled media upload)
+
+**Problem.** The ImageBlock currently reads dropped/pasted/selected images with
+`FileReader.readAsDataURL` and stores them as **base64 `data:` URLs** inside the
+document. That's fatal for email: clients (Gmail, Outlook) strip or block inline
+base64, and the document/HTML balloons. The editor must let the host upload the
+file somewhere (we use Cloudinary) and store the returned **hosted URL** instead.
+
+**Contract.** Add an optional prop on `LixEditor`:
+
+```ts
+uploadFile?: (file: File) => Promise<string>;
+// Resolve to a public URL for the stored asset.
+// Reject (throw) to signal failure — the editor should toast and keep the block editable.
+```
+
+**Behavior.**
+- If `uploadFile` is provided, the ImageBlock (and any future media block) calls
+  it for every drop / paste / file-input selection, shows the existing
+  "uploading…" state while the promise is pending, then sets
+  `block.props.url = <resolved url>` and `block.props.name = file.name`.
+- If `uploadFile` is **omitted**, keep today's base64 `readAsDataURL` behavior as
+  the fallback (so the package still works standalone with zero config).
+- On reject: show the existing fail toast, call `onUploadError?.(err, file)` if
+  provided, and leave the block in an editable/empty state (don't insert base64).
+
+**Threading.** Deep block components can't see top-level props directly. Pick one
+(either is fine — we'll adapt):
+- **Preferred:** a React context set by `<LixEditor>` (e.g. `LixUploadContext`)
+  that the ImageBlock reads via a `useUploadFile()` hook, **or**
+- a module-level setter mirroring the existing link-preview pattern:
+  `export function setImageUploader(fn: (file: File) => Promise<string>): void`.
+  (You already ship `setLinkPreviewEndpoint`, so this is consistent — but a prop
+  threaded through context is cleaner and SSR-safe.)
+
+**Nice-to-haves on the same hook:**
+```ts
+acceptImageTypes?: string[];   // default ["image/png","image/jpeg","image/gif","image/webp"]
+maxFileSizeBytes?: number;     // reject + toast over this; default unlimited
+onUploadError?: (err: Error, file: File) => void;
+```
+
+**How mail.elixpo will use it** (so the contract is unambiguous):
+```tsx
+<LixEditor
+  uploadFile={async (file) => {
+    const form = new FormData();
+    form.append("file", file);
+    const res = await fetch("/api/uploads/image", { method: "POST", body: form });
+    if (!res.ok) throw new Error("upload failed");
+    const { url } = await res.json();   // already Cloudinary f_auto,q_auto URL
+    return url;
+  }}
+  features={{ images: true, /* … */ }}
+/>
+```
+
+---
+
+### 2. Button block, insertable from the `/` slash menu
+
+**Problem.** `features.buttons` / `ButtonBlock` exist, but there's no first-class
+way to **insert** a CTA button from the slash menu and edit its label/link/style.
+Email templates need bulletproof CTA buttons.
+
+**Contract.**
+- When `features.buttons` is true, register a slash-menu item **"Button"** (group
+  "Basic" or "Embed", aliases: `button`, `cta`, `link button`). Selecting it
+  inserts a `button` block with default props.
+- Block props (all editable via an inline popover/toolbar on the block):
+  ```ts
+  interface ButtonBlockProps {
+    text: string;          // "Get started"
+    url: string;           // "https://…" — supports {{variables}} (left as-is in HTML)
+    align: "left" | "center" | "right";   // default "left"
+    variant: "solid" | "outline";          // default "solid"
+    color: string;         // hex, default theme accent (e.g. "#7c5cff")
+    radius?: number;       // px, default 8
+  }
+  ```
+- Allow the host to set defaults:
+  ```ts
+  buttonDefaults?: Partial<ButtonBlockProps>;   // prop on <LixEditor>
+  ```
+
+**Email-safe HTML export (important).** `renderBlocksToHTML` / `getHTML()` must
+emit a **table/anchor "bulletproof button"**, not a styled `<div>` — inline
+styles only, no external CSS, Outlook-safe. Target shape:
+```html
+<table role="presentation" cellspacing="0" cellpadding="0" align="left">
+  <tr><td style="border-radius:8px;background:#7c5cff;">
+    <a href="{{url}}" target="_blank"
+       style="display:inline-block;padding:12px 22px;font-family:Arial,Helvetica,sans-serif;
+              font-size:15px;font-weight:700;color:#ffffff;text-decoration:none;border-radius:8px;">
+      Get started
+    </a>
+  </td></tr>
+</table>
+```
+(For `variant:"outline"`: transparent background, `border:2px solid {color}`,
+text color = `{color}`.) Leave `{{variables}}` in `url`/`text` untouched so the
+host's merge step can substitute them.
+
+---
+
+## P1 — high value for our use case
+
+### 3. Merge-variable token `{{variable}}` (inline)
+
+Email templates are built around `{{firstName}}`-style merge fields. Today users
+type raw `{{…}}` text. A first-class inline token would be a big UX win:
+
+- An inline spec rendered as a styled chip (e.g. subtle pill `{{ firstName }}`).
+- A slash item **"Variable"** and/or an autocomplete trigger on typing `{{` that
+  suggests from a host-supplied list:
+  ```ts
+  variableSuggestions?: string[];   // ["firstName","amount","orderId", …]
+  ```
+- **HTML export must round-trip to literal `{{name}}` text** (so our existing
+  `substituteVariables()` keeps working). The chip is purely an editing
+  affordance; `getHTML()` emits `{{name}}`.
+
+If a full inline spec is too much for 2.7.0, even just exposing the `{{` →
+autocomplete over `variableSuggestions` (emitting plain `{{name}}`) is enough.
+
+### 4. `editable` / `readOnly` prop
+
+```ts
+editable?: boolean;   // default true; false → render-only (we want this for previews)
+```
+We currently use `LixPreview` for read-only; a single editor with `editable=false`
+would simplify and guarantee identical rendering.
+
+### 5. Generic file uploads (attachments)
+
+Same `uploadFile` hook, but allow non-image files for a future attachment/file
+block (`acceptTypes`, returns a hosted URL + filename). Not needed for 2.7.0 if
+it complicates things — flag the seam so it's reusable.
+
+---
+
+## P2 — polish / DX
+
+6. **Ship TypeScript types.** The package ships **no `.d.ts`** (v2.6.9), so we
+   hand-maintain ambient declarations in `types/lixeditor.d.ts`. Please publish
+   real types — start from the interface below (it's what we already consume plus
+   the new props). This alone removes a whole class of dogfooding friction.
+
+7. **`linkPreviewEndpoint` as a prop** (in addition to `setLinkPreviewEndpoint`)
+   — consistency with `uploadFile`.
+
+8. **Image block fields for email:** `alt` (accessibility/clients with images
+   off), `width`, `align`, and optional `link` (wrap the `<img>` in an `<a>`).
+   `getHTML()` should already give images `max-width:100%`.
+
+9. **`sanitize` / email-safe export mode** on `getHTML()` — strip scripts, inline
+   everything, no `class`/external CSS dependency. (We post-wrap, but a built-in
+   email mode would be ideal.)
+
+---
+
+## TypeScript surface to publish (target 2.7.0)
+
+```ts
+export interface LixFeatures {
+  equations?: boolean; mermaid?: boolean; codeHighlighting?: boolean;
+  tableOfContents?: boolean; images?: boolean; buttons?: boolean;
+  pdf?: boolean; dates?: boolean; linkPreview?: boolean; markdownLinks?: boolean;
+}
+
+export interface ButtonBlockProps {
+  text: string; url: string;
+  align?: "left" | "center" | "right";
+  variant?: "solid" | "outline";
+  color?: string; radius?: number;
+}
+
+export interface LixEditorProps {
+  initialContent?: LixBlock[] | string | null;
+  onChange?: (editor: any) => void;
+  onReady?: () => void;
+  features?: LixFeatures;
+  placeholder?: string;
+
+  // NEW in 2.7.0
+  uploadFile?: (file: File) => Promise<string>;
+  acceptImageTypes?: string[];
+  maxFileSizeBytes?: number;
+  onUploadError?: (err: Error, file: File) => void;
+  buttonDefaults?: Partial<ButtonBlockProps>;
+  variableSuggestions?: string[];
+  editable?: boolean;
+  linkPreviewEndpoint?: string;
+
+  codeLanguages?: Record<string, any>;
+  extraBlockSpecs?: any[]; extraInlineSpecs?: any[]; slashMenuItems?: any[];
+  collaboration?: any; children?: ReactNode; ref?: Ref<LixEditorHandle>;
+}
+
+// Optional module-level alternative to the prop (mirrors setLinkPreviewEndpoint):
+export function setImageUploader(fn: (file: File) => Promise<string>): void;
+```
+
+---
+
+## Acceptance criteria
+
+- [ ] Dropping/pasting an image with `uploadFile` set stores the **returned URL**,
+      never a `data:` URL; without it, base64 fallback still works.
+- [ ] Upload failure toasts and leaves the block editable (no base64 inserted).
+- [ ] `/` menu shows **Button** when `features.buttons` is on; inserts an editable
+      CTA; `getHTML()` emits a bulletproof table/anchor button with inline styles.
+- [ ] `{{variables}}` survive `getHTML()` as literal text (round-trip safe).
+- [ ] Package ships `.d.ts`; the new props are typed.
+- [ ] No SSR regressions (we import the editor `ssr:false`, but types/exports must
+      resolve on the server).
+
+## After publishing
+1. Bump the package (suggest `2.7.0`) and publish.
+2. Ping back here — mail.elixpo will:
+   - `npm i @elixpo/lixeditor@2.7.0`,
+   - delete the hand-written `types/lixeditor.d.ts` (or trim to gaps),
+   - pass `uploadFile`, `variableSuggestions`, `buttonDefaults`, `editable` from
+     the template composer, and ship the Cloudinary upload route.

--- a/packages/lixeditor/index.d.ts
+++ b/packages/lixeditor/index.d.ts
@@ -1,0 +1,111 @@
+import type { ReactNode, Ref } from 'react';
+
+export interface LixFeatures {
+  equations?: boolean;
+  mermaid?: boolean;
+  codeHighlighting?: boolean;
+  tableOfContents?: boolean;
+  images?: boolean;
+  buttons?: boolean;
+  pdf?: boolean;
+  dates?: boolean;
+  linkPreview?: boolean;
+  markdownLinks?: boolean;
+}
+
+export interface ButtonBlockProps {
+  text: string;
+  url: string;
+  align?: 'left' | 'center' | 'right';
+  variant?: 'solid' | 'outline';
+  color?: string;
+  radius?: number;
+}
+
+export type LixBlock = Record<string, any>;
+
+export interface LixEditorHandle {
+  getDocument(): LixBlock[];
+  getEditor(): any;
+  getBlocks(): LixBlock[];
+  /** Email-safe HTML: bulletproof buttons, inline-styled images, {{vars}} round-trip. */
+  getHTML(): string;
+  /** BlockNote's lossy editor-DOM HTML. */
+  getHTMLLossy(): Promise<string>;
+  getMarkdown(): Promise<string>;
+}
+
+export interface LixEditorProps {
+  initialContent?: LixBlock[] | string | null;
+  onChange?: (editor: any) => void;
+  onReady?: () => void;
+  features?: LixFeatures;
+  placeholder?: string;
+
+  // Added in 2.7.0
+  uploadFile?: (file: File) => Promise<string>;
+  acceptImageTypes?: string[];
+  maxFileSizeBytes?: number;
+  onUploadError?: (err: Error, file: File) => void;
+  buttonDefaults?: Partial<ButtonBlockProps>;
+  variableSuggestions?: string[];
+  editable?: boolean;
+  linkPreviewEndpoint?: string;
+
+  codeLanguages?: Record<string, any>;
+  extraBlockSpecs?: any[];
+  extraInlineSpecs?: any[];
+  slashMenuItems?: any[];
+  collaboration?: any;
+  children?: ReactNode;
+  ref?: Ref<LixEditorHandle>;
+}
+
+export const LixEditor: React.ForwardRefExoticComponent<
+  LixEditorProps & React.RefAttributes<LixEditorHandle>
+>;
+
+export interface LixPreviewProps {
+  blocks?: LixBlock[] | string | null;
+  html?: string;
+  features?: LixFeatures;
+  className?: string;
+}
+export const LixPreview: React.FC<LixPreviewProps>;
+
+export const LixThemeProvider: React.FC<{ children?: ReactNode; theme?: string; defaultTheme?: string }>;
+export function useLixTheme(): {
+  theme: string; setTheme: (t: string) => void; toggleTheme: () => void; isDark: boolean; mounted: boolean;
+};
+
+// Block / inline specs (for custom schemas)
+export const BlockEquation: (config?: any) => any;
+export const InlineEquation: any;
+export const DateInline: any;
+export const VariableInline: any;
+export const MermaidBlock: (config?: any) => any;
+export const TableOfContents: (config?: any) => any;
+export const ButtonBlock: (config?: any) => any;
+export const PDFEmbedBlock: (config?: any) => any;
+export const ImageBlock: (config?: any) => any;
+
+// Utilities
+export function renderBlocksToHTML(blocks: LixBlock[]): string;
+export function buttonBlockToHTML(props: Partial<ButtonBlockProps> & Record<string, any>): string;
+export const LinkPreviewTooltip: React.FC<any>;
+export function useLinkPreview(): any;
+export function setLinkPreviewEndpoint(endpoint: string): void;
+export const KeyboardShortcutsModal: React.FC<any>;
+
+// Host-controlled media upload (module-level alternative to the uploadFile prop)
+export function setImageUploader(fn: (file: File) => Promise<string>): void;
+export const LixUploadContext: React.Context<any>;
+export function useUploadConfig(): {
+  uploadFile: ((file: File) => Promise<string>) | null;
+  acceptImageTypes: string[];
+  maxFileSizeBytes: number;
+  onUploadError: ((err: Error, file: File) => void) | null;
+};
+
+// Merge-variable suggestions (module-level alternative to variableSuggestions prop)
+export function setVariableSuggestions(list: string[]): void;

--- a/packages/lixeditor/package.json
+++ b/packages/lixeditor/package.json
@@ -1,11 +1,13 @@
 {
   "name": "@elixpo/lixeditor",
-  "version": "2.6.9",
-  "description": "A rich WYSIWYG block editor and renderer built on BlockNote — equations, mermaid diagrams, code highlighting, and more.",
+  "version": "2.7.0",
+  "description": "A rich WYSIWYG block editor and renderer built on BlockNote — equations, mermaid diagrams, code highlighting, host-controlled uploads, email-safe button export, and more.",
   "main": "dist/index.js",
   "module": "dist/index.js",
+  "types": "index.d.ts",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
@@ -23,7 +25,8 @@
   ],
   "files": [
     "dist",
-    "src"
+    "src",
+    "index.d.ts"
   ],
   "scripts": {
     "build": "node build.mjs",

--- a/packages/lixeditor/src/blocks/ButtonBlock.jsx
+++ b/packages/lixeditor/src/blocks/ButtonBlock.jsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { createReactBlockSpec } from '@blocknote/react';
-import { useState, useEffect, useRef } from 'react';
+import { useState } from 'react';
 
 const BUTTON_ACTIONS = [
   { value: 'link', label: 'Open Link' },
@@ -11,77 +11,98 @@ const BUTTON_ACTIONS = [
 ];
 
 const BUTTON_VARIANTS = [
-  { value: 'primary', label: 'Primary', cls: 'bg-[#9b7bf7] text-[var(--text-primary)] hover:bg-[#b69aff]' },
-  { value: 'secondary', label: 'Secondary', cls: 'bg-[var(--bg-surface)] border border-[var(--border-default)] text-[var(--text-primary)] hover:border-[var(--border-hover)]' },
-  { value: 'accent', label: 'Accent', cls: 'bg-[#9b7bf7] text-[var(--text-primary)] hover:bg-[#b69aff]' },
+  { value: 'solid', label: 'Solid' },
+  { value: 'outline', label: 'Outline' },
 ];
 
+const ALIGN = ['left', 'center', 'right'];
+
+// 2.7.0 contract: { text, url, align, variant: solid|outline, color, radius }.
+// Legacy fields (label, action, actionValue + variant primary/secondary/accent)
+// are kept in the schema for backward compatibility and read as fallbacks.
 export const ButtonBlock = createReactBlockSpec(
   {
     type: 'buttonBlock',
     propSchema: {
-      label: { default: 'Button' },
+      // email contract
+      text: { default: '' },
+      url: { default: '' },
+      align: { default: 'left' },
+      variant: { default: 'solid' },
+      color: { default: '#7c5cff' },
+      radius: { default: 8 },
+      // legacy / interactive (kept for back-compat)
+      label: { default: '' },
       action: { default: 'link' },
       actionValue: { default: '' },
-      variant: { default: 'primary' },
     },
     content: 'none',
   },
   {
     render: ({ block, editor }) => {
-      const [editing, setEditing] = useState(!block.props.label || block.props.label === 'Button');
-      const [label, setLabel] = useState(block.props.label);
-      const [action, setAction] = useState(block.props.action);
-      const [actionValue, setActionValue] = useState(block.props.actionValue);
-      const [variant, setVariant] = useState(block.props.variant);
+      const p = block.props;
+      const initialText = p.text || p.label || '';
+      const initialUrl = p.url || (p.action === 'link' ? p.actionValue : '') || '';
+      // Normalize a legacy variant (primary/accent → solid, secondary → outline).
+      const initialVariant = p.variant === 'outline' || p.variant === 'secondary' ? 'outline' : 'solid';
+
+      const [editing, setEditing] = useState(!initialText);
+      const [text, setText] = useState(initialText);
+      const [url, setUrl] = useState(initialUrl);
+      const [align, setAlign] = useState(p.align || 'left');
+      const [variant, setVariant] = useState(initialVariant);
+      const [color, setColor] = useState(p.color || '#7c5cff');
+      const [radius, setRadius] = useState(p.radius ?? 8);
 
       const save = () => {
-        editor.updateBlock(block, { props: { label, action, actionValue, variant } });
+        editor.updateBlock(block, {
+          props: {
+            text, url, align, variant, color, radius: Number(radius) || 0,
+            // mirror into legacy fields so older renderers still work
+            label: text, action: 'link', actionValue: url,
+          },
+        });
         setEditing(false);
       };
+
+      const input = 'w-full bg-[var(--bg-app)] border border-[var(--border-default)] rounded-lg px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--border-hover)] placeholder-[#6b7a8d]';
 
       if (editing) {
         return (
           <div className="border border-[var(--border-default)] rounded-xl bg-[var(--bg-surface)] p-4 my-2 space-y-3">
-            <p className="text-[11px] text-[var(--text-muted)] font-medium">Button Block</p>
-            <input
-              type="text"
-              value={label}
-              onChange={(e) => setLabel(e.target.value)}
-              placeholder="Button label"
-              className="w-full bg-[var(--bg-app)] border border-[var(--border-default)] rounded-lg px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--border-hover)] placeholder-[#6b7a8d]"
-            />
-            <div className="flex gap-2">
-              <select value={action} onChange={(e) => setAction(e.target.value)} className="bg-[var(--bg-app)] border border-[var(--border-default)] rounded-lg px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none flex-1">
-                {BUTTON_ACTIONS.map((a) => <option key={a.value} value={a.value}>{a.label}</option>)}
+            <p className="text-[11px] text-[var(--text-muted)] font-medium">Button</p>
+            <input type="text" value={text} onChange={(e) => setText(e.target.value)} placeholder="Button text — e.g. Get started" className={input} />
+            <input type="text" value={url} onChange={(e) => setUrl(e.target.value)} placeholder="https://…  (supports {{variables}})" className={input} />
+            <div className="flex gap-2 flex-wrap">
+              <select value={align} onChange={(e) => setAlign(e.target.value)} className="bg-[var(--bg-app)] border border-[var(--border-default)] rounded-lg px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none">
+                {ALIGN.map((a) => <option key={a} value={a}>{a}</option>)}
               </select>
               <select value={variant} onChange={(e) => setVariant(e.target.value)} className="bg-[var(--bg-app)] border border-[var(--border-default)] rounded-lg px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none">
                 {BUTTON_VARIANTS.map((v) => <option key={v.value} value={v.value}>{v.label}</option>)}
               </select>
+              <input type="color" value={color} onChange={(e) => setColor(e.target.value)} title="Color" className="w-9 h-9 rounded-lg border border-[var(--border-default)] bg-transparent cursor-pointer" />
+              <input type="number" min="0" max="40" value={radius} onChange={(e) => setRadius(e.target.value)} title="Corner radius (px)" className="w-16 bg-[var(--bg-app)] border border-[var(--border-default)] rounded-lg px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none" />
             </div>
-            {(action === 'link' || action === 'copy') && (
-              <input
-                type="text"
-                value={actionValue}
-                onChange={(e) => setActionValue(e.target.value)}
-                placeholder={action === 'link' ? 'https://...' : 'Text to copy'}
-                className="w-full bg-[var(--bg-app)] border border-[var(--border-default)] rounded-lg px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--border-hover)] placeholder-[#6b7a8d]"
-              />
-            )}
             <div className="flex justify-end gap-2">
               <button onClick={() => setEditing(false)} className="px-3 py-1 text-[12px] text-[#888] hover:text-[var(--text-primary)] transition-colors">Cancel</button>
-              <button onClick={save} className="px-3 py-1 text-[12px] bg-[#9b7bf7] text-[var(--text-primary)] rounded-md font-medium hover:bg-[#b69aff] transition-colors">Done</button>
+              <button onClick={save} className="px-3 py-1 text-[12px] bg-[#9b7bf7] text-white rounded-md font-medium hover:bg-[#b69aff] transition-colors">Done</button>
             </div>
           </div>
         );
       }
 
-      const variantCls = BUTTON_VARIANTS.find((v) => v.value === variant)?.cls || BUTTON_VARIANTS[0].cls;
+      const solid = variant !== 'outline';
+      const btnStyle = solid
+        ? { background: color, color: '#fff', border: `2px solid ${color}` }
+        : { background: 'transparent', color, border: `2px solid ${color}` };
 
       return (
-        <div className="my-2" onDoubleClick={() => setEditing(true)}>
-          <button className={`px-5 py-2 rounded-lg text-[13px] font-medium transition-colors ${variantCls}`}>
-            {label}
+        <div className="my-2" style={{ textAlign: align }} onDoubleClick={() => setEditing(true)}>
+          <button
+            className="px-5 py-2.5 text-[14px] font-semibold transition-opacity hover:opacity-90"
+            style={{ ...btnStyle, borderRadius: `${Number(radius) || 0}px`, cursor: 'pointer' }}
+          >
+            {text || 'Button'}
           </button>
         </div>
       );

--- a/packages/lixeditor/src/blocks/ImageBlock.jsx
+++ b/packages/lixeditor/src/blocks/ImageBlock.jsx
@@ -21,6 +21,11 @@ export const BlogImageBlock = createReactBlockSpec(
       previewWidth: { default: 740 },
       name: { default: '' },
       showPreview: { default: true },
+      // email/export fields (2.7.0)
+      alt: { default: '' },
+      width: { default: '' },
+      align: { default: '' },
+      link: { default: '' },
     },
     content: 'none',
   },

--- a/packages/lixeditor/src/blocks/ImageBlock.jsx
+++ b/packages/lixeditor/src/blocks/ImageBlock.jsx
@@ -2,6 +2,7 @@
 
 import { createReactBlockSpec } from '@blocknote/react';
 import { useState, useRef, useCallback, useEffect } from 'react';
+import { useUploadConfig } from '../editor/uploadConfig';
 
 /**
  * Image block for @elixpo/lixeditor.
@@ -30,6 +31,7 @@ export const BlogImageBlock = createReactBlockSpec(
 
 function ImageRenderer({ block, editor }) {
   const { url, caption } = block.props;
+  const { uploadFile: hostUpload, acceptImageTypes, maxFileSizeBytes, onUploadError } = useUploadConfig();
   const [mode, setMode] = useState('idle'); // idle | embed | uploading
   const [embedUrl, setEmbedUrl] = useState('');
   const [embedError, setEmbedError] = useState('');

--- a/packages/lixeditor/src/blocks/ImageBlock.jsx
+++ b/packages/lixeditor/src/blocks/ImageBlock.jsx
@@ -62,11 +62,38 @@ function ImageRenderer({ block, editor }) {
     return () => el.removeEventListener('keydown', handleKey);
   }, [editor, block.id, mode, url]);
 
-  // Upload — reads file as base64 data URL
+  // Add an image. If the host provided `uploadFile`, store the returned hosted
+  // URL (required for email — base64 is stripped by Gmail/Outlook). Otherwise
+  // fall back to a base64 data URL so the package still works with zero config.
   const uploadFile = useCallback(async (file) => {
     if (!file || !file.type.startsWith('image/')) return;
+    if (acceptImageTypes?.length && !acceptImageTypes.includes(file.type)) {
+      showFailToast('Unsupported image type');
+      return;
+    }
+    if (maxFileSizeBytes && file.size > maxFileSizeBytes) {
+      showFailToast(`Image exceeds ${Math.round(maxFileSizeBytes / 1024 / 1024)}MB limit`);
+      return;
+    }
     setMode('uploading');
-    setUploadStatus('Processing...');
+    setUploadStatus(hostUpload ? 'Uploading…' : 'Processing...');
+
+    if (hostUpload) {
+      try {
+        const resultUrl = await hostUpload(file);
+        if (!resultUrl || typeof resultUrl !== 'string') throw new Error('uploadFile did not return a URL');
+        editor.updateBlock(block.id, { props: { url: resultUrl, name: file.name } });
+        setMode('idle');
+      } catch (err) {
+        const e = err instanceof Error ? err : new Error(String(err));
+        onUploadError?.(e, file);
+        showFailToast('Upload failed');
+        setMode('idle'); // keep the block editable/empty — never insert base64 here
+      }
+      return;
+    }
+
+    // Base64 fallback (standalone / zero-config)
     try {
       const reader = new FileReader();
       reader.onload = () => {
@@ -81,7 +108,7 @@ function ImageRenderer({ block, editor }) {
     } catch {
       setMode('idle');
     }
-  }, [editor, block.id]);
+  }, [editor, block.id, hostUpload, acceptImageTypes, maxFileSizeBytes, onUploadError]);
 
   // Paste handler
   const handlePaste = useCallback((e) => {

--- a/packages/lixeditor/src/blocks/VariableInline.jsx
+++ b/packages/lixeditor/src/blocks/VariableInline.jsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { createReactInlineContentSpec } from '@blocknote/react';
+import { useState, useRef, useEffect } from 'react';
+
+// Host-supplied merge-variable names (e.g. ["firstName","amount"]). Set via the
+// `variableSuggestions` prop on <LixEditor>; mirrors setLinkPreviewEndpoint.
+let VARIABLE_SUGGESTIONS = [];
+export function setVariableSuggestions(list) {
+  VARIABLE_SUGGESTIONS = Array.isArray(list) ? list : [];
+}
+
+function VariableChip({ inlineContent }) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState(inlineContent.props.name || '');
+  const ref = useRef(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e) => { if (ref.current && !ref.current.contains(e.target)) setOpen(false); };
+    document.addEventListener('mousedown', onClick);
+    return () => document.removeEventListener('mousedown', onClick);
+  }, [open]);
+
+  const commit = (v) => {
+    const clean = String(v || '').trim().replace(/[{}]/g, '');
+    inlineContent.props.name = clean;
+    setName(clean);
+    setOpen(false);
+  };
+
+  return (
+    <span className="relative inline-flex items-center" ref={ref}>
+      <span
+        onClick={(e) => { e.preventDefault(); e.stopPropagation(); setOpen((o) => !o); }}
+        className="inline-flex items-center px-1.5 py-0.5 rounded text-[13px] font-medium mx-0.5 cursor-pointer transition-all hover:ring-2 hover:ring-[#9b7bf7]/30"
+        style={{ color: '#9b7bf7', backgroundColor: 'rgba(155,123,247,0.08)', border: '1px solid rgba(155,123,247,0.2)', fontFamily: 'ui-monospace, monospace' }}
+        title="Merge variable — exported as literal {{name}}"
+      >
+        {`{{ ${inlineContent.props.name || 'variable'} }}`}
+      </span>
+      {open && (
+        <span
+          className="absolute z-[100] top-full left-0 mt-1 rounded-lg shadow-2xl p-2 flex flex-col gap-1"
+          style={{ backgroundColor: 'var(--bg-app)', border: '1px solid var(--border-default)', minWidth: '180px' }}
+          onMouseDown={(e) => e.stopPropagation()}
+        >
+          <input
+            autoFocus
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') commit(name); if (e.key === 'Escape') setOpen(false); }}
+            placeholder="variable name"
+            className="px-2 py-1 text-[12px] rounded outline-none"
+            style={{ backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border-default)', color: 'var(--text-primary)', fontFamily: 'ui-monospace, monospace' }}
+          />
+          {VARIABLE_SUGGESTIONS.length > 0 && (
+            <span className="flex flex-col max-h-40 overflow-y-auto">
+              {VARIABLE_SUGGESTIONS
+                .filter((s) => s.toLowerCase().includes(name.toLowerCase()))
+                .slice(0, 8)
+                .map((s) => (
+                  <button
+                    key={s}
+                    onClick={() => commit(s)}
+                    className="text-left px-2 py-1 text-[12px] rounded hover:bg-[var(--bg-hover)]"
+                    style={{ color: 'var(--text-body)', fontFamily: 'ui-monospace, monospace' }}
+                  >
+                    {`{{ ${s} }}`}
+                  </button>
+                ))}
+            </span>
+          )}
+        </span>
+      )}
+    </span>
+  );
+}
+
+export const VariableInline = createReactInlineContentSpec(
+  {
+    type: 'lixVariable',
+    propSchema: { name: { default: '' } },
+    content: 'none',
+  },
+  {
+    render: (props) => <VariableChip {...props} />,
+  }
+);

--- a/packages/lixeditor/src/editor/LixEditor.jsx
+++ b/packages/lixeditor/src/editor/LixEditor.jsx
@@ -26,6 +26,7 @@ import { MermaidBlock } from '../blocks/MermaidBlock';
 import { TableOfContents } from '../blocks/TableOfContents';
 import { InlineEquation } from '../blocks/InlineEquation';
 import { DateInline } from '../blocks/DateInline';
+import { VariableInline, setVariableSuggestions } from '../blocks/VariableInline';
 
 // Optional blocks — imported but can be disabled via config
 import { BlogImageBlock as ImageBlock } from '../blocks/ImageBlock';
@@ -35,6 +36,7 @@ import { PDFEmbedBlock } from '../blocks/PDFEmbedBlock';
 // Utilities
 import LinkPreviewTooltip, { useLinkPreview, setLinkPreviewEndpoint } from './LinkPreviewTooltip';
 import { LixUploadContext } from './uploadConfig';
+import { renderBlocksToHTML } from '../preview/renderBlocks';
 
 // Default code block languages
 const DEFAULT_LANGUAGES = {
@@ -164,6 +166,7 @@ const LixEditor = forwardRef(function LixEditor({
     const inlineContentSpecs = { ...defaultInlineContentSpecs };
     if (f.equations) inlineContentSpecs.inlineEquation = InlineEquation;
     if (f.dates) inlineContentSpecs.dateInline = DateInline;
+    inlineContentSpecs.lixVariable = VariableInline;
 
     // Register extra inline specs
     for (const spec of extraInlineSpecs) {
@@ -195,7 +198,10 @@ const LixEditor = forwardRef(function LixEditor({
     getDocument: () => editor.document,
     getEditor: () => editor,
     getBlocks: () => editor.document,
-    getHTML: async () => await editor.blocksToHTMLLossy(editor.document),
+    // Email-safe HTML: bulletproof buttons, inline-styled images, {{vars}} round-trip.
+    getHTML: () => renderBlocksToHTML(editor.document),
+    // BlockNote's lossy HTML, if a consumer wants the editor-DOM flavour instead.
+    getHTMLLossy: async () => await editor.blocksToHTMLLossy(editor.document),
     getMarkdown: async () => await editor.blocksToMarkdownLossy(editor.document),
   }), [editor]);
 
@@ -213,6 +219,9 @@ const LixEditor = forwardRef(function LixEditor({
       try { editor.isEditable = editable; } catch {}
     }
   }, [editor, editable]);
+
+  // Host-supplied merge-variable suggestions for the {{variable}} chip.
+  useEffect(() => { setVariableSuggestions(variableSuggestions || []); }, [variableSuggestions]);
 
   // Auto-convert ![alt](url) to image block and [text](url) to link as you type
   useEffect(() => {
@@ -398,6 +407,19 @@ const LixEditor = forwardRef(function LixEditor({
         },
       });
     }
+
+    custom.push({
+      title: 'Variable',
+      subtext: 'Insert a {{merge variable}} (exports as literal text)',
+      group: 'Advanced',
+      aliases: ['variable', 'merge', 'token', 'field', '{{'],
+      icon: <span style={{ fontSize: 13, fontFamily: 'monospace' }}>{'{}'}</span>,
+      onItemClick: () => {
+        try {
+          editor._tiptapEditor.commands.insertContent({ type: 'lixVariable', attrs: { name: '' } });
+        } catch {}
+      },
+    });
 
     if (f.buttons) {
       custom.push({

--- a/packages/lixeditor/src/editor/LixEditor.jsx
+++ b/packages/lixeditor/src/editor/LixEditor.jsx
@@ -423,10 +423,17 @@ const LixEditor = forwardRef(function LixEditor({
     if (onChange) onChange(editor);
   }, [editor, onChange]);
 
+  const uploadCfg = useMemo(
+    () => ({ uploadFile, acceptImageTypes, maxFileSizeBytes, onUploadError }),
+    [uploadFile, acceptImageTypes, maxFileSizeBytes, onUploadError],
+  );
+
   return (
+    <LixUploadContext.Provider value={uploadCfg}>
     <div className={`lix-editor-wrapper${''}`} ref={wrapperRef} style={{ position: 'relative' }}>
       <BlockNoteView
         editor={editor}
+        editable={editable}
         onChange={handleChange}
         theme={isDark ? 'dark' : 'light'}
         slashMenu={false}

--- a/packages/lixeditor/src/editor/LixEditor.jsx
+++ b/packages/lixeditor/src/editor/LixEditor.jsx
@@ -399,6 +399,21 @@ const LixEditor = forwardRef(function LixEditor({
       });
     }
 
+    if (f.buttons) {
+      custom.push({
+        title: 'Button',
+        subtext: 'Call-to-action button (email-safe export)',
+        group: 'Basic',
+        aliases: ['button', 'cta', 'link button'],
+        icon: <span style={{ fontSize: 14 }}>▭</span>,
+        onItemClick: () => editor.insertBlocks(
+          [{ type: 'buttonBlock', props: { ...(buttonDefaults || {}) } }],
+          editor.getTextCursorPosition().block,
+          'after',
+        ),
+      });
+    }
+
     const all = [...defaults, ...custom, ...extraSlashItems];
     const filtered = filterSuggestionItems(all, query);
 
@@ -417,7 +432,7 @@ const LixEditor = forwardRef(function LixEditor({
       .map((item, i) => ({ item, i, gIdx: groupOrder.get(item.group ?? '') }))
       .sort((a, b) => a.gIdx - b.gIdx || a.i - b.i)
       .map((x) => x.item);
-  }, [editor, f, extraSlashItems]);
+  }, [editor, f, extraSlashItems, buttonDefaults]);
 
   const handleChange = useCallback(() => {
     if (onChange) onChange(editor);
@@ -465,6 +480,7 @@ const LixEditor = forwardRef(function LixEditor({
         />
       )}
     </div>
+    </LixUploadContext.Provider>
   );
 });
 

--- a/packages/lixeditor/src/editor/LixEditor.jsx
+++ b/packages/lixeditor/src/editor/LixEditor.jsx
@@ -33,7 +33,8 @@ import { ButtonBlock } from '../blocks/ButtonBlock';
 import { PDFEmbedBlock } from '../blocks/PDFEmbedBlock';
 
 // Utilities
-import LinkPreviewTooltip, { useLinkPreview } from './LinkPreviewTooltip';
+import LinkPreviewTooltip, { useLinkPreview, setLinkPreviewEndpoint } from './LinkPreviewTooltip';
+import { LixUploadContext } from './uploadConfig';
 
 // Default code block languages
 const DEFAULT_LANGUAGES = {
@@ -108,6 +109,15 @@ const LixEditor = forwardRef(function LixEditor({
   collaboration,
   onReady,
   children,
+  // NEW in 2.7.0
+  uploadFile,
+  acceptImageTypes,
+  maxFileSizeBytes,
+  onUploadError,
+  buttonDefaults,
+  variableSuggestions,
+  editable = true,
+  linkPreviewEndpoint,
 }, ref) {
   const { isDark } = useLixTheme();
   const wrapperRef = useRef(null);
@@ -191,6 +201,18 @@ const LixEditor = forwardRef(function LixEditor({
 
   // Notify parent when ready
   useEffect(() => { if (onReady) onReady(); }, []);
+
+  // Host-configurable link-preview endpoint (prop mirrors setLinkPreviewEndpoint).
+  useEffect(() => {
+    if (linkPreviewEndpoint) setLinkPreviewEndpoint(linkPreviewEndpoint);
+  }, [linkPreviewEndpoint]);
+
+  // Toggle editability (read-only previews).
+  useEffect(() => {
+    if (editor?.isEditable !== undefined) {
+      try { editor.isEditable = editable; } catch {}
+    }
+  }, [editor, editable]);
 
   // Auto-convert ![alt](url) to image block and [text](url) to link as you type
   useEffect(() => {

--- a/packages/lixeditor/src/editor/uploadConfig.js
+++ b/packages/lixeditor/src/editor/uploadConfig.js
@@ -1,0 +1,28 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+
+// Host-controlled media upload. Two ways to provide it:
+//  1. <LixEditor uploadFile={...} /> → set via this context (preferred, SSR-safe)
+//  2. setImageUploader(fn) → module-level fallback (mirrors setLinkPreviewEndpoint)
+// When neither is set, blocks fall back to base64 readAsDataURL (zero-config).
+
+let moduleUploader = null;
+export function setImageUploader(fn) { moduleUploader = typeof fn === 'function' ? fn : null; }
+export function getModuleUploader() { return moduleUploader; }
+
+export const LixUploadContext = createContext(null);
+
+const DEFAULT_IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp'];
+
+// Resolves the effective upload config for a block: context first, then module
+// setter. `uploadFile` is null when the host hasn't configured one.
+export function useUploadConfig() {
+  const ctx = useContext(LixUploadContext);
+  return {
+    uploadFile: ctx?.uploadFile || moduleUploader || null,
+    acceptImageTypes: ctx?.acceptImageTypes || DEFAULT_IMAGE_TYPES,
+    maxFileSizeBytes: ctx?.maxFileSizeBytes || 0, // 0 = unlimited
+    onUploadError: ctx?.onUploadError || null,
+  };
+}

--- a/packages/lixeditor/src/index.js
+++ b/packages/lixeditor/src/index.js
@@ -39,3 +39,6 @@ export {
 export { renderBlocksToHTML } from './preview/renderBlocks';
 export { default as LinkPreviewTooltip, useLinkPreview, setLinkPreviewEndpoint } from './editor/LinkPreviewTooltip';
 export { default as KeyboardShortcutsModal } from './editor/KeyboardShortcutsModal';
+
+// Host-controlled media upload (module-level alternative to the uploadFile prop)
+export { setImageUploader, LixUploadContext, useUploadConfig } from './editor/uploadConfig';

--- a/packages/lixeditor/src/index.js
+++ b/packages/lixeditor/src/index.js
@@ -34,9 +34,10 @@ export {
   PDFEmbedBlock,
   ImageBlock,
 } from './blocks/index';
+export { VariableInline, setVariableSuggestions } from './blocks/VariableInline';
 
 // Utilities
-export { renderBlocksToHTML } from './preview/renderBlocks';
+export { renderBlocksToHTML, buttonBlockToHTML } from './preview/renderBlocks';
 export { default as LinkPreviewTooltip, useLinkPreview, setLinkPreviewEndpoint } from './editor/LinkPreviewTooltip';
 export { default as KeyboardShortcutsModal } from './editor/KeyboardShortcutsModal';
 

--- a/packages/lixeditor/src/preview/renderBlocks.js
+++ b/packages/lixeditor/src/preview/renderBlocks.js
@@ -1,3 +1,24 @@
+const esc = (s) => String(s ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+const escAttr = (s) => String(s ?? '').replace(/"/g, '&quot;');
+
+// Email-safe "bulletproof" CTA button (table/anchor, inline styles, Outlook-safe).
+// Reads the 2.7.0 props (text/url/align/variant/color/radius) with legacy
+// (label/action/actionValue) fallbacks. {{variables}} in url/text are left intact.
+export function buttonBlockToHTML(props = {}) {
+  const text = props.text || props.label || 'Button';
+  const url = props.url || (props.action === 'link' ? props.actionValue : '') || '#';
+  const align = ['left', 'center', 'right'].includes(props.align) ? props.align : 'left';
+  const outline = props.variant === 'outline' || props.variant === 'secondary';
+  const color = props.color || '#7c5cff';
+  const radius = Number.isFinite(props.radius) ? props.radius : 8;
+  const td = outline
+    ? `border-radius:${radius}px;background:transparent;border:2px solid ${color};`
+    : `border-radius:${radius}px;background:${color};`;
+  const aColor = outline ? color : '#ffffff';
+  const aStyle = `display:inline-block;padding:12px 22px;font-family:Arial,Helvetica,sans-serif;font-size:15px;font-weight:700;color:${aColor};text-decoration:none;border-radius:${radius}px;`;
+  return `<table role="presentation" cellspacing="0" cellpadding="0" border="0" align="${align}" style="margin:8px 0;"><tr><td style="${td}"><a href="${escAttr(url)}" target="_blank" rel="noopener noreferrer" style="${aStyle}">${esc(text)}</a></td></tr></table>`;
+}
+
 /**
  * Converts BlockNote document blocks to HTML string.
  * Used by LixPreview for server-side or static rendering.
@@ -10,6 +31,10 @@ export function renderBlocksToHTML(blocks) {
     return content.map((c) => {
       if (c.type === 'inlineEquation' && c.props?.latex) {
         return `<span class="lix-inline-equation" data-latex="${encodeURIComponent(c.props.latex)}"></span>`;
+      }
+      // Merge-variable chip → round-trips to literal {{name}} text.
+      if (c.type === 'lixVariable' && c.props?.name) {
+        return `{{${c.props.name}}}`;
       }
       if (c.type === 'dateInline' && c.props?.date) {
         let formatted;
@@ -87,9 +112,17 @@ export function renderBlocksToHTML(blocks) {
         const code = (block.content || []).map(c => c.text || '').join('');
         return `<pre><code class="language-${lang}">${code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')}</code></pre>${childrenHTML}`;
       }
+      case 'buttonBlock':
+        return buttonBlockToHTML(block.props) + childrenHTML;
       case 'image':
         if (block.props?.url) {
-          return `<figure><img src="${block.props.url}" alt="${block.props?.caption || ''}" />${block.props?.caption ? `<figcaption>${block.props.caption}</figcaption>` : ''}</figure>${childrenHTML}`;
+          const ip = block.props;
+          const alt = escAttr(ip.alt || ip.caption || '');
+          const widthAttr = ip.width ? ` width="${escAttr(ip.width)}"` : '';
+          const align = ['left', 'center', 'right'].includes(ip.align) ? ip.align : null;
+          let img = `<img src="${escAttr(ip.url)}" alt="${alt}"${widthAttr} style="max-width:100%;height:auto;${align === 'center' ? 'display:block;margin:0 auto;' : ''}" />`;
+          if (ip.link) img = `<a href="${escAttr(ip.link)}" target="_blank" rel="noopener noreferrer">${img}</a>`;
+          return `<figure${align ? ` style="text-align:${align}"` : ''}>${img}${ip.caption ? `<figcaption>${ip.caption}</figcaption>` : ''}</figure>${childrenHTML}`;
         }
         return childrenHTML;
       case 'table': {


### PR DESCRIPTION
## Changes Made
- Added `feature-req,md` documenting the spec from mail.elixpo covering `uploadFile`, button block slash-menu insertion, merge-variable tokens, and TypeScript type publishing for the 2.7.0 target.
- Added `packages/lixeditor/index.d.ts` shipping full TypeScript definitions: `LixEditorProps`, `ButtonBlockProps`, `LixEditorHandle`, block/inline specs, and the new `setImageUploader`/`useUploadConfig`/`setVariableSuggestions` exports.
- Updated `packages/lixeditor/package.json` — bumped version to 2.7.0, wired `index.d.ts` into `types`, `exports["."].types`, and `files` so consumers get real type resolution.
- Refactored `packages/lixeditor/src/blocks/ButtonBlock.jsx` to the email-safe prop contract (`text`, `url`, `align`, `variant: solid|outline`, `color`, `radius`) while reading legacy `label`/`action`/`actionValue` and normalizing `primary`/`accent`→`solid`, `secondary`→`outline` for backward compatibility.

## Checklist
- [x] No Node built-ins imported (crypto, fs, path, stream, Buffer)
- [x] `./biome.sh ci` clean
- [ ] Tested locally: <how>

Fixes #87