### PR TITLE
[FEAT]: Attach the blockquote fixes

### DIFF
--- a/feature-req,md
+++ b/feature-req,md
@@ -1,40 +1,10 @@
+### D. `getHTML()` drops the `quote` block (P1 — for 2.7.2)
+BlockNote (the peer dep) has a **`quote`** block and the editor creates it fine,
+but lixeditor's `getHTML()` has no case for it (zero `quote`/`blockquote` in the
+bundle) — so a quote renders in the editor but **vanishes from the email export
++ preview**. `renderBlock` should emit `<blockquote>${content}</blockquote>` for
+`type === "quote"` (our email CSS already styles `blockquote`). Pairs with the
+alignment fix (C).
 
-# 2.7.1 follow-ups (after dogfooding 2.7.0)
-
-2.7.0 wired up correctly on our side (types, `uploadFile`, slash button). Two
-package-level issues surfaced when actually using it:
-
-### A. Button block inline editor is unstyled / broken (P0 bug)
-Inserting a button from `/` renders its inline editor with **no layout**: the
-fields (`text`, `url`, align, variant, color, radius) are cramped onto lines and
-the **"Cancel" / "Done" buttons run together** ("CancelDone"). Screenshot shows
-the controls have effectively no CSS. Likely the button-editor styles aren't in
-the shipped `dist/styles/index.css`, or are scoped to a class that isn't emitted.
-- Ship the button-editor styles (spacing, control sizing, a real button row with
-  a gap, labels). It should look like a small popover/toolbar, not raw inputs.
-- Verify against a **dark** `LixThemeProvider` (our embed is dark) — the inputs
-  need readable contrast.
-
-### B. Suppress BlockNote's default image placeholder UI (for host-driven insert)
-We insert images from our **own** toolbar (file → Cloudinary → insert a ready
-image block), and via drag/drop/paste (already routed through `uploadFile`). But
-an empty image block still shows BlockNote's default **"Upload / Embed URL"**
-card with an Embed-URL tab — which is not our flow and confuses users. Please add
-a way to turn that off:
-```ts
-// on <LixEditor> (or features):
-imageInsert?: "default" | "host";   // "host" → no in-block Upload/Embed-URL placeholder;
-                                     // images appear only once they have a URL
-```
-and/or expose a tiny imperative helper on the handle so the host can insert an
-image block programmatically with the URL already set (we can do this via
-`getEditor()` + BlockNote today, but a first-class helper is cleaner):
-```ts
-insertImage(url: string, opts?: { alt?: string; align?: "left"|"center"|"right" }): void;
-```
-With `imageInsert:"host"`, the slash "Image" item should either be hidden or
-trigger the host's `uploadFile` directly (file picker → upload → inserted), never
-the embed-URL card.
-
-> Everything else in 2.7.0 is working. These two unblock a clean compose UX on
-> our side; once published we'll bump and drop our remaining workarounds.
+> Everything else in 2.7.0 is working. These unblock a clean compose UX on our
+> side; once published we'll bump and drop our remaining workarounds.

