### PR TITLE
[FEAT]: Editor version patch to fix button styling

### DIFF
--- a/feature-req,md
+++ b/feature-req,md
@@ -1,238 +1,40 @@
-# @elixpo/lixeditor — feature requests (from mail.elixpo)
 
-Spec for changes to implement in the **lixeditor package repo** (dogfooded by
-mail.elixpo). Current consumed version: **2.6.9**. Suggested target: **2.7.0**.
+# 2.7.1 follow-ups (after dogfooding 2.7.0)
 
-mail.elixpo embeds LixEditor as its email-template WYSIWYG. Two things block us
-today, plus a few that would make the editor a clean embed for any host app.
-The contracts below are what mail.elixpo will code against — please keep the
-prop names / signatures exact so integration is drop-in.
+2.7.0 wired up correctly on our side (types, `uploadFile`, slash button). Two
+package-level issues surfaced when actually using it:
 
----
+### A. Button block inline editor is unstyled / broken (P0 bug)
+Inserting a button from `/` renders its inline editor with **no layout**: the
+fields (`text`, `url`, align, variant, color, radius) are cramped onto lines and
+the **"Cancel" / "Done" buttons run together** ("CancelDone"). Screenshot shows
+the controls have effectively no CSS. Likely the button-editor styles aren't in
+the shipped `dist/styles/index.css`, or are scoped to a class that isn't emitted.
+- Ship the button-editor styles (spacing, control sizing, a real button row with
+  a gap, labels). It should look like a small popover/toolbar, not raw inputs.
+- Verify against a **dark** `LixThemeProvider` (our embed is dark) — the inputs
+  need readable contrast.
 
-## P0 — must have
-
-### 1. `uploadFile` hook (host-controlled media upload)
-
-**Problem.** The ImageBlock currently reads dropped/pasted/selected images with
-`FileReader.readAsDataURL` and stores them as **base64 `data:` URLs** inside the
-document. That's fatal for email: clients (Gmail, Outlook) strip or block inline
-base64, and the document/HTML balloons. The editor must let the host upload the
-file somewhere (we use Cloudinary) and store the returned **hosted URL** instead.
-
-**Contract.** Add an optional prop on `LixEditor`:
-
+### B. Suppress BlockNote's default image placeholder UI (for host-driven insert)
+We insert images from our **own** toolbar (file → Cloudinary → insert a ready
+image block), and via drag/drop/paste (already routed through `uploadFile`). But
+an empty image block still shows BlockNote's default **"Upload / Embed URL"**
+card with an Embed-URL tab — which is not our flow and confuses users. Please add
+a way to turn that off:
 ```ts
-uploadFile?: (file: File) => Promise<string>;
-// Resolve to a public URL for the stored asset.
-// Reject (throw) to signal failure — the editor should toast and keep the block editable.
+// on <LixEditor> (or features):
+imageInsert?: "default" | "host";   // "host" → no in-block Upload/Embed-URL placeholder;
+                                     // images appear only once they have a URL
 ```
