### PR TITLE
fix: implement member-only posts end-to-end (closes #94)

### DIFF
--- a/app/api/blogs/draft/route.js
+++ b/app/api/blogs/draft/route.js
@@ -24,7 +24,7 @@ export async function GET(request) {
     const { decompressBlogContent } = await import('../../../../lib/compress');
     const db = getDB();
 
-    const COLS = 'id, slug, title, subtitle, content, cover_image_r2_key, cover_pos_x, cover_pos_y, cover_zoom, author_id, published_as, status, page_emoji, collection_id';
+    const COLS = 'id, slug, title, subtitle, content, cover_image_r2_key, cover_pos_x, cover_pos_y, cover_zoom, author_id, published_as, status, page_emoji, collection_id, member_only';
 
     // The param may be the canonical id (new blogs) or the human slug (edit links).
     // Resolve by id first; otherwise by slug scoped to a blog THIS user can edit

--- a/app/api/blogs/publish/route.js
+++ b/app/api/blogs/publish/route.js
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server';
 import { getSession } from '../../../../lib/auth';
 import { requestTooLarge, byteLength, MAX_BLOG_CONTENT_BYTES, MAX_TITLE_LEN, MAX_SUBTITLE_LEN } from '../../../../lib/limits';
 import { readTimeFromWords } from '../../../../lib/readTime';
+import { getLimits } from '../../../../lib/tiers';
 
 export async function POST(request) {
   const session = await getSession();
@@ -15,7 +16,8 @@ export async function POST(request) {
   }
 
   const body = await request.json();
-  const { slugid, title, subtitle, tags, publishAs, editorContent, pageEmoji, coverUrl, coverPos, coverZoom, status, lastKnownUpdatedAt, slug: requestedSlug, collectionId } = body;
+  const { slugid, title, subtitle, tags, publishAs, editorContent, pageEmoji, coverUrl, coverPos, coverZoom, status, lastKnownUpdatedAt, slug: requestedSlug, collectionId, member_only: memberOnlyRaw } = body;
+  const memberOnly = memberOnlyRaw === true; 
   const posX = Number.isFinite(coverPos?.x) ? coverPos.x : 50;
   const posY = Number.isFinite(coverPos?.y) ? coverPos.y : 50;
   const zoom = Number.isFinite(coverZoom) ? coverZoom : 1;
@@ -56,6 +58,17 @@ export async function POST(request) {
     const { checkPublishSafety } = await import('../../../../lib/blog-version');
     const db = getDB();
     const now = Math.floor(Date.now() / 1000);
+    if (memberOnly) {
+      const authorRow = await db.prepare('SELECT tier FROM users WHERE id = ?')
+        .bind(session.userId).first();
+      const limits = getLimits(authorRow?.tier);
+      if (!limits.canMarkMemberOnly) {
+        return NextResponse.json(
+          { error: 'Member-only posts require a Member subscription.' },
+          { status: 403 }
+        );
+       }
+      }
     const readTime = readTimeFromWords(countWords(editorContent));
     const compressedContent = editorContent ? compressBlogContent(editorContent) : '';
     const { excerptFromBlocks } = await import('../../../../lib/excerpt');
@@ -136,13 +149,15 @@ export async function POST(request) {
         ? (existing.status === 'draft' ? now : null)
         : null;
 
+      
       let query = `
         UPDATE blogs SET title = ?, subtitle = ?, slug = ?, content = ?, excerpt = ?, published_as = ?,
           collection_id = ?, status = ?, page_emoji = ?, cover_image_r2_key = ?, cover_pos_x = ?, cover_pos_y = ?, cover_zoom = ?,
-          read_time_minutes = ?, updated_at = ?
+          read_time_minutes = ?, updated_at = ?, member_only = ?
       `;
       const params = [title, subtitle || '', slug, compressedContent, excerpt, publishAs || 'personal',
-        finalCollectionId, targetStatus, pageEmoji || '', coverUrl || '', posX, posY, zoom, readTime, now];
+        finalCollectionId, targetStatus, pageEmoji || '', coverUrl || '', posX, posY, zoom, readTime, now, memberOnly ? 1 : 0];
+      
 
       if (publishedAt) {
         query += ', published_at = ?';
@@ -156,13 +171,14 @@ export async function POST(request) {
       // Create and publish in one step
       await db.prepare(`
         INSERT INTO blogs (id, slug, title, subtitle, content, excerpt, author_id, published_as, collection_id, status,
-          page_emoji, cover_image_r2_key, cover_pos_x, cover_pos_y, cover_zoom, read_time_minutes, created_at, updated_at, published_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          page_emoji, cover_image_r2_key, cover_pos_x, cover_pos_y, cover_zoom, read_time_minutes, created_at, updated_at, published_at, member_only)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `).bind(
         slugid, slug, title, subtitle || '', compressedContent, excerpt,
         session.userId, publishAs || 'personal', finalCollectionId, targetStatus,
         pageEmoji || '', coverUrl || '', posX, posY, zoom, readTime, now, now,
-        (targetStatus === 'published' || targetStatus === 'unlisted') ? now : null
+        (targetStatus === 'published' || targetStatus === 'unlisted') ? now : null,
+        memberOnly ? 1 : 0
       ).run();
     }
 

--- a/app/api/resolve/route.js
+++ b/app/api/resolve/route.js
@@ -2,6 +2,8 @@ export const runtime = 'edge';
 import { NextResponse } from 'next/server';
 import { decompressBlogContent } from '../../../lib/compress';
 import { STAFF_ORG_ID } from '../../../lib/staff';
+import { getLimits } from '../../../lib/tiers';
+import { getSession } from '../../../lib/auth';
 
 // Accepted co-authors (max 10) with display info for multi-author bylines.
 async function fetchCoAuthors(db, blogId) {
@@ -29,9 +31,66 @@ function decompressBlog(blog) {
   }
   return blog;
 }
+async function memberOnlyGate(blog, session) {
+  if (!blog.member_only) return null; 
+
+  
+  if (session?.userId && session.userId === blog.author_id) return null;
+
+  
+  let viewerTier = 'free';
+  if (session?.userId) {
+    
+    try {
+      const { getDB } = await import('../../../lib/cloudflare');
+      const db = getDB();
+      const viewer = await db.prepare('SELECT tier FROM users WHERE id = ?')
+        .bind(session.userId).first();
+      viewerTier = viewer?.tier || 'free';
+    } catch { /* stay 'free' on error */ }
+  }
+
+  const limits = getLimits(viewerTier);
+  if (limits.canReadMemberOnly) return null; 
+
+  let teaser = null;
+  try {
+    const blocks = Array.isArray(blog.content) ? blog.content : JSON.parse(blog.content || '[]');
+    const text = blocks
+      .flatMap(b => (Array.isArray(b.content) ? b.content : []))
+      .map(c => c.text || '')
+      .join(' ')
+      .trim();
+    teaser = text.slice(0, 300) || null;
+  } catch { /* no teaser on parse error */ }
+
+  return NextResponse.json({
+    type: 'blog',
+    gated: true,
+    member_only: true,
+    blog: {
+      id: blog.id,
+      slug: blog.slug,
+      title: blog.title,
+      subtitle: blog.subtitle,
+      cover_image_r2_key: blog.cover_image_r2_key,
+      page_emoji: blog.page_emoji,
+      read_time_minutes: blog.read_time_minutes,
+      published_at: blog.published_at,
+      author_id: blog.author_id,
+      author_username: blog.author_username,
+      author_name: blog.author_name,
+      author_avatar: blog.author_avatar,
+      member_only: true,
+      content: null,   
+      teaser,
+    },
+  }, { status: 200 });
+}
 
 // Resolve @name to user or org, optionally fetch a blog by slug
 export async function GET(request) {
+  const session = await getSession(); // needed for member-only gate
   const { searchParams } = new URL(request.url);
   const name = (searchParams.get('name') || '').trim().toLowerCase();
   const slug = (searchParams.get('slug') || '').trim().toLowerCase();
@@ -107,6 +166,10 @@ export async function GET(request) {
           db.prepare('SELECT tag FROM blog_tags WHERE blog_id = ?').bind(blog.id).all(),
           fetchCoAuthors(db, blog.id),
         ]);
+
+        // Gate member-only posts before decompressing content
+        const gated = await memberOnlyGate(blog, session);
+        if (gated) return gated;
 
         return NextResponse.json({
           type: 'blog',
@@ -184,6 +247,9 @@ export async function GET(request) {
           db.prepare('SELECT tag FROM blog_tags WHERE blog_id = ?').bind(blog.id).all(),
           fetchCoAuthors(db, blog.id),
         ]);
+        const gated2 = await memberOnlyGate(blog, session);
+        if (gated2) return gated2;
+
         return NextResponse.json({
           type: 'blog',
           owner: { type: 'org', ...org },
@@ -247,6 +313,9 @@ export async function GET(request) {
           db.prepare('SELECT tag FROM blog_tags WHERE blog_id = ?').bind(blog.id).all(),
           fetchCoAuthors(db, blog.id),
         ]);
+        const gated3 = await memberOnlyGate(blog, session);
+        if (gated3) return gated3;
+
         return NextResponse.json({
           type: 'blog',
           owner: { type: 'org', ...org },

--- a/src/views/WritePage.jsx
+++ b/src/views/WritePage.jsx
@@ -11,6 +11,7 @@ import '@blocknote/mantine/style.css';
 import '../styles/editor/editor.css';
 import '../styles/katex-fonts.css';
 import { readTimeFromWords } from '../../lib/readTime';
+import { getLimits } from '../../lib/tiers';
 import { IMAGE_ACCEPT_ATTR, isAllowedImage } from '../utils/allowedImageTypes';
 import { generatePixelAvatar } from '../utils/pixelAvatar';
 import { useCollaboration } from '../hooks/useCollaboration';
@@ -471,7 +472,7 @@ export default function WritePage({ slugid }) {
   const [collabLock, setCollabLock] = useState(null);
   const [collabLockDismissed, setCollabLockDismissed] = useState(false);
   const [showPublishConfirm, setShowPublishConfirm] = useState(false);
-  const [conflict, setConflict] = useState(null); // { message, currentVersion, status }
+  const [memberOnly, setMemberOnly] = useState(false);
   const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
   const [pendingLeaveUrl, setPendingLeaveUrl] = useState(null);
   const [showMdReplaceConfirm, setShowMdReplaceConfirm] = useState(false);
@@ -788,6 +789,7 @@ export default function WritePage({ slugid }) {
         if (Number.isFinite(cloud.cover_pos_x) && Number.isFinite(cloud.cover_pos_y)) setCoverPos({ x: cloud.cover_pos_x, y: cloud.cover_pos_y });
         if (Number.isFinite(cloud.cover_zoom)) setCoverZoom(cloud.cover_zoom);
         if (cloud.page_emoji) setPageEmoji(cloud.page_emoji);
+        setMemberOnly(!!cloud.member_only);
         if (version) { setBlogVersion(version); setLastKnownUpdatedAt(version.updatedAt); }
 
         // Content: use the server copy unless localStorage holds strictly newer
@@ -1181,7 +1183,7 @@ export default function WritePage({ slugid }) {
   }, [title, draftLoading, editorReady]);
 
   // Serialized publish-settings, used to detect "nothing changed" on Update.
-  const settingsKey = () => JSON.stringify({ title, subtitle, tags, publishAs, collectionId, pageEmoji, coverPreview, coverPos, coverZoom, slug });
+  const settingsKey = () => JSON.stringify({ title, subtitle, tags, publishAs, collectionId, pageEmoji, coverPreview, coverPos, coverZoom, slug, memberOnly });
   // Capture a baseline once the blog has finished loading.
   useEffect(() => {
     if (!draftLoading && settingsSnapshotRef.current === '') settingsSnapshotRef.current = settingsKey();
@@ -1211,7 +1213,7 @@ export default function WritePage({ slugid }) {
       const res = await fetch('/api/blogs/publish', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ slugid: blogId, title, subtitle, tags, publishAs, collectionId, editorContent, pageEmoji, coverUrl: coverPreview, coverPos, coverZoom, slug, status: targetStatus, lastKnownUpdatedAt }),
+        body: JSON.stringify({ slugid: blogId, title, subtitle, tags, publishAs, collectionId, editorContent, pageEmoji, coverUrl: coverPreview, coverPos, coverZoom, slug, status: targetStatus, lastKnownUpdatedAt, member_only: memberOnly }),
       });
 
       if (res.status === 409) {
@@ -1262,7 +1264,7 @@ export default function WritePage({ slugid }) {
       await fetch('/api/blogs/publish', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ slugid: blogId, title, subtitle, tags, publishAs, collectionId, editorContent, pageEmoji, slug, status: 'unlisted', lastKnownUpdatedAt }),
+        body: JSON.stringify({ slugid: blogId, title, subtitle, tags, publishAs, collectionId, editorContent, pageEmoji, slug, status: 'unlisted', lastKnownUpdatedAt, member_only: memberOnly }),
       });
       setShowPublishPanel(false);
     } catch { /* silent */ }
@@ -2409,6 +2411,46 @@ export default function WritePage({ slugid }) {
               Co-authors can view, edit, or admin — the post cross-posts to their profile.
             </p>
           </div>
+
+          {/* Member-only toggle — visible only to member-tier authors */}
+          {getLimits(user?.tier).canMarkMemberOnly && (
+            <div>
+              <label className="text-[12px] font-medium mb-2 block" style={{ color: 'var(--text-muted)' }}>
+                Visibility
+              </label>
+              <button
+                onClick={() => setMemberOnly(v => !v)}
+                className="w-full flex items-center justify-between gap-3 rounded-lg px-3 py-2.5 text-[13px] transition-colors"
+                style={{
+                  backgroundColor: memberOnly ? '#e8a84014' : 'var(--bg-app)',
+                  border: memberOnly ? '1px solid #e8a84050' : '1px solid var(--border-default)',
+                }}
+              >
+                <span className="flex items-center gap-2" style={{ color: 'var(--text-primary)' }}>
+                  <ion-icon
+                    name={memberOnly ? 'sparkles' : 'globe-outline'}
+                    style={{ fontSize: '16px', color: memberOnly ? '#e8a840' : 'var(--text-muted)' }}
+                  />
+                  {memberOnly ? 'Member-only' : 'Everyone'}
+                </span>
+                {/* Toggle pill */}
+                <div
+                  className="relative w-9 h-5 rounded-full transition-colors flex-shrink-0"
+                  style={{ backgroundColor: memberOnly ? '#e8a840' : 'var(--bg-elevated)', border: '1px solid var(--border-default)' }}
+                >
+                  <div
+                    className="absolute top-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform"
+                    style={{ transform: memberOnly ? 'translateX(18px)' : 'translateX(2px)' }}
+                  />
+                </div>
+              </button>
+              <p className="text-[11px] mt-1" style={{ color: 'var(--text-faint)' }}>
+                {memberOnly
+                  ? 'Only members can read the full content. Non-members see a teaser.'
+                  : 'Visible to all readers.'}
+              </p>
+            </div>
+          )}
         </div>
 
         {/* Bottom actions */}


### PR DESCRIPTION
Closes #94

## broken
- `member_only` was never written to on publish
- No UI to toggle it in the editor
- `resolve` returned the flag but never blocked non-members

## Changes

| File | What |
|------|------|
| `app/api/blogs/draft/route.js` | Add `member_only` to SELECT so editor restores it on load |
| `app/api/blogs/publish/route.js` | Read `member_only` from body, fetch author tier from DB, reject free users with 403, persist in UPDATE + INSERT |
| `app/api/resolve/route.js` | Add `memberOnlyGate()` — non-members get `gated:true` + teaser, members/authors get full content |
| `src/views/WritePage.jsx` | `memberOnly` state, restored on load, sent on publish, toggle UI in Publish Settings panel (member tier only) |

## Acceptance criteria
- [x] Member can toggle member-only at publish — persists to DB
- [x] Free user sending `member_only: true` → 403
- [x] Non-member hitting a member-only post → sees teaser only