--- a/packages/lixeditor/package.json
+++ b/packages/lixeditor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elixpo/lixeditor",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "A rich WYSIWYG block editor and renderer built on BlockNote — equations, mermaid diagrams, code highlighting, host-controlled uploads, email-safe button export, and more.",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/lixeditor/src/editor/LixEditor.jsx
+++ b/packages/lixeditor/src/editor/LixEditor.jsx
@@ -254,9 +254,10 @@ const LixEditor = forwardRef(function LixEditor({
   // Host-supplied merge-variable suggestions for the {{variable}} chip.
   useEffect(() => { setVariableSuggestions(variableSuggestions || []); }, [variableSuggestions]);
 
-  // Auto-convert ![alt](url) to image block and [text](url) to link as you type
+  // Markdown-as-you-type: "> " \u2192 quote (always), plus ![alt](url)/[text](url)
+  // conversions (gated on markdownLinks).
   useEffect(() => {
-    if (!f.markdownLinks || !editor) return;
+    if (!editor) return;
     const tiptap = editor._tiptapEditor;
     if (!tiptap) return;
 
@@ -264,6 +265,20 @@ const LixEditor = forwardRef(function LixEditor({
       const { state, view } = tiptap;
       const { $from } = state.selection;
       const textBefore = $from.parent.textBetween(0, $from.parentOffset, undefined, '\ufffc');
+
+      // "> " at the start of a line \u2192 turn the block into a blockquote.
+      if (textBefore === '> ') {
+        try {
+          const block = editor.getTextCursorPosition().block;
+          if (block && block.type !== 'quote') {
+            view.dispatch(state.tr.delete($from.pos - 2, $from.pos)); // strip the "> " marker
+            editor.updateBlock(block, { type: 'quote' });
+            return;
+          }
+        } catch {}
+      }
+
+      if (!f.markdownLinks) return;
 
       // Image syntax: ![alt](url)
       const imgMatch = textBefore.match(/!\[([^\]]*)\]\((https?:\/\/[^\s)]+)\)$/);
@@ -300,6 +315,22 @@ const LixEditor = forwardRef(function LixEditor({
     tiptap.on('update', handleInput);
     return () => tiptap.off('update', handleInput);
   }, [editor, f.markdownLinks]);
+
+  // Shift+Arrow should extend the text selection, not move/rearrange blocks.
+  // BlockNote binds block-move to Shift+ArrowUp/Down; intercept it in the capture
+  // phase (before ProseMirror's handler) so the native selection happens instead.
+  useEffect(() => {
+    const el = wrapperRef.current;
+    if (!el) return;
+    const onKeyDown = (e) => {
+      if (e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey
+        && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) {
+        e.stopImmediatePropagation();
+      }
+    };
+    el.addEventListener('keydown', onKeyDown, true);
+    return () => el.removeEventListener('keydown', onKeyDown, true);
+  }, [editor]);
 
   // Link preview hover
   useEffect(() => {

--- a/packages/lixeditor/src/preview/renderBlocks.js
+++ b/packages/lixeditor/src/preview/renderBlocks.js
@@ -112,6 +112,8 @@ export function renderBlocksToHTML(blocks) {
       case 'mermaidBlock':
         if (block.props?.diagram) return `<div class="lix-mermaid-block" data-diagram="${encodeURIComponent(block.props.diagram)}"></div>${childrenHTML}`;
         return childrenHTML;
+      case 'quote':
+        return `<blockquote${alignAttr}>${content}</blockquote>${childrenHTML}`;
       case 'divider':
         return `<hr class="lix-divider" />${childrenHTML}`;
       case 'codeBlock': {


### PR DESCRIPTION
## Changes Made
- `feature-req,md` — Replaced stale 2.7.1 follow-ups (button-editor styling, image placeholder suppression) with the current P1 request: `getHTML()` dropping the `quote` block in email export/preview.
- `packages/lixeditor/package.json` — Bumped version from 2.7.1 to 2.7.2.
- `packages/lixeditor/src/editor/LixEditor.jsx` — Added `> ` markdown auto-conversion to a `quote` block, always on (not gated behind `markdownLinks`); image/link syntax conversions remain gated as before.
- `packages/lixeditor/src/editor/LixEditor.jsx` — Intercepted Shift+ArrowUp/Down in the capture phase to stop BlockNote's block-move handler, restoring native text-selection extension.
- `packages/lixeditor/src/preview/renderBlocks.js` — Added a `quote` case to `renderBlocksToHTML` that emits `<blockquote>` with the alignment attribute, so quote blocks survive the email export/preview pipeline.

## Checklist
- [ ] No Node built-ins imported (crypto, fs, path, stream, Buffer)
- [ ] `./biome.sh ci` clean
- [ ] Tested locally: <how>