-
-**Behavior.**
-- If `uploadFile` is provided, the ImageBlock (and any future media block) calls
-  it for every drop / paste / file-input selection, shows the existing
-  "uploading…" state while the promise is pending, then sets
-  `block.props.url = <resolved url>` and `block.props.name = file.name`.
-- If `uploadFile` is **omitted**, keep today's base64 `readAsDataURL` behavior as
-  the fallback (so the package still works standalone with zero config).
-- On reject: show the existing fail toast, call `onUploadError?.(err, file)` if
-  provided, and leave the block in an editable/empty state (don't insert base64).
-
-**Threading.** Deep block components can't see top-level props directly. Pick one
-(either is fine — we'll adapt):
-- **Preferred:** a React context set by `<LixEditor>` (e.g. `LixUploadContext`)
-  that the ImageBlock reads via a `useUploadFile()` hook, **or**
-- a module-level setter mirroring the existing link-preview pattern:
-  `export function setImageUploader(fn: (file: File) => Promise<string>): void`.
-  (You already ship `setLinkPreviewEndpoint`, so this is consistent — but a prop
-  threaded through context is cleaner and SSR-safe.)
-
-**Nice-to-haves on the same hook:**
+and/or expose a tiny imperative helper on the handle so the host can insert an
+image block programmatically with the URL already set (we can do this via
+`getEditor()` + BlockNote today, but a first-class helper is cleaner):
 ```ts
-acceptImageTypes?: string[];   // default ["image/png","image/jpeg","image/gif","image/webp"]
-maxFileSizeBytes?: number;     // reject + toast over this; default unlimited
-onUploadError?: (err: Error, file: File) => void;
+insertImage(url: string, opts?: { alt?: string; align?: "left"|"center"|"right" }): void;
 ```
+With `imageInsert:"host"`, the slash "Image" item should either be hidden or
+trigger the host's `uploadFile` directly (file picker → upload → inserted), never
+the embed-URL card.
 
-**How mail.elixpo will use it** (so the contract is unambiguous):
-```tsx
-<LixEditor
-  uploadFile={async (file) => {
-    const form = new FormData();
-    form.append("file", file);
-    const res = await fetch("/api/uploads/image", { method: "POST", body: form });
-    if (!res.ok) throw new Error("upload failed");
-    const { url } = await res.json();   // already Cloudinary f_auto,q_auto URL
-    return url;
-  }}
-  features={{ images: true, /* … */ }}
-/>
-```
-
----
-
-### 2. Button block, insertable from the `/` slash menu
-
-**Problem.** `features.buttons` / `ButtonBlock` exist, but there's no first-class
-way to **insert** a CTA button from the slash menu and edit its label/link/style.
-Email templates need bulletproof CTA buttons.
-
-**Contract.**
-- When `features.buttons` is true, register a slash-menu item **"Button"** (group
-  "Basic" or "Embed", aliases: `button`, `cta`, `link button`). Selecting it
-  inserts a `button` block with default props.
-- Block props (all editable via an inline popover/toolbar on the block):
-  ```ts
-  interface ButtonBlockProps {
-    text: string;          // "Get started"
-    url: string;           // "https://…" — supports {{variables}} (left as-is in HTML)
-    align: "left" | "center" | "right";   // default "left"
-    variant: "solid" | "outline";          // default "solid"
-    color: string;         // hex, default theme accent (e.g. "#7c5cff")
-    radius?: number;       // px, default 8
-  }
-  ```
-- Allow the host to set defaults:
-  ```ts
-  buttonDefaults?: Partial<ButtonBlockProps>;   // prop on <LixEditor>
-  ```
-
-**Email-safe HTML export (important).** `renderBlocksToHTML` / `getHTML()` must
-emit a **table/anchor "bulletproof button"**, not a styled `<div>` — inline
-styles only, no external CSS, Outlook-safe. Target shape:
-```html
-<table role="presentation" cellspacing="0" cellpadding="0" align="left">
-  <tr><td style="border-radius:8px;background:#7c5cff;">
-    <a href="{{url}}" target="_blank"
-       style="display:inline-block;padding:12px 22px;font-family:Arial,Helvetica,sans-serif;
-              font-size:15px;font-weight:700;color:#ffffff;text-decoration:none;border-radius:8px;">
-      Get started
-    </a>
-  </td></tr>
-</table>
-```
-(For `variant:"outline"`: transparent background, `border:2px solid {color}`,
-text color = `{color}`.) Leave `{{variables}}` in `url`/`text` untouched so the
-host's merge step can substitute them.
-
----
-
-## P1 — high value for our use case
-
-### 3. Merge-variable token `{{variable}}` (inline)
-
-Email templates are built around `{{firstName}}`-style merge fields. Today users
-type raw `{{…}}` text. A first-class inline token would be a big UX win:
-
-- An inline spec rendered as a styled chip (e.g. subtle pill `{{ firstName }}`).
-- A slash item **"Variable"** and/or an autocomplete trigger on typing `{{` that
-  suggests from a host-supplied list:
-  ```ts
-  variableSuggestions?: string[];   // ["firstName","amount","orderId", …]
-  ```
-- **HTML export must round-trip to literal `{{name}}` text** (so our existing
-  `substituteVariables()` keeps working). The chip is purely an editing
-  affordance; `getHTML()` emits `{{name}}`.
-
-If a full inline spec is too much for 2.7.0, even just exposing the `{{` →
-autocomplete over `variableSuggestions` (emitting plain `{{name}}`) is enough.
-
-### 4. `editable` / `readOnly` prop
-
-```ts
-editable?: boolean;   // default true; false → render-only (we want this for previews)
-```
-We currently use `LixPreview` for read-only; a single editor with `editable=false`
-would simplify and guarantee identical rendering.
-
-### 5. Generic file uploads (attachments)
-
-Same `uploadFile` hook, but allow non-image files for a future attachment/file
-block (`acceptTypes`, returns a hosted URL + filename). Not needed for 2.7.0 if
-it complicates things — flag the seam so it's reusable.
-
----
-
-## P2 — polish / DX
-
-6. **Ship TypeScript types.** The package ships **no `.d.ts`** (v2.6.9), so we
-   hand-maintain ambient declarations in `types/lixeditor.d.ts`. Please publish
-   real types — start from the interface below (it's what we already consume plus
-   the new props). This alone removes a whole class of dogfooding friction.
-
-7. **`linkPreviewEndpoint` as a prop** (in addition to `setLinkPreviewEndpoint`)
-   — consistency with `uploadFile`.
-
-8. **Image block fields for email:** `alt` (accessibility/clients with images
-   off), `width`, `align`, and optional `link` (wrap the `<img>` in an `<a>`).
-   `getHTML()` should already give images `max-width:100%`.
-
-9. **`sanitize` / email-safe export mode** on `getHTML()` — strip scripts, inline
-   everything, no `class`/external CSS dependency. (We post-wrap, but a built-in
-   email mode would be ideal.)
-
----
-
-## TypeScript surface to publish (target 2.7.0)
-
-```ts
-export interface LixFeatures {
-  equations?: boolean; mermaid?: boolean; codeHighlighting?: boolean;
-  tableOfContents?: boolean; images?: boolean; buttons?: boolean;
-  pdf?: boolean; dates?: boolean; linkPreview?: boolean; markdownLinks?: boolean;
-}
-
-export interface ButtonBlockProps {
-  text: string; url: string;
-  align?: "left" | "center" | "right";
-  variant?: "solid" | "outline";
-  color?: string; radius?: number;
-}
-
-export interface LixEditorProps {
-  initialContent?: LixBlock[] | string | null;
-  onChange?: (editor: any) => void;
-  onReady?: () => void;
-  features?: LixFeatures;
-  placeholder?: string;
-
-  // NEW in 2.7.0
-  uploadFile?: (file: File) => Promise<string>;
-  acceptImageTypes?: string[];
-  maxFileSizeBytes?: number;
-  onUploadError?: (err: Error, file: File) => void;
-  buttonDefaults?: Partial<ButtonBlockProps>;
-  variableSuggestions?: string[];
-  editable?: boolean;
-  linkPreviewEndpoint?: string;
-
-  codeLanguages?: Record<string, any>;
-  extraBlockSpecs?: any[]; extraInlineSpecs?: any[]; slashMenuItems?: any[];
-  collaboration?: any; children?: ReactNode; ref?: Ref<LixEditorHandle>;
-}
-
-// Optional module-level alternative to the prop (mirrors setLinkPreviewEndpoint):
-export function setImageUploader(fn: (file: File) => Promise<string>): void;
-```
-
----
-
-## Acceptance criteria
-
-- [ ] Dropping/pasting an image with `uploadFile` set stores the **returned URL**,
-      never a `data:` URL; without it, base64 fallback still works.
-- [ ] Upload failure toasts and leaves the block editable (no base64 inserted).
-- [ ] `/` menu shows **Button** when `features.buttons` is on; inserts an editable
-      CTA; `getHTML()` emits a bulletproof table/anchor button with inline styles.
-- [ ] `{{variables}}` survive `getHTML()` as literal text (round-trip safe).
-- [ ] Package ships `.d.ts`; the new props are typed.
-- [ ] No SSR regressions (we import the editor `ssr:false`, but types/exports must
-      resolve on the server).
-
-## After publishing
-1. Bump the package (suggest `2.7.0`) and publish.
-2. Ping back here — mail.elixpo will:
-   - `npm i @elixpo/lixeditor@2.7.0`,
-   - delete the hand-written `types/lixeditor.d.ts` (or trim to gaps),
-   - pass `uploadFile`, `variableSuggestions`, `buttonDefaults`, `editable` from
-     the template composer, and ship the Cloudinary upload route.
+> Everything else in 2.7.0 is working. These two unblock a clean compose UX on
+> our side; once published we'll bump and drop our remaining workarounds.

--- a/packages/lixeditor/index.d.ts
+++ b/packages/lixeditor/index.d.ts
@@ -33,6 +33,8 @@ export interface LixEditorHandle {
   /** BlockNote's lossy editor-DOM HTML. */
   getHTMLLossy(): Promise<string>;
   getMarkdown(): Promise<string>;
+  /** Insert a ready image block with the URL already set (host-driven insert). */
+  insertImage(url: string, opts?: { alt?: string; align?: 'left' | 'center' | 'right'; name?: string }): void;
 }
 
 export interface LixEditorProps {
@@ -51,6 +53,8 @@ export interface LixEditorProps {
   variableSuggestions?: string[];
   editable?: boolean;
   linkPreviewEndpoint?: string;
+  /** "host" → no in-block Upload/Embed-URL card; images appear only with a URL. */
+  imageInsert?: 'default' | 'host';
 
   codeLanguages?: Record<string, any>;
   extraBlockSpecs?: any[];

--- a/packages/lixeditor/package.json
+++ b/packages/lixeditor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elixpo/lixeditor",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "A rich WYSIWYG block editor and renderer built on BlockNote — equations, mermaid diagrams, code highlighting, host-controlled uploads, email-safe button export, and more.",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/lixeditor/src/blocks/ButtonBlock.jsx
+++ b/packages/lixeditor/src/blocks/ButtonBlock.jsx
@@ -65,27 +65,43 @@ export const ButtonBlock = createReactBlockSpec(
         setEditing(false);
       };
 
-      const input = 'w-full bg-[var(--bg-app)] border border-[var(--border-default)] rounded-lg px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--border-hover)] placeholder-[#6b7a8d]';
-
       if (editing) {
         return (
-          <div className="border border-[var(--border-default)] rounded-xl bg-[var(--bg-surface)] p-4 my-2 space-y-3">
-            <p className="text-[11px] text-[var(--text-muted)] font-medium">Button</p>
-            <input type="text" value={text} onChange={(e) => setText(e.target.value)} placeholder="Button text — e.g. Get started" className={input} />
-            <input type="text" value={url} onChange={(e) => setUrl(e.target.value)} placeholder="https://…  (supports {{variables}})" className={input} />
-            <div className="flex gap-2 flex-wrap">
-              <select value={align} onChange={(e) => setAlign(e.target.value)} className="bg-[var(--bg-app)] border border-[var(--border-default)] rounded-lg px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none">
-                {ALIGN.map((a) => <option key={a} value={a}>{a}</option>)}
-              </select>
-              <select value={variant} onChange={(e) => setVariant(e.target.value)} className="bg-[var(--bg-app)] border border-[var(--border-default)] rounded-lg px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none">
-                {BUTTON_VARIANTS.map((v) => <option key={v.value} value={v.value}>{v.label}</option>)}
-              </select>
-              <input type="color" value={color} onChange={(e) => setColor(e.target.value)} title="Color" className="w-9 h-9 rounded-lg border border-[var(--border-default)] bg-transparent cursor-pointer" />
-              <input type="number" min="0" max="40" value={radius} onChange={(e) => setRadius(e.target.value)} title="Corner radius (px)" className="w-16 bg-[var(--bg-app)] border border-[var(--border-default)] rounded-lg px-3 py-2 text-[13px] text-[var(--text-primary)] outline-none" />
+          <div className="lix-btn-editor">
+            <p className="lix-btn-editor-title">Button</p>
+            <label className="lix-btn-editor-field">
+              <span className="lix-btn-editor-label">Text</span>
+              <input type="text" value={text} onChange={(e) => setText(e.target.value)} placeholder="e.g. Get started" className="lix-btn-editor-input" />
+            </label>
+            <label className="lix-btn-editor-field">
+              <span className="lix-btn-editor-label">Link URL</span>
+              <input type="text" value={url} onChange={(e) => setUrl(e.target.value)} placeholder="https://…  (supports {{variables}})" className="lix-btn-editor-input" />
+            </label>
+            <div className="lix-btn-editor-row">
+              <label className="lix-btn-editor-field">
+                <span className="lix-btn-editor-label">Align</span>
+                <select value={align} onChange={(e) => setAlign(e.target.value)} className="lix-btn-editor-select">
+                  {ALIGN.map((a) => <option key={a} value={a}>{a}</option>)}
+                </select>
+              </label>
+              <label className="lix-btn-editor-field">
+                <span className="lix-btn-editor-label">Style</span>
+                <select value={variant} onChange={(e) => setVariant(e.target.value)} className="lix-btn-editor-select">
+                  {BUTTON_VARIANTS.map((v) => <option key={v.value} value={v.value}>{v.label}</option>)}
+                </select>
+              </label>
+              <label className="lix-btn-editor-field">
+                <span className="lix-btn-editor-label">Color</span>
+                <input type="color" value={color} onChange={(e) => setColor(e.target.value)} title="Color" className="lix-btn-editor-color" />
+              </label>
+              <label className="lix-btn-editor-field">
+                <span className="lix-btn-editor-label">Radius</span>
+                <input type="number" min="0" max="40" value={radius} onChange={(e) => setRadius(e.target.value)} title="Corner radius (px)" className="lix-btn-editor-input lix-btn-editor-radius" />
+              </label>
             </div>
-            <div className="flex justify-end gap-2">
-              <button onClick={() => setEditing(false)} className="px-3 py-1 text-[12px] text-[#888] hover:text-[var(--text-primary)] transition-colors">Cancel</button>
-              <button onClick={save} className="px-3 py-1 text-[12px] bg-[#9b7bf7] text-white rounded-md font-medium hover:bg-[#b69aff] transition-colors">Done</button>
+            <div className="lix-btn-editor-actions">
+              <button onClick={() => setEditing(false)} className="lix-btn-editor-cancel">Cancel</button>
+              <button onClick={save} className="lix-btn-editor-done">Done</button>
             </div>
           </div>
         );
@@ -97,10 +113,10 @@ export const ButtonBlock = createReactBlockSpec(
         : { background: 'transparent', color, border: `2px solid ${color}` };
 
       return (
-        <div className="my-2" style={{ textAlign: align }} onDoubleClick={() => setEditing(true)}>
+        <div className="lix-btn-wrap" style={{ textAlign: align }} onDoubleClick={() => setEditing(true)}>
           <button
-            className="px-5 py-2.5 text-[14px] font-semibold transition-opacity hover:opacity-90"
-            style={{ ...btnStyle, borderRadius: `${Number(radius) || 0}px`, cursor: 'pointer' }}
+            className="lix-btn"
+            style={{ ...btnStyle, borderRadius: `${Number(radius) || 0}px` }}
           >
             {text || 'Button'}
           </button>

--- a/packages/lixeditor/src/blocks/ImageBlock.jsx
+++ b/packages/lixeditor/src/blocks/ImageBlock.jsx
@@ -36,7 +36,7 @@ export const BlogImageBlock = createReactBlockSpec(
 
 function ImageRenderer({ block, editor }) {
   const { url, caption } = block.props;
-  const { uploadFile: hostUpload, acceptImageTypes, maxFileSizeBytes, onUploadError } = useUploadConfig();
+  const { uploadFile: hostUpload, acceptImageTypes, maxFileSizeBytes, onUploadError, imageInsert } = useUploadConfig();
   const [mode, setMode] = useState('idle'); // idle | embed | uploading
   const [embedUrl, setEmbedUrl] = useState('');
   const [embedError, setEmbedError] = useState('');
@@ -176,6 +176,9 @@ function ImageRenderer({ block, editor }) {
 
   // ─── No image yet ───
   if (!url) {
+    // Host-driven insert: never show the default Upload/Embed-URL card. The host
+    // inserts ready image blocks (with a URL) via its own toolbar / insertImage().
+    if (imageInsert === 'host') return null;
     return (
       <div
         ref={blockRef}

--- a/packages/lixeditor/src/editor/LixEditor.jsx
+++ b/packages/lixeditor/src/editor/LixEditor.jsx
@@ -120,6 +120,7 @@ const LixEditor = forwardRef(function LixEditor({
   variableSuggestions,
   editable = true,
   linkPreviewEndpoint,
+  imageInsert = 'default',
 }, ref) {
   const { isDark } = useLixTheme();
   const wrapperRef = useRef(null);
@@ -203,7 +204,37 @@ const LixEditor = forwardRef(function LixEditor({
     // BlockNote's lossy HTML, if a consumer wants the editor-DOM flavour instead.
     getHTMLLossy: async () => await editor.blocksToHTMLLossy(editor.document),
     getMarkdown: async () => await editor.blocksToMarkdownLossy(editor.document),
+    // Insert a ready image block with the URL already set (host-driven insert).
+    insertImage: (url, opts = {}) => {
+      if (!url) return;
+      const props = { url, alt: opts.alt || '', align: opts.align || '', name: opts.name || '' };
+      const ref = editor.getTextCursorPosition?.()?.block || editor.document[editor.document.length - 1];
+      if (ref) editor.insertBlocks([{ type: 'image', props }], ref, 'after');
+      else editor.insertBlocks([{ type: 'image', props }], editor.document[0], 'before');
+    },
   }), [editor]);
+
+  // Host image picker — file → uploadFile → insertImage (used by the slash item
+  // when imageInsert='host', so users never hit the embed-URL card).
+  const pickHostImage = useCallback(() => {
+    if (!uploadFile) return;
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = (acceptImageTypes || ['image/png', 'image/jpeg', 'image/gif', 'image/webp']).join(',');
+    input.onchange = async () => {
+      const file = input.files?.[0];
+      if (!file) return;
+      try {
+        const url = await uploadFile(file);
+        if (!url) throw new Error('no url');
+        const ref = editor.getTextCursorPosition?.()?.block || editor.document[editor.document.length - 1];
+        if (ref) editor.insertBlocks([{ type: 'image', props: { url, name: file.name } }], ref, 'after');
+      } catch (err) {
+        onUploadError?.(err instanceof Error ? err : new Error(String(err)), file);
+      }
+    };
+    input.click();
+  }, [editor, uploadFile, acceptImageTypes, onUploadError]);
 
   // Notify parent when ready
   useEffect(() => { if (onReady) onReady(); }, []);
@@ -352,9 +383,23 @@ const LixEditor = forwardRef(function LixEditor({
   // BlockNote items had no `title` field for the current schema).
   const getItems = useCallback(async (query) => {
     const defaults = getDefaultReactSlashMenuItems(editor)
-      .filter(item => !['video', 'audio', 'file'].includes(item.key));
+      .filter(item => !['video', 'audio', 'file'].includes(item.key))
+      // Host-driven image insert: drop BlockNote's default image item (it opens
+      // the Upload/Embed-URL card we're suppressing) — replaced below.
+      .filter(item => !(imageInsert === 'host' && f.images && item.key === 'image'));
 
     const custom = [];
+
+    if (f.images && imageInsert === 'host' && uploadFile) {
+      custom.push({
+        title: 'Image',
+        subtext: 'Upload an image',
+        group: 'Basic',
+        aliases: ['image', 'img', 'photo', 'picture', 'upload'],
+        icon: <span style={{ fontSize: 14 }}>🖼️</span>,
+        onItemClick: () => pickHostImage(),
+      });
+    }
 
     if (f.equations) {
       custom.push({
@@ -454,15 +499,15 @@ const LixEditor = forwardRef(function LixEditor({
       .map((item, i) => ({ item, i, gIdx: groupOrder.get(item.group ?? '') }))
       .sort((a, b) => a.gIdx - b.gIdx || a.i - b.i)
       .map((x) => x.item);
-  }, [editor, f, extraSlashItems, buttonDefaults]);
+  }, [editor, f, extraSlashItems, buttonDefaults, imageInsert, uploadFile, pickHostImage]);
 
   const handleChange = useCallback(() => {
     if (onChange) onChange(editor);
   }, [editor, onChange]);
 
   const uploadCfg = useMemo(
-    () => ({ uploadFile, acceptImageTypes, maxFileSizeBytes, onUploadError }),
-    [uploadFile, acceptImageTypes, maxFileSizeBytes, onUploadError],
+    () => ({ uploadFile, acceptImageTypes, maxFileSizeBytes, onUploadError, imageInsert }),
+    [uploadFile, acceptImageTypes, maxFileSizeBytes, onUploadError, imageInsert],
   );
 
   return (

--- a/packages/lixeditor/src/editor/uploadConfig.js
+++ b/packages/lixeditor/src/editor/uploadConfig.js
@@ -24,5 +24,8 @@ export function useUploadConfig() {
     acceptImageTypes: ctx?.acceptImageTypes || DEFAULT_IMAGE_TYPES,
     maxFileSizeBytes: ctx?.maxFileSizeBytes || 0, // 0 = unlimited
     onUploadError: ctx?.onUploadError || null,
+    // 'default' → in-block Upload/Embed-URL card; 'host' → no placeholder, images
+    // appear only once they have a URL (host inserts via its own toolbar/picker).
+    imageInsert: ctx?.imageInsert || 'default',
   };
 }

--- a/packages/lixeditor/src/preview/renderBlocks.js
+++ b/packages/lixeditor/src/preview/renderBlocks.js
@@ -16,7 +16,11 @@ export function buttonBlockToHTML(props = {}) {
     : `border-radius:${radius}px;background:${color};`;
   const aColor = outline ? color : '#ffffff';
   const aStyle = `display:inline-block;padding:12px 22px;font-family:Arial,Helvetica,sans-serif;font-size:15px;font-weight:700;color:${aColor};text-decoration:none;border-radius:${radius}px;`;
-  return `<table role="presentation" cellspacing="0" cellpadding="0" border="0" align="${align}" style="margin:8px 0;"><tr><td style="${td}"><a href="${escAttr(url)}" target="_blank" rel="noopener noreferrer" style="${aStyle}">${esc(text)}</a></td></tr></table>`;
+  // Block-level (own line, never inline): a block <div> wrapper drives alignment
+  // in modern clients (text-align + inline-block table), while align="" on the
+  // table keeps Outlook correct. The wrapper also prevents float-into-text.
+  const table = `<table role="presentation" cellspacing="0" cellpadding="0" border="0" align="${align}" style="display:inline-block;"><tr><td style="${td}"><a href="${escAttr(url)}" target="_blank" rel="noopener noreferrer" style="${aStyle}">${esc(text)}</a></td></tr></table>`;
+  return `<div class="lix-btn-block" style="display:block;margin:12px 0;text-align:${align};">${table}</div>`;
 }
 
 /**
@@ -80,6 +84,9 @@ export function renderBlocksToHTML(blocks) {
   function renderBlock(block) {
     const content = inlineToHTML(block.content);
     const childrenHTML = block.children?.length ? renderListGroup(block.children) : '';
+    // BlockNote stores block alignment in props.textAlignment — preserve it on export.
+    const ta = block.props?.textAlignment;
+    const alignAttr = ta && ta !== 'left' ? ` style="text-align:${ta}"` : '';
 
     switch (block.type) {
       case 'tableOfContents':
@@ -88,7 +95,7 @@ export function renderBlocksToHTML(blocks) {
         const level = block.props?.level || 1;
         const text = (block.content || []).map(c => c.text || '').join('');
         const id = `h-${text.trim().toLowerCase().replace(/[^\w]+/g, '-').slice(0, 40)}`;
-        return `<h${level} id="${id}">${content}</h${level}>${childrenHTML}`;
+        return `<h${level} id="${id}"${alignAttr}>${content}</h${level}>${childrenHTML}`;
       }
       case 'bulletListItem':
         return `<li class="lix-bullet">${content}${childrenHTML}</li>`;
@@ -147,7 +154,7 @@ export function renderBlocksToHTML(blocks) {
       }
       case 'paragraph':
       default:
-        if (content) return `<p>${content}</p>${childrenHTML}`;
+        if (content) return `<p${alignAttr}>${content}</p>${childrenHTML}`;
         return childrenHTML || '';
     }
   }

--- a/packages/lixeditor/src/styles/blocks.css
+++ b/packages/lixeditor/src/styles/blocks.css
@@ -1152,3 +1152,35 @@
   background-color: rgba(248, 113, 113, 0.08);
   border-color: rgba(248, 113, 113, 0.3);
 }
+
+/* ── Button block: inline editor + preview (2.7.1) ──────────────────────────
+   Real classes (no Tailwind) so the editor is styled inside any host app. */
+.lix-btn-editor {
+  display: flex; flex-direction: column; gap: 12px;
+  background: var(--bg-surface); border: 1px solid var(--border-default);
+  border-radius: 12px; padding: 16px; margin: 8px 0; max-width: 460px;
+  box-shadow: var(--shadow-lg, 0 12px 40px rgba(0,0,0,0.25));
+}
+.lix-btn-editor-title { margin: 0; font-size: 11px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase; color: var(--text-muted); }
+.lix-btn-editor-field { display: flex; flex-direction: column; gap: 4px; }
+.lix-btn-editor-label { font-size: 11px; color: var(--text-faint); }
+.lix-btn-editor-input, .lix-btn-editor-select {
+  width: 100%; box-sizing: border-box; padding: 8px 10px; font-size: 13px; outline: none;
+  background: var(--bg-app); color: var(--text-primary);
+  border: 1px solid var(--border-default); border-radius: 8px;
+}
+.lix-btn-editor-input:focus, .lix-btn-editor-select:focus { border-color: var(--border-hover); }
+.lix-btn-editor-input::placeholder { color: var(--text-faint); }
+.lix-btn-editor-row { display: flex; gap: 10px; flex-wrap: wrap; align-items: flex-end; }
+.lix-btn-editor-row .lix-btn-editor-field { flex: 0 0 auto; }
+.lix-btn-editor-color { width: 38px; height: 36px; padding: 2px; cursor: pointer; background: var(--bg-app); border: 1px solid var(--border-default); border-radius: 8px; }
+.lix-btn-editor-radius { width: 64px; }
+.lix-btn-editor-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 4px; }
+.lix-btn-editor-cancel, .lix-btn-editor-done { padding: 7px 14px; font-size: 12px; font-weight: 600; border: none; border-radius: 8px; cursor: pointer; }
+.lix-btn-editor-cancel { background: var(--bg-elevated); color: var(--text-muted); }
+.lix-btn-editor-cancel:hover { color: var(--text-primary); }
+.lix-btn-editor-done { background: #9b7bf7; color: #fff; }
+.lix-btn-editor-done:hover { background: #b69aff; }
+.lix-btn-wrap { margin: 10px 0; }
+.lix-btn { padding: 10px 22px; font-size: 14px; font-weight: 600; cursor: pointer; transition: opacity .15s ease; }
+.lix-btn:hover { opacity: .9; }


### PR DESCRIPTION
## Changes Made
- `packages/lixeditor/package.json` — bumped version from 2.7.0 to 2.7.1 for the patch release.
- `packages/lixeditor/src/blocks/ButtonBlock.jsx` — replaced inline Tailwind utility classes on the button-block inline editor with semantic CSS class names (`lix-btn-editor`, `lix-btn-editor-field`, `lix-btn-editor-row`, etc.) and wrapped each field in `<label>` elements with visible label text, fixing the broken/cramped layout where "Cancel"/"Done" ran together.
- `packages/lixeditor/index.d.ts` — added `insertImage(url, opts?)` to `LixEditorHandle` so hosts can programmatically insert an image block with a pre-set URL, and added `imageInsert?: 'default' | 'host'` prop to `LixEditorProps` to let hosts suppress BlockNote's default Upload/Embed-URL placeholder card.
- `feature-req,md` — replaced the 2.7.0 feature-request spec with a 2.7.1 follow-up doc describing the two dogfooding issues (button-editor styling and image-insert suppression) that this patch addresses.

## Checklist
- [ ] No Node built-ins imported (crypto, fs, path, stream, Buffer)
- [ ] `./biome.sh ci` clean
- [ ] Tested locally: <how>

> Everything else in 2.7.0 is working. These two unblock a clean compose UX on
> our side; once published we'll bump and drop our remaining workarounds.