### PR TITLE
FIX: Enforce tier-based co-author limits and surface tier-aware invite errors

### DIFF
--- a/app/api/blogs/invite/route.js
+++ b/app/api/blogs/invite/route.js
@@ -1,6 +1,7 @@
 export const runtime = 'edge';
 import { NextResponse } from 'next/server';
 import { getSession } from '../../../../lib/auth';
+import { getLimits } from '../../../../lib/tiers';
 
 /**
  * Blog collaborator management.
@@ -76,6 +77,14 @@ export async function POST(request) {
     const { allowed, blog } = await canManage(db, slugid, session.userId);
     if (!allowed) return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
 
+    const owner = await db
+      .prepare('SELECT tier FROM users WHERE id = ?')
+      .bind(blog.author_id)
+      .first();
+
+    const ownerTier = owner?.tier || 'free';
+    const limits = getLimits(ownerTier);
+
     const invitee = await db.prepare('SELECT id, username FROM users WHERE LOWER(username) = LOWER(?)').bind(username).first();
     if (!invitee) return NextResponse.json({ error: 'User not found' }, { status: 404 });
     if (invitee.id === blog.author_id) return NextResponse.json({ error: 'Cannot invite the blog author' }, { status: 400 });
@@ -85,8 +94,14 @@ export async function POST(request) {
     const existing = await db.prepare('SELECT 1 FROM blog_co_authors WHERE blog_id = ? AND user_id = ?').bind(slugid, invitee.id).first();
     if (!existing) {
       const countRow = await db.prepare('SELECT COUNT(*) AS c FROM blog_co_authors WHERE blog_id = ?').bind(slugid).first();
-      if ((countRow?.c || 0) >= 10) {
-        return NextResponse.json({ error: 'A blog can have at most 10 collaborators.' }, { status: 400 });
+      if ((countRow?.c || 0) >= limits.coAuthorsPerBlog) {
+        return NextResponse.json(
+          {
+            error: `You can add up to ${limits.coAuthorsPerBlog} co-authors on the ${ownerTier} plan.`,
+            upgrade: ownerTier === "free",
+          },
+          { status: 400 }
+        );
       }
     }
 

--- a/app/api/search/route.js
+++ b/app/api/search/route.js
@@ -24,7 +24,7 @@ export async function GET(request) {
       const users = await db.prepare(`
         SELECT id, username, display_name, avatar_url
         FROM users WHERE LOWER(username) LIKE ? OR LOWER(display_name) LIKE ?
-        LIMIT 5
+        LIMIT 10
       `).bind(pattern, pattern).all();
       results.users = users?.results || [];
     }

--- a/src/components/Editor/CollaboratorPanel.jsx
+++ b/src/components/Editor/CollaboratorPanel.jsx
@@ -68,6 +68,7 @@ export default function CollaboratorPanel({ slugid, onClose }) {
         setSearchResults([]);
         fetchCollabs();
       } else {
+        setSearchResults([]); // close the dropdown
         setInviteError(data.error || 'Failed to invite');
       }
     } catch { setInviteError('Network error'); }
@@ -166,9 +167,21 @@ export default function CollaboratorPanel({ slugid, onClose }) {
                   {ROLES.map(r => <option key={r.value} value={r.value}>{r.label}</option>)}
                 </select>
               </div>
-              {inviteError && <p className="text-[11px] mt-1.5" style={{ color: '#f87171' }}>{inviteError}</p>}
-            </div>
-          )}
+              {inviteError && (
+                <div
+                  className="mb-3 rounded-lg border px-3 py-2 flex items-start gap-2 mt-14"
+                  style={{
+                    background: "rgba(239,68,68,.08)",
+                    borderColor: "rgba(239,68,68,.25)",
+                    color: "#ef4444",
+                  }}
+                >
+                  <span>⚠️</span>
+                  <span>{inviteError}</span>
+                </div>
+              )}
+              </div>
+            )}
 
           {/* Divider */}
           <div style={{ height: '1px', backgroundColor: 'var(--divider)' }} />


### PR DESCRIPTION
## Summary

This PR replaces the hardcoded collaborator limit with tier-based enforcement using the existing `getLimits()` configuration.

Fixes #95 

### Changes

* Replaced the hardcoded collaborator limit (`10`) with `getLimits(ownerTier).coAuthorsPerBlog`.
* Resolved the blog owner's subscription tier before enforcing collaborator limits.
* Added tier-aware error messages indicating the current plan's collaborator limit.
* Returned an `upgrade` flag for free-tier users when the collaborator limit is reached.
* Improved the collaborator invite UI by ensuring limit errors remain visible instead of being obscured by the search dropdown.

### Behavior

* **Free** tier authors can invite up to **3** co-authors.
* **Member** tier authors can invite up to **5** co-authors.
* Blogs that already exceed the new limits are grandfathered; existing collaborators remain unaffected, while additional collaborator invites are blocked once the tier limit is reached.

### Testing

* Verified that free-tier authors can successfully invite up to 3 collaborators and receive a tier-aware error on the 4th invite.
* Verified that member-tier authors can successfully invite up to 5 collaborators and receive a tier-aware error on the 6th invite.
* Confirmed that collaborator limit errors are surfaced correctly in the editor UI